### PR TITLE
ENH: Refactor Env Analysis .json conversions

### DIFF
--- a/docs/user/requirements.rst
+++ b/docs/user/requirements.rst
@@ -27,6 +27,7 @@ The following packages are needed in order to run RocketPy:
 - timezonefinder
 - simplekml
 - ipywidgets >= 7.6.3
+- jsonpickle
 
  
 All of these packages, with the exception of netCDF4, should be automatically installed when RocketPy is installed using either ``pip`` or ``conda``.

--- a/docs/user/requirements.rst
+++ b/docs/user/requirements.rst
@@ -49,6 +49,7 @@ The packages needed can be installed via ``pip`` by running the following lines 
     pip install pytz
     pip install timezonefinder
     pip install simplekml
+    pip install jsonpickle
 
 Installing Required Packages Using ``conda``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/user/requirements.rst
+++ b/docs/user/requirements.rst
@@ -27,7 +27,6 @@ The following packages are needed in order to run RocketPy:
 - timezonefinder
 - simplekml
 - ipywidgets >= 7.6.3
-- json
 
  
 All of these packages, with the exception of netCDF4, should be automatically installed when RocketPy is installed using either ``pip`` or ``conda``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ requests
 pytz
 timezonefinder
 simplekml
-json

--- a/rocketpy/EnvironmentAnalysis.py
+++ b/rocketpy/EnvironmentAnalysis.py
@@ -6,6 +6,7 @@ __license__ = "MIT"
 
 import bisect
 import warnings
+import json
 from collections import defaultdict
 
 import ipywidgets as widgets
@@ -2687,7 +2688,15 @@ class EnvironmentAnalysis:
         Exports the mean profiles of the weather data to a file in order to it
         be used as inputs on Environment Class by using the CustomAtmosphere
         model.
