### PR TITLE
ENH: Add Sweep Length to Trapezoidal Fins

### DIFF
--- a/rocketpy/Rocket.py
+++ b/rocketpy/Rocket.py
@@ -482,6 +482,7 @@ class Rocket:
         span,
         distanceToCM,
         cantAngle=0,
+        sweepLength=None,
         radius=None,
         airfoil=None,
     ):
@@ -507,6 +508,12 @@ class Rocket:
         cantAngle : int, float, optional
             Fins cant angle with respect to the rocket centerline. Must
             be given in degrees.
+        sweepLength : int, float, optional
+            Fins sweep length in meters. By sweep length, understand the axial distance
+            between the fin root leading edge and the fin tip leading edge measured
+            parallel to the rocket centerline. If not given, the sweep length is
+            assumed to be equal the root chord minus the tip chord, in which case the
+            fin is a right trapezoid with its base perpendicular to the rocket's axis.
         radius : int, float, optional
             Reference radius to calculate lift coefficient. If None, which
             is default, use rocket radius. Otherwise, enter the radius
@@ -538,6 +545,7 @@ class Rocket:
         """
         # Retrieves and convert basic geometrical parameters
         Cr, Ct = rootChord, tipChord
+        sweepLength = Cr - Ct if sweepLength is None else sweepLength
         s = span
         radius = self.radius if radius is None else radius
         cantAngleRad = np.radians(cantAngle)
@@ -548,8 +556,11 @@ class Rocket:
         Yr = Cr + Ct
         Af = Yr * s / 2  # Fin area
         AR = 2 * s**2 / Af  # Fin aspect ratio
-        gamac = np.arctan((Cr - Ct) / (2 * s))  # Mid chord angle
+        gamma_c = np.arctan(
+            (sweepLength + 0.5 * Ct - 0.5 * Cr) / (span)
+        )  # Mid chord angle
         Yma = (s / 3) * (Cr + 2 * Ct) / Yr  # Span wise coord of mean aero chord
+
         rollGeometricalConstant = (
             (Cr + 3 * Ct) * s**3
             + 4 * (Cr + 2 * Ct) * radius * s**2
@@ -558,7 +569,7 @@ class Rocket:
 
         # Center of pressure position relative to CDM (center of dry mass)
         cpz = distanceToCM + np.sign(distanceToCM) * (
-            ((Cr - Ct) / 3) * ((Cr + 2 * Ct) / (Cr + Ct))
+            (sweepLength / 3) * ((Cr + 2 * Ct) / (Cr + Ct))
             + (1 / 6) * (Cr + Ct - Cr * Ct / (Cr + Ct))
         )
 
@@ -636,11 +647,11 @@ class Rocket:
             clalpha2D = Function(lambda mach: clalpha2D_Mach0 / beta(mach))
 
         # Diederich's Planform Correlation Parameter
-        FD = 2 * np.pi * AR / (clalpha2D * np.cos(gamac))
+        FD = 2 * np.pi * AR / (clalpha2D * np.cos(gamma_c))
 
         # Lift coefficient derivative for a single fin
         clalphaSingleFin = Function(
-            lambda mach: (clalpha2D(mach) * FD(mach) * (Af / Aref) * np.cos(gamac))
+            lambda mach: (clalpha2D(mach) * FD(mach) * (Af / Aref) * np.cos(gamma_c))
             / (2 + FD(mach) * np.sqrt(1 + (2 / FD(mach)) ** 2))
         )
 


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [ ] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [ ] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

See #223.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`Rocket.addTrapezoidalFins` now supports a new argument: `sweepLength`: Fins sweep length in meters. By sweep length, understand the axial distance between the fin root leading edge and the fin tip leading edge measured parallel to the rocket centerline. If not given, the sweep length is assumed to be equal the root chord minus the tip chord, in which case the fin is a right trapezoid with its base perpendicular to the rocket's axis.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No
