### PR TITLE
BUG: Flight.plotPressureSignals and "StandardAtmosphere" environment pressure calculation

### DIFF
--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -2470,7 +2470,6 @@ class Flight:
 
         return F11, F12, F21, F22
 
-    @cached_property
     def __calculate_pressure_signal(self):
         """Calculate the pressure signal from the pressure sensor.
         It creates a SignalFunction attribute in the parachute object.
@@ -3663,7 +3662,7 @@ class Flight:
         if len(self.rocket.parachutes) == 0:
             plt.figure()
             ax1 = plt.subplot(111)
-            ax1.plot(self.z[:, 0], self.env.pressure(self.z[:, 1]))
+            ax1.plot(self.z[:, 0], self.env.pressure(self.z[:, 1].tolist()))
             ax1.set_title("Pressure at Rocket's Altitude")
             ax1.set_xlabel("Time (s)")
             ax1.set_ylabel("Pressure (Pa)")
@@ -3675,6 +3674,7 @@ class Flight:
         else:
             for parachute in self.rocket.parachutes:
                 print("Parachute: ", parachute.name)
+                self.__calculate_pressure_signal()
                 parachute.noiseSignalFunction()
                 parachute.noisyPressureSignalFunction()
                 parachute.cleanPressureSignalFunction()


### PR DESCRIPTION
## Pull request type

- [x] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Description
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When working on #290 I found that the `Flight.plotPressureSignals` method did not work. This was just because the `__calculate_pressure_signal` method was not being called. Furthermore, when using `"StandardAtmosphere"` the `Pressure at Rocket's Altitude` plot raised an error. This error comes from calling `Environment.pressure` with an array as such: 

![image](https://user-images.githubusercontent.com/69485049/209993548-75522967-5c79-40c0-aa3b-b5a2534c0c38.png)

Using a list instead works fine:

![image](https://user-images.githubusercontent.com/69485049/209993650-b1629c47-599c-4af1-879e-05df68b01cae.png)

I am pretty sure that a Function object should be able to receive an np.array so I think this not working as intended.

One more thing, looking at how the pressure Function is calculated for `StandardAtmosphere`. Lines 2832 and 2833 are incoherent. I don't know much about pressure profiles though, so I might be wrong. Maybe @Gui-FernandesBR or @giovaniceotto know more.

![image](https://user-images.githubusercontent.com/69485049/209995068-409d1bab-6438-4e5f-b898-525c3d729686.png)

## What was changed

The only thing changed currently in this PR is that the plot for `Pressure at Rocket's Altitude` now converts the np.array into a list when getting the pressure values and also calls `__calculate_pressure_signal`, which was not doing before so it just did not work. This fixes the plot but there may be more things wrong here. 

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No