-        TODO: Improve docs
+
+        Parameters
+        ----------
+        filename : str, optional
+            Name of the file where to be saved, by default "EnvAnalysisDict"
+
+        Returns
+        -------
+        None
         """
 
         self.process_temperature_profile_over_average_day()

--- a/rocketpy/EnvironmentAnalysis.py
+++ b/rocketpy/EnvironmentAnalysis.py
@@ -156,6 +156,14 @@ class EnvironmentAnalysis:
             self.surfaceDataDict = self.loaded_data["surfaceDataDict"]
             self.pressureLevelDataDict = self.loaded_data["pressureLevelDataDict"]
 
+            # Fix old masked values on surface data
+            for days in self.surfaceDataDict.keys():
+                for hours in self.surfaceDataDict[days].keys():
+                    for variables in self.surfaceDataDict[days][hours].keys():
+                        if self.surfaceDataDict[days][hours][variables] == "--":
+                            # TODO: is there any other value that we can use to prevent "NaN"?
+                            self.surfaceDataDict[days][hours][variables] = float("NaN")
+
             # Initialize variables again, to accomplish to the data available at the loaded file
             self.elevation = self.loaded_data["elevation"]
             self.latitude = self.loaded_data["latitude"]
@@ -979,8 +987,8 @@ class EnvironmentAnalysis:
         self.calculate_record_max_surface_100m_wind_speed()
         self.calculate_record_min_surface_100m_wind_speed()
         self.calculate_percentage_of_days_with_precipitation()
-        self.calculate_average_cloud_base_height()
-        self.calculate_min_cloud_base_height()
+        self.calculate_average_cloud_base_height()  # Having problems with masks!
+        self.calculate_min_cloud_base_height()  # Having problems with masks!
         self.calculate_percentage_of_days_with_no_cloud_coverage()
 
     @property

--- a/rocketpy/EnvironmentAnalysis.py
+++ b/rocketpy/EnvironmentAnalysis.py
@@ -5,8 +5,8 @@ __copyright__ = "Copyright 20XX, RocketPy Team"
 __license__ = "MIT"
 
 import bisect
-import warnings
 import json
+import warnings
 from collections import defaultdict
 
 import ipywidgets as widgets
@@ -127,6 +127,7 @@ class EnvironmentAnalysis:
         self.__find_preferred_timezone()
         self.__localize_input_dates()
 
+        # Parse data files, surface goes first to calculate elevation
         self.surfaceDataDict = {}
         self.parseSurfaceData()
         self.pressureLevelDataDict = {}
@@ -589,7 +590,7 @@ class EnvironmentAnalysis:
                 variablePointsArray = np.array([heightAboveSeaLevelArray, valueArray]).T
                 variableFunction = Function(
                     variablePointsArray,
-                    inputs="Height Above Ground Level (m)",  # TODO: Check if it is really AGL or ASL here
+                    inputs="Height Above Ground Level (m)",  # TODO: Check if it is really AGL or ASL here, see 3 lines above
                     outputs=key,
                     extrapolation="constant",
                 )
@@ -856,8 +857,8 @@ class EnvironmentAnalysis:
         self.calculate_record_max_surface_100m_wind_speed()
         self.calculate_record_min_surface_100m_wind_speed()
         self.calculate_percentage_of_days_with_precipitation()
-        self.calculate_average_cloud_base_height()  # Having problems with masks!
-        self.calculate_min_cloud_base_height()  # Having problems with masks!
+        self.calculate_average_cloud_base_height()
+        self.calculate_min_cloud_base_height()
         self.calculate_percentage_of_days_with_no_cloud_coverage()
 
     @property
@@ -2748,8 +2749,6 @@ class EnvironmentAnalysis:
             # "maxExpectedHeight": 80000, # TODO: Implement this parameter at EnvAnalysis Class
             "surfaceDataFile": self.surfaceDataFile,
             "pressureLevelDataFile": self.pressureLevelDataFile,
-            # "surfaceDataDict": self.surfaceDataDict, # TODO: Too large, make it optional
-            # "pressureLevelDataDict": self.pressureLevelDataDict, # TODO: Too large, make it optional
             "atmosphericModelPressureProfile": organized_pressure_dict,
             "atmosphericModelTemperatureProfile": organized_temperature_dict,
             "atmosphericModelWindVelocityXProfile": organized_windX_dict,

--- a/rocketpy/EnvironmentAnalysis.py
+++ b/rocketpy/EnvironmentAnalysis.py
@@ -142,7 +142,7 @@ class EnvironmentAnalysis:
 
             # Convert units
             self.set_unit_system(unit_system)
-        else: # In case of loading previous data, still need to test if all the other functions will work!
+        else:  # In case of loading previous data, still need to test if all the other functions will work!
             # Opening JSON file
             try:
                 with open(self.load_previous_data) as json_file:
@@ -155,7 +155,7 @@ class EnvironmentAnalysis:
             # Load dictionary
             self.surfaceDataDict = self.loaded_data["surfaceDataDict"]
             self.pressureLevelDataDict = self.loaded_data["pressureLevelDataDict"]
-            
+
             # Initialize variables again, to accomplish to the data available at the loaded file
             self.elevation = self.loaded_data["elevation"]
             self.latitude = self.loaded_data["latitude"]
@@ -164,13 +164,46 @@ class EnvironmentAnalysis:
             # Convert back to Function objects, then we will be able to process set_unit_system
             ## Use the units on the files, and then convert to the final/selected units
             decodeDict = {
-                "pressure": ["Height Above Sea Level (m)", "Pressure ({})".format(self.loaded_data["unit_system"]['pressure'])],
-                "temperature": ["Height Above Sea Level (m)", "Temperature ({})".format(self.loaded_data["unit_system"]['temperature'])],
-                "windDirection": ["Height Above Sea Level (m)", "Wind Direction ({})".format(self.loaded_data["unit_system"]['angle'])],
-                "windHeading": ["Height Above Sea Level (m)", "Wind Heading ({})".format(self.loaded_data["unit_system"]['angle'])],
-                "windSpeed": ["Height Above Sea Level (m)", "Wind Speed ({})".format(self.loaded_data["unit_system"]['wind_speed'])],
-                "windVelocityX": ["Height Above Sea Level (m)", "Wind Velocity X ({})".format(self.loaded_data["unit_system"]['velocity'])],
-                "windVelocityY": ["Height Above Sea Level (m)", "Wind Velocity Y ({})".format(self.loaded_data["unit_system"]['velocity'])],
+                "pressure": [
+                    "Height Above Sea Level (m)",
+                    "Pressure ({})".format(self.loaded_data["unit_system"]["pressure"]),
+                ],
+                "temperature": [
+                    "Height Above Sea Level (m)",
+                    "Temperature ({})".format(
+                        self.loaded_data["unit_system"]["temperature"]
+                    ),
+                ],
+                "windDirection": [
+                    "Height Above Sea Level (m)",
+                    "Wind Direction ({})".format(
+                        self.loaded_data["unit_system"]["angle"]
+                    ),
+                ],
+                "windHeading": [
+                    "Height Above Sea Level (m)",
+                    "Wind Heading ({})".format(
+                        self.loaded_data["unit_system"]["angle"]
+                    ),
+                ],
+                "windSpeed": [
+                    "Height Above Sea Level (m)",
+                    "Wind Speed ({})".format(
+                        self.loaded_data["unit_system"]["wind_speed"]
+                    ),
+                ],
+                "windVelocityX": [
+                    "Height Above Sea Level (m)",
+                    "Wind Velocity X ({})".format(
+                        self.loaded_data["unit_system"]["velocity"]
+                    ),
+                ],
+                "windVelocityY": [
+                    "Height Above Sea Level (m)",
+                    "Wind Velocity Y ({})".format(
+                        self.loaded_data["unit_system"]["velocity"]
+                    ),
+                ],
             }
 
             # TODO: document this
@@ -179,11 +212,14 @@ class EnvironmentAnalysis:
                     for variable in decodeDict.keys():
                         lst = self.pressureLevelDataDict[days][hours][variable]
                         self.pressureLevelDataDict[days][hours][variable] = Function(
-                            source= np.column_stack(([item[0] for item in lst], [item[1] for item in lst])),
+                            source=np.column_stack(
+                                ([item[0] for item in lst], [item[1] for item in lst])
+                            ),
                             inputs=[decodeDict[variable][0]],
-                            outputs=[decodeDict[variable][1]], 
-                            interpolation='linear',
-                            extrapolation='constant')
+                            outputs=[decodeDict[variable][1]],
+                            interpolation="linear",
+                            extrapolation="constant",
+                        )
 
             print(
                 "Information of the data loaded from previous Environment Analysis.\n"
@@ -218,8 +254,9 @@ class EnvironmentAnalysis:
                 self.set_unit_system(unit_system)
                 print(self.unit_system)
                 print()
-            print("Alright, the previous data file were completely loaded, all set to go!")
-
+            print(
+                "Alright, the previous data file were completely loaded, all set to go!"
+            )
 
         # Initialize result variables
         self.average_max_temperature = 0
@@ -675,7 +712,7 @@ class EnvironmentAnalysis:
                 variablePointsArray = np.array([heightAboveSeaLevelArray, valueArray]).T
                 variableFunction = Function(
                     variablePointsArray,
-                    inputs="Height Above Ground Level (m)", # TODO: Check if it is really AGL or ASL here
+                    inputs="Height Above Ground Level (m)",  # TODO: Check if it is really AGL or ASL here
                     outputs=key,
                     extrapolation="constant",
                 )
@@ -925,7 +962,7 @@ class EnvironmentAnalysis:
     # Calculations
     def process_data(self):
         """Process data that is shown in the allInfo method."""
-        # TODO: self.calculate_pressure_stats()
+        self.calculate_pressure_stats()
         self.calculate_average_max_temperature()
         self.calculate_average_min_temperature()
         self.calculate_record_max_temperature()
@@ -941,9 +978,9 @@ class EnvironmentAnalysis:
         self.calculate_average_min_surface_100m_wind_speed()
         self.calculate_record_max_surface_100m_wind_speed()
         self.calculate_record_min_surface_100m_wind_speed()
-        # TODO: self.calculate_percentage_of_days_with_precipitation()
-        # TODO: self.calculate_average_cloud_base_height()
-        # TODO: self.calculate_min_cloud_base_height()
+        self.calculate_percentage_of_days_with_precipitation()
+        self.calculate_average_cloud_base_height()
+        self.calculate_min_cloud_base_height()
         self.calculate_percentage_of_days_with_no_cloud_coverage()
 
     @property
@@ -2868,8 +2905,16 @@ class EnvironmentAnalysis:
         for days in pressureLevelDataDictCopy.keys():
             for hours in pressureLevelDataDictCopy[days].keys():
                 for variable in pressureLevelDataDictCopy[days][hours].keys():
-                    pressureLevelDataDictCopy[days][hours][variable] = np.column_stack( (pressureLevelDataDictCopy[days][hours][variable].getSource()[:,0], pressureLevelDataDictCopy[days][hours][variable].getSource()[:,1])).tolist()
-
+                    pressureLevelDataDictCopy[days][hours][variable] = np.column_stack(
+                        (
+                            pressureLevelDataDictCopy[days][hours][
+                                variable
+                            ].getSource()[:, 0],
+                            pressureLevelDataDictCopy[days][hours][
+                                variable
+                            ].getSource()[:, 1],
+                        )
+                    ).tolist()
 
         self.EnvAnalysisDict = {
             "start_date": self.start_date.strftime("%Y-%m-%d"),

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
         "pytz",
         "timezonefinder",
         "simplekml",
+        "jsonpickle",
     ],
     maintainer="RocketPy Developers",
     author="Giovani Hidalgo Ceotto",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setuptools.setup(
         "pytz",
         "timezonefinder",
         "simplekml",
-        "json",
     ],
     maintainer="RocketPy Developers",
     author="Giovani Hidalgo Ceotto",


### PR DESCRIPTION
## Pull request type

- [X] Code maintenance (refactoring, formatting, renaming, tests)

## Pull request checklist

- ReadMe, Docs and GitHub maintenance:

  - [x] Spelling has been verified
  - [x] Code docs are working correctly 

- Code base maintenance (refactoring, formatting, renaming):

  - [ ] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [ ] All tests (`pytest --runslow`) have passed locally

## What is the new behavior?

I'm fixing a problem regarding the PR #226 tasks list.
Now it's finally possible to save the already-processed data from EnvironmentAnalysis into a .json file and then re-use it to initialize other Environment Analysis objects 

## Does this introduce a breaking change?
- [ ] Yes
- [X] No

## Other information
I'm creating this PR only to have theses steps documented in the future, reviewing it is important, but please keep in mind that others PR are coming soon and they will need these implementations already merged