### PR TITLE
REL: Automate Release to PyPI with GitHub Actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,34 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+
+name: Publish New Version to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.7'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [x] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- ReadMe, Docs and GitHub maintenance:

  - [x] Spelling has been verified
  - [x] Code docs are working correctly 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Since Travis CI stopped working, automatic publishing of new releases to PyPI stopped working.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

A GitHub Action called `Publish New Version to PyPI` will be triggered when a new release is published, building rocketpy and uploading it to PyPI.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Inspiration from: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/