### PR TITLE
Fix: Cached Property support for Python 3.6 and 3.7

### DIFF
--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -9,7 +9,6 @@ __license__ = "MIT"
 import math
 import time
 import warnings
-from functools import cached_property
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -17,6 +16,11 @@ import simplekml
 from scipy import integrate
 
 from .Function import Function
+
+try:
+    from functools import cached_property
+except ImportError:
+    from .tools import cached_property
 
 
 class Flight:

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -13,6 +13,9 @@ class cached_property:
     def __get__(self, instance, owner=None):
         if instance is None:
             return self
+        if self.attrname is None:
+            raise TypeError(
+                "Cannot use cached_property instance without calling __set_name__ on it.")
         cache = instance.__dict__
         val = cache.get(self.attrname, _NOT_FOUND)
         if val is _NOT_FOUND:

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -15,7 +15,8 @@ class cached_property:
             return self
         if self.attrname is None:
             raise TypeError(
-                "Cannot use cached_property instance without calling __set_name__ on it.")
+                "Cannot use cached_property instance without calling __set_name__ on it."
+            )
         cache = instance.__dict__
         val = cache.get(self.attrname, _NOT_FOUND)
         if val is _NOT_FOUND:

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -1,0 +1,21 @@
+_NOT_FOUND = object()
+
+
+class cached_property:
+    def __init__(self, func):
+        self.func = func
+        self.attrname = None
+        self.__doc__ = func.__doc__
+
+    def __set_name__(self, owner, name):
+        self.attrname = name
+
+    def __get__(self, instance, owner=None):
+        if instance is None:
+            return self
+        cache = instance.__dict__
+        val = cache.get(self.attrname, _NOT_FOUND)
+        if val is _NOT_FOUND:
+            val = self.func(instance)
+            cache[self.attrname] = val
+        return val


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [x] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Python 3.6 and 3.7 does not include `functools.cached_property`, which is currently being used in the develop branch causing errors.
Since RocketPy does support Python 3.6+ according to our [docs](https://docs.rocketpy.org/en/latest/user/requirements.html#python-version), this needs to be fixed.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

@Gui-FernandesBR had proposed a solution for this issue in #279, however, I was not comfortable with it since it made use of `functools.lru_cache`. It is my understanding that such implementation uses much more memory since it stores a copy of the class instance to make sure that the input argument `self` matches before using the cached result.

Since I have a keen interest in special class-based decorators such as these, given similar applications in the Liquid Motors milestone, I did some research to learn how could this be improved.

Based on other implementations and also the [oficial `functools.cached_property` implementation](https://github.com/python/cpython/blob/main/Lib/functools.py#L965), I have created a simplified version to be used whenever the official implementation is not available. This version is faster and does not consume extra memory during caching.

In summary, the solution was:

- Create a new decorator named `cached_property` in a new auxiliary file named `tools.py`.
- In the Flight module, try to import `functools.cached_property` and if it fails, import `tools.cached_property` instead.

These are the only modifications thus far.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

A couple of things to discuss:

- The `tools.py` file should probably be named `utils.py` and contain all auxiliary decorators, classes and functions that can be used by the rest of the core code but has no interesting use to end-users.
- The `utilities.py` should probably be renamed to `tools.py` as it contains a series of tools for the end-user.
- All Flight methods that have the `@cached_property` decorator also contain other arguments, such as `interpolation="spline", extrapolation="natural"`. This is **broken**. Properties cannot have any other argument besides self. Although this does not cause any errors during execution, it is currently impossible to use and change these arguments from their default value. **This does not seem right.**