### PR TITLE
ENH: Make timezonefinder an optional dependency

### DIFF
--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -22,11 +22,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
         pip install -r requirements_test.txt
     - name: Build RocketPy
       run: |
-        python setup.py install
+        pip install -e .
     - name: Test with pytest
       run: |
         pytest

--- a/docs/user/requirements.rst
+++ b/docs/user/requirements.rst
@@ -7,9 +7,10 @@ But read further if this is not your case!
 Python Version
 --------------
 
-RocketPy was made to run on Python 3.6+.
+RocketPy supports Python 3.7 and above.
+Support for Python 3.11 is still limited by some dependencies.
 Sorry, there are currently no plans to support earlier versions.
-If you really need to run RocketPy on Python 3.5 or earlier, feel free to submit an issue and we will see what we can do!
+If you really need to run RocketPy on Python 3.6 or earlier, feel free to submit an issue and we will see what we can do!
 
 Required Packages
 -----------------
@@ -20,17 +21,16 @@ The following packages are needed in order to run RocketPy:
 - Numpy >= 1.0
 - Scipy >= 1.0
 - Matplotlib >= 3.0
-- netCDF4 >= 1.4 (optional, requires Cython)
+- netCDF4 >= 1.4
 - windrose >= 1.6.8
 - requests
 - pytz
-- timezonefinder
 - simplekml
 - ipywidgets >= 7.6.3
 - jsonpickle
 
  
-All of these packages, with the exception of netCDF4, should be automatically installed when RocketPy is installed using either ``pip`` or ``conda``.
+All of these packages, are automatically installed when RocketPy is installed using either ``pip`` or ``conda``.
 However, in case the user wants to install these packages manually, they can do so by following the instructions bellow.
 
 Installing Required Packages Using ``pip``
@@ -63,6 +63,20 @@ To update Scipy and install netCDF4 using Conda, the following code is used:
 
     conda install "scipy>=1.0"
     conda install -c anaconda "netcdf4>=1.4"
+
+
+Optional Packages
+-----------------
+
+Optionally, you can install timezonefinder to allow for automatic timezone detection when performing Enviornment Analysis.
+This can be done by running the following line of code in your preferred terminal:
+
+.. code-block:: shell
+
+    pip install timezonefinder
+
+Keep in mind that this package is not required to run RocketPy, but it can be useful if you want to perform Environment Analysis.
+Furthermore, timezonefinder can only be used with Python 3.8+.
 
 Useful Packages
 ---------------

--- a/rocketpy/EnvironmentAnalysis.py
+++ b/rocketpy/EnvironmentAnalysis.py
@@ -424,11 +424,11 @@ class EnvironmentAnalysis:
                 import timezonefinder as TimezoneFinder
             except ImportError:
                 raise ImportError(
-                    "The timezonefinder package is required to automatically " +
-                    "determine local timezone based on lat,lon coordinates. " +
-                    "Please specify the desired timezone using the `timezone` " +
-                    "argument when initializing the EnvironmentAnalysis class " +
-                    "or install timezonefinder with `pip install timezonefinder`."
+                    "The timezonefinder package is required to automatically "
+                    + "determine local timezone based on lat,lon coordinates. "
+                    + "Please specify the desired timezone using the `timezone` "
+                    + "argument when initializing the EnvironmentAnalysis class "
+                    + "or install timezonefinder with `pip install timezonefinder`."
                 )
             # Use local timezone based on lat lon pair
             tf = TimezoneFinder()

--- a/rocketpy/EnvironmentAnalysis.py
+++ b/rocketpy/EnvironmentAnalysis.py
@@ -22,7 +22,6 @@ from matplotlib import pyplot as plt
 from matplotlib.animation import FuncAnimation
 from matplotlib.animation import PillowWriter as ImageWriter
 from scipy import stats
-from timezonefinder import TimezoneFinder
 from windrose import WindroseAxes
 from rocketpy.Environment import Environment
 
@@ -421,6 +420,16 @@ class EnvironmentAnalysis:
 
     def __find_preferred_timezone(self):
         if self.preferred_timezone is None:
+            try:
+                import timezonefinder as TimezoneFinder
+            except ImportError:
+                raise ImportError(
+                    "The timezonefinder package is required to automatically " +
+                    "determine local timezone based on lat,lon coordinates. " +
+                    "Please specify the desired timezone using the `timezone` " +
+                    "argument when initializing the EnvironmentAnalysis class " +
+                    "or install timezonefinder with `pip install timezonefinder`."
+                )
             # Use local timezone based on lat lon pair
             tf = TimezoneFinder()
             self.preferred_timezone = pytz.timezone(

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,12 @@ setuptools.setup(
         "ipywidgets>=7.6.3",
         "requests",
         "pytz",
-        "timezonefinder",
         "simplekml",
         "jsonpickle",
     ],
+    extras_require={
+        "timezonefinder": ["timezonefinder"],
+    },
     maintainer="RocketPy Developers",
     author="Giovani Hidalgo Ceotto",
     author_email="ghceotto@gmail.com",
@@ -32,5 +34,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [x] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

1. RocketPy fails to install when using Python 3.7 on Windows, since the `timezonefinder` package does not support Python 3.7 anymore. See #314.
2. The `timezonefinder` package is rarely used and not required for any major RocketPy functionality. It is currently a required package inspite of this. And to make things worse, it requires a download larger than 40 MB.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The `timezonefinder` is made an optional requirement. By default, when installing RocketPy, it will not be installed and thus RocketPy will remain compatible with Python 3.7. The total downloads needed to install RocketPy will be reduced by about 40 MB. If the user desires, he/she can install the optional requirement using:

```shell
pip install rocketpy[timezonefinder]
```

Note, however, that this only works with Python 3.8+.

The only feature that is not supported when `timezonefinder` is not installed is automatic timezone detection based on latitude and longitude when initializing the `EnvironmentAnalysis` class. The user needs to specify the timezone to be used for reporting. If the user does not specify it, the following error will be raised:

```
ImportError: The timezonefinder package is required to automatically determine local timezone based on lat,lon coordinates. Please specify the desired timezone using the `timezone` argument when initializing the EnvironmentAnalysis class or install it with `pip install timezonefinder`.
``` 

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This PR should solve the failing GitHub Actions that has been haunting us for a couple of months now.