### PR TITLE
BUG: Power on and power off drag inverted

### DIFF
--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -1368,7 +1368,7 @@ class Flight:
 
         # Determine aerodynamics forces
         # Determine Drag Force
-        if t > self.rocket.motor.burnOutTime:
+        if t < self.rocket.motor.burnOutTime:
             dragCoeff = self.rocket.powerOnDrag.getValueOpt(freestreamMach)
         else:
             dragCoeff = self.rocket.powerOffDrag.getValueOpt(freestreamMach)

--- a/rocketpy/Rocket.py
+++ b/rocketpy/Rocket.py
@@ -191,14 +191,14 @@ class Rocket:
             powerOffDrag,
             "Mach Number",
             "Drag Coefficient with Power Off",
-            "spline",
+            "linear",
             "constant",
         )
         self.powerOnDrag = Function(
             powerOnDrag,
             "Mach Number",
             "Drag Coefficient with Power On",
-            "spline",
+            "linear",
             "constant",
         )
 


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`powerOnDrag` and `powerOffDrag` are inverted in the flight class, so the simulation is using `powerOffDrag` while the motor is on an `powerOnDrag` when the motor is off. 

Also, both drag curves are used to set a Function object with `'spline'` interpolation. Sometimes this can cause problems with clustered data archives. Changed it to `'linear'` so it is more compatible.