### PR TITLE
TST: new plots tests

### DIFF
--- a/rocketpy/plots/compare/compare_flights.py
+++ b/rocketpy/plots/compare/compare_flights.py
@@ -52,6 +52,74 @@ class CompareFlights(Compare):
 
         return None
 
+    def __process_xlim(self, x_lim):
+        """Function to process the x_lim key word argument. It is simply a
+        logic to check if the string "apogee" is used as an item for the tuple,
+        and if so, replace it with the maximum apogee time of all flights.
+        This garantes that we do not repeat the same code for each plot.
+
+        Parameters
+        ----------
+        x_lim : tuple
+            A list of two items, where the first item represents the x axis lower limit
+            and second item, the x axis upper limit. If set to None, will be calculated
+            automatically by matplotlib. If the string "apogee" is used as a item for the
+            tuple, the maximum apogee time of all flights will be used instead.
+
+        Returns
+        -------
+        x_lim
+            The processed x_lim keyword argument.
+        """
+        if x_lim:
+            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
+            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        return x_lim
+
+    def __process_savefig(self, filename, fig):
+        """Function to either save the plot or show it, depending on the
+        filename key word argument. This way we do not repeat the same code
+        for each plot.
+
+        Parameters
+        ----------
+        filename : str, optional
+            If a filename is provided, the plot will be saved to a file, by default None.
+            Image options are: png, pdf, ps, eps and svg.
+        fig : matplotlib.figure.Figure
+            The figure to be saved or shown.
+
+        Returns
+        -------
+        None
+        """
+        if filename:
+            fig.savefig(filename)
+            print("Plot saved to file: " + filename)
+        else:
+            plt.show()
+        return None
+
+    def __process_legend(self, legend, fig):
+        """Function to add a legend to the plot, if the legend key word
+        argument is set to True. This way we do not repeat the same code for
+        each plot.
+
+        Parameters
+        ----------
+        legend : bool
+            If set to True, a legend will be added to the plot, by default True.
+        fig : matplotlib.figure.Figure
+            The figure to which the legend will be added.
+
+        Returns
+        -------
+        None
+        """
+        if legend:
+            fig.legend()
+        return None
+
     def positions(
         self, figsize=(7, 10), x_lim=None, y_lim=None, legend=True, filename=None
     ):
@@ -83,9 +151,7 @@ class CompareFlights(Compare):
         None
         """
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -102,10 +168,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -146,9 +209,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -165,10 +226,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -210,9 +268,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -239,10 +295,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -283,9 +336,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -307,10 +358,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -346,9 +394,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -369,10 +415,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -413,9 +456,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -437,10 +478,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -476,9 +514,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -499,10 +535,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -538,14 +571,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
-
-        # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -566,8 +592,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -603,9 +628,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -626,10 +649,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -670,9 +690,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -692,10 +710,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -735,9 +750,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -757,10 +770,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -794,9 +804,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -817,10 +825,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -859,9 +864,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -878,10 +881,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -921,9 +921,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -950,10 +948,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -993,9 +988,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -1012,10 +1005,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -1055,9 +1045,7 @@ class CompareFlights(Compare):
         """
 
         # Check if key word is used for x_limit
-        if x_lim:
-            x_lim[0] = self.apogee_time if x_lim[0] == "apogee" else x_lim[0]
-            x_lim[1] = self.apogee_time if x_lim[1] == "apogee" else x_lim[1]
+        x_lim = self.__process_xlim(x_lim)
 
         # Create the figure
         fig, _ = super().create_comparison_figure(
@@ -1084,10 +1072,7 @@ class CompareFlights(Compare):
         )
 
         # Saving the plot to a file if a filename is provided, showing the plot otherwise
-        if filename:
-            fig.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -1420,16 +1405,12 @@ class CompareFlights(Compare):
         ax.set_xlim([minXY, maxXY])
 
         # Add legend
-        if legend:
-            fig.legend()
+        self.__process_legend(legend, fig)
 
         fig.tight_layout()
 
         # Save figure
-        if filename:
-            plt.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -1488,8 +1469,7 @@ class CompareFlights(Compare):
         ax.set_xlim([minXY, maxXY])
 
         # Add legend
-        if legend:
-            fig.legend()
+        self.__process_legend(legend, fig)
 
         fig.tight_layout()
 
@@ -1556,16 +1536,12 @@ class CompareFlights(Compare):
         ax.set_xlim([minXY, maxXY])
 
         # Add legend
-        if legend:
-            fig.legend()
+        self.__process_legend(legend, fig)
 
         fig.tight_layout()
 
         # Save figure
-        if filename:
-            plt.savefig(filename)
-        else:
-            plt.show()
+        self.__process_savefig(filename, fig)
 
         return None
 
@@ -1582,6 +1558,8 @@ class CompareFlights(Compare):
         """
 
         self.trajectories_3d()
+
+        self.trajectories_2d()
 
         self.positions()
 

--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -132,7 +132,9 @@ class _RocketPlots:
         return None
 
     def all(self):
-        """Prints out all graphs available about the Rocket.
+        """Prints out all graphs available about the Rocket. It simply calls
+        all the other plotter methods in this class.
+
         Parameters
         ----------
         None
@@ -143,12 +145,12 @@ class _RocketPlots:
 
         # Show plots
         print("\nMass Plots")
-        self.rocket.totalMass()
-        self.rocket.reducedMass()
+        self.totalMass()
+        self.reducedMass()
         print("\nAerodynamics Plots")
-        self.rocket.staticMargin()
-        self.rocket.powerOnDrag()
-        self.rocket.powerOffDrag()
-        self.rocket.thrustToWeight.plot(lower=0, upper=self.rocket.motor.burnOutTime)
+        self.staticMargin()
+        self.powerOnDrag()
+        self.powerOffDrag()
+        self.thrustToWeight()
 
         return None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
-import pytest
-from rocketpy import SolidMotor
-from rocketpy import Rocket
+import datetime
+
 import numericalunits
+import pytest
+
+from rocketpy import Environment, Rocket, SolidMotor
 
 
 def pytest_addoption(parser):
@@ -100,3 +102,25 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
+
+
+@pytest.fixture
+def example_env():
+    Env = Environment(railLength=5, datum="WGS84")
+    return Env
+
+
+@pytest.fixture
+def example_env_robust():
+    Env = Environment(
+        railLength=5,
+        latitude=32.990254,
+        longitude=-106.974998,
+        elevation=1400,
+        datum="WGS84",
+    )
+    tomorrow = datetime.date.today() + datetime.timedelta(days=1)
+    Env.setDate(
+        (tomorrow.year, tomorrow.month, tomorrow.day, 12)
+    )  # Hour given in UT/C time
+    return Env

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -6,28 +6,6 @@ import pytz
 from rocketpy import Environment, Flight, Rocket, SolidMotor
 
 
-@pytest.fixture
-def example_env():
-    Env = Environment(railLength=5, datum="WGS84")
-    return Env
-
-
-@pytest.fixture
-def example_env_robust():
-    Env = Environment(
-        railLength=5,
-        latitude=32.990254,
-        longitude=-106.974998,
-        elevation=1400,
-        datum="WGS84",
-    )
-    tomorrow = datetime.date.today() + datetime.timedelta(days=1)
-    Env.setDate(
-        (tomorrow.year, tomorrow.month, tomorrow.day, 12)
-    )  # Hour given in UTC time
-    return Env
-
-
 def test_env_set_date(example_env):
     tomorrow = datetime.date.today() + datetime.timedelta(days=1)
     example_env.setDate((tomorrow.year, tomorrow.month, tomorrow.day, 12))

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,105 @@
+import os
+from unittest.mock import patch
+
+import matplotlib.pyplot as plt
+
+from rocketpy import Flight
+from rocketpy.plots.compare import Compare, CompareFlights
+
+
+@patch("matplotlib.pyplot.show")
+def test_compare(mock_show, rocket, example_env):
+    """Here we want to test the 'x_attributes' argument, which is the only one
+    that is not tested in the other tests.
+
+    Parameters
+    ----------
+    mock_show :
+        Mocks the matplotlib.pyplot.show() function to avoid showing the plots.
+    rocket : rocketpy.Rocket
+        Rocket object to be used in the tests. See conftest.py for more details.
+    example_env : rocketpy.Environment
+        Environment object to be used in the tests. See conftest.py for more details.
+    """
+    rocket.setRailButtons([-0.5, 0.2])
+    flight = Flight(environment=example_env, rocket=rocket, inclination=85, heading=0)
+
+    objects = [flight, flight, flight]
+
+    comparison = Compare(object_list=objects)
+
+    fig, _ = comparison.create_comparison_figure(
+        y_attributes=["z"],
+        n_rows=1,
+        n_cols=1,
+        figsize=(10, 10),
+        legend=False,
+        title="Test",
+        x_labels=["Time (s)"],
+        y_labels=["Altitude (m)"],
+        x_lim=(0, 3),
+        y_lim=(0, 1000),
+        x_attributes=["time"],
+    )
+
+    assert isinstance(fig, plt.Figure) == True
+
+
+@patch("matplotlib.pyplot.show")
+def test_compare_flights(mock_show, rocket, example_env):
+    """Tests the CompareFlights class. It simply ensures that all the methods
+    are being called without errors. It does not test the actual plots, which
+    would be very difficult to do.
+
+    Parameters
+    ----------
+    mock_show :
+        Mocks the matplotlib.pyplot.show() function to avoid showing the plots.
+    rocket : rocketpy.Rocket
+        Rocket object to be used in the tests. See conftest.py for more details.
+    example_env : rocketpy.Environment
+        Environment object to be used in the tests. See conftest.py for more details.
+
+    Returns
+    -------
+    None
+    """
+    example_env.setAtmosphericModel(
+        type="CustomAtmosphere",
+        pressure=None,
+        temperature=300,
+        wind_u=[(0, 5), (1000, 10)],
+        wind_v=[(0, -2), (500, 3), (1600, 2)],
+    )
+
+    rocket.setRailButtons([-0.5, 0.2])
+
+    inclinations = [60, 70, 80, 90]
+    headings = [0, 45, 90, 180]
+    flights = []
+
+    # Create (4 * 4) = 16 different flights to be compared
+    for heading in headings:
+        for inclination in inclinations:
+            flight = Flight(
+                environment=example_env,
+                rocket=rocket,
+                inclination=inclination,
+                heading=heading,
+                name=f"Incl {inclination} Head {heading}",
+            )
+            flights.append(flight)
+
+    comparison = CompareFlights(flights)
+
+    assert comparison.all() == None
+    assert comparison.trajectories_2d(plane="xz", legend=False) == None
+    assert comparison.trajectories_2d(plane="yz", legend=True) == None
+
+    # Test save fig and then remove file
+    assert comparison.positions(filename="test.png") == None
+    os.remove("test.png")
+
+    # Test xlim and ylim arguments
+    assert comparison.positions(x_lim=[0, 100], y_lim=[0, 1000]) == None
+    assert comparison.positions(x_lim=[0, "apogee"]) == None


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [x] Other (please describe): Unit Tests

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base maintenance (refactoring, formatting, renaming):

  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?

We need unit tests to finish #287 development.

## What is the new behavior?

Tests were added, the coverage reported was generated and is printed below:
Obs.: The number 14, highlighted, should be, actually, 0.
![image](https://user-images.githubusercontent.com/63590233/210711776-11f10bee-1bff-4391-ac73-0723f3f8489f.png)

To reproduce the report, just run: 
`coverage run --module pytest --runslow`
`coverage html`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

@MateusStano , please read the commits descriptions 1 by 1 in order to understand what I've done.
Basically, a couple of MAINT were needed to optimize the tests, mainly, avoiding repetitions.
I am adding only two new tests, and I think everything is already being accomplished for now.
We can separate these two functions into more, if you want to. But I don't think it is necessary.

Ready for your review!