### PR TITLE
ENH: adding name as a karg in Flight class

### DIFF
--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -586,7 +586,7 @@ class Flight:
         verbose : bool, optional
             If true, verbose mode is activated. Default is False.
         name : str, optional
-            Name of the flight. Default is "".
+            Name of the flight. Default is "Flight".
 
         Returns
         -------

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -62,6 +62,8 @@ class Flight:
             Original rail length minus the distance measured from nozzle exit
             to the lower rail button. It assumes the nozzle to be aligned with
             the beginning of the rail.
+        Flight.name: str
+            Name of the flight.
 
 
         Numerical Integration settings:
@@ -527,6 +529,7 @@ class Flight:
         atol=6 * [1e-3] + 4 * [1e-6] + 3 * [1e-3],
         timeOvershoot=True,
         verbose=False,
+        name="",
     ):
         """Run a trajectory simulation.
 
@@ -582,6 +585,8 @@ class Flight:
             time in some cases. Default is True.
         verbose : bool, optional
             If true, verbose mode is activated. Default is False.
+        name : str, optional
+            Name of the flight. Default is "".
 
         Returns
         -------
@@ -607,6 +612,7 @@ class Flight:
         self.initialSolution = initialSolution
         self.timeOvershoot = timeOvershoot
         self.terminateOnApogee = terminateOnApogee
+        self.name = name
 
         # Modifying Rail Length for a better out of rail condition
         upperRButton = max(self.rocket.railButtons[0])

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -529,7 +529,7 @@ class Flight:
         atol=6 * [1e-3] + 4 * [1e-6] + 3 * [1e-3],
         timeOvershoot=True,
         verbose=False,
-        name="",
+        name="Flight",
     ):
         """Run a trajectory simulation.
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [ ] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [ ] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
I cannot easily differentiate one flight object from other.

## What is the new behavior?
New argument and attribute "name" added to Flight class, allowing if to easily label/name your object. It was inspired in the recent AeroSurfaces implementation. This will help a lot on compare plots functions.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
Could apply to other classes as well, if evrybody thinks