### PR TITLE
MAINT: use raw.githubusercontent address in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ TestFlight.allInfo()
 
 Here is just a quick taste of what RocketPy is able to calculate. There are hundred of plots and data points computed by RocketPy to enhance your analyses.
 
-![6-DOF Trajectory Plot](docs/static/rocketpy_example_trajectory.svg)
+![6-DOF Trajectory Plot](https://raw.githubusercontent.com/RocketPy-Team/RocketPy/master/docs/static/rocketpy_example_trajectory.svg)
 
 <br>
 
@@ -317,9 +317,10 @@ See a [detailed list of contributors](https://github.com/RocketPy-Team/RocketPy/
 
 ## Supporting RocketPy and Contributing
 
-The easiest way to help RocketPy is to demonstrate your support by starring our repository! ![GitHub Repo stars](https://img.shields.io/github/stars/RocketPy-Team/RocketPy?style=social)
+The easiest way to help RocketPy is to demonstrate your support by starring our repository!
+[![starcharts stargazers over time](https://starchart.cc/rocketpy-team/rocketpy.svg)](https://starchart.cc/rocketpy-team/rocketpy)
 
-<br>
+You can also become a [sponsor](https://github.com/sponsors/RocketPy-Team) and help us financially to keep the project going.
 
 If you are actively using RocketPy in one of your projects, reaching out to our core team via [Discord](https://discord.gg/b6xYnNh) and providing feedback can help improve RocketPy a lot!
 


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

Please check the type of change your PR introduces:

- [x] ReadMe, Docs and GitHub maintenance

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- ReadMe, Docs and GitHub maintenance:

  - [x] Spelling has been verified
  - [x] Code docs are working correctly 

## What is the current behavior?
Docs page cannot load two images of our README.md file as they have bad reference.

## What is the new behavior?
Images are now referred to their raw content, and therefore the docs page should be restored.
This solves the #204 issue.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

It is true that more improvements to the README.md files can be done, but this PR aims to only solve the proposed related issue.