### PR TITLE
MAINT: move flutter analysis into utilities submodule

### DIFF
--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -511,16 +511,6 @@ class Flight:
             Defined as the minimum angle between the attitude vector and
             the freestream velocity vector. Can be called or accessed as
             array.
-
-        Fin Flutter Analysis:
-        Flight.flutterMachNumber: Function
-            The freestream velocity at which begins flutter phenomenon in
-            rocket's fins. It's expressed as a function of the air pressure
-            experienced  for the rocket. Can be called or accessed as array.
-        Flight.difference: Function
-            Difference between flutterMachNumber and machNumber, as a function of time.
-        Flight.safetyFactor: Function
-            Ratio between the flutterMachNumber and machNumber, as a function of time.
     """
 
     def __init__(
@@ -1069,9 +1059,6 @@ class Flight:
         """Initialize post-process variables."""
         # Initialize all variables calculated after initialization.
         # Important to do so that MATLAB® can access them
-        self.flutterMachNumber = Function(0)
-        self.difference = Function(0)
-        self.safetyFactor = Function(0)
         self._drift = Function(0)
         self._bearing = Function(0)
         self._latitude = Function(0)
@@ -2678,160 +2665,6 @@ class Flight:
                 stallAngle, wV
             )
         )
-
-        return None
-
-    def calculateFinFlutterAnalysis(self, finThickness, shearModulus):
-        """Calculate, create and plot the Fin Flutter velocity, based on the
-        pressure profile provided by Atmospheric model selected. It considers the
-        Flutter Boundary Equation that is based on a calculation published in
-        NACA Technical Paper 4197.
-        Be careful, these results are only estimates of a real problem and may
-        not be useful for fins made from non-isotropic materials. These results
-        should not be used as a way to fully prove the safety of any rocket's fins.
-        IMPORTANT: This function works if only a single set of fins is added.
-
-        Parameters
-        ----------
-        finThickness : float
-            The fin thickness, in meters
-        shearModulus : float
-            Shear Modulus of fins' material, must be given in Pascal
-
-        Return
-        ------
-        None
-        """
-
-        s = (self.rocket.tipChord + self.rocket.rootChord) * self.rocket.span / 2
-        ar = self.rocket.span * self.rocket.span / s
-        la = self.rocket.tipChord / self.rocket.rootChord
-
-        # Calculate the Fin Flutter Mach Number
-        self.flutterMachNumber = (
-            (shearModulus * 2 * (ar + 2) * (finThickness / self.rocket.rootChord) ** 3)
-            / (1.337 * (ar**3) * (la + 1) * self.pressure)
-        ) ** 0.5
-
-        # Calculate difference between Fin Flutter Mach Number and the Rocket Speed
-        self.difference = self.flutterMachNumber - self.MachNumber
-
-        # Calculate a safety factor for flutter
-        self.safetyFactor = self.flutterMachNumber / self.MachNumber
-
-        # Calculate the minimum Fin Flutter Mach Number and Velocity
-        # Calculate the time and height of minimum Fin Flutter Mach Number
-        minflutterMachNumberTimeIndex = np.argmin(self.flutterMachNumber[:, 1])
-        minflutterMachNumber = self.flutterMachNumber[minflutterMachNumberTimeIndex, 1]
-        minMFTime = self.flutterMachNumber[minflutterMachNumberTimeIndex, 0]
-        minMFHeight = self.z(minMFTime) - self.env.elevation
-        minMFVelocity = minflutterMachNumber * self.env.speedOfSound(minMFHeight)
-
-        # Calculate minimum difference between Fin Flutter Mach Number and the Rocket Speed
-        # Calculate the time and height of the difference ...
-        minDifferenceTimeIndex = np.argmin(self.difference[:, 1])
-        minDif = self.difference[minDifferenceTimeIndex, 1]
-        minDifTime = self.difference[minDifferenceTimeIndex, 0]
-        minDifHeight = self.z(minDifTime) - self.env.elevation
-        minDifVelocity = minDif * self.env.speedOfSound(minDifHeight)
-
-        # Calculate the minimum Fin Flutter Safety factor
-        # Calculate the time and height of minimum Fin Flutter Safety factor
-        minSFTimeIndex = np.argmin(self.safetyFactor[:, 1])
-        minSF = self.safetyFactor[minSFTimeIndex, 1]
-        minSFTime = self.safetyFactor[minSFTimeIndex, 0]
-        minSFHeight = self.z(minSFTime) - self.env.elevation
-
-        # Print fin's geometric parameters
-        print("Fin's geometric parameters")
-        print("Surface area (S): {:.4f} m2".format(s))
-        print("Aspect ratio (AR): {:.3f}".format(ar))
-        print("TipChord/RootChord = \u03BB = {:.3f}".format(la))
-        print("Fin Thickness: {:.5f} m".format(finThickness))
-
-        # Print fin's material properties
-        print("\n\nFin's material properties")
-        print("Shear Modulus (G): {:.3e} Pa".format(shearModulus))
-
-        # Print a summary of the Fin Flutter Analysis
-        print("\n\nFin Flutter Analysis")
-        print(
-            "Minimum Fin Flutter Velocity: {:.3f} m/s at {:.2f} s".format(
-                minMFVelocity, minMFTime
-            )
-        )
-        print("Minimum Fin Flutter Mach Number: {:.3f} ".format(minflutterMachNumber))
-        # print(
-        #    "Altitude of minimum Fin Flutter Velocity: {:.3f} m (AGL)".format(
-        #        minMFHeight
-        #    )
-        # )
-        print(
-            "Minimum of (Fin Flutter Mach Number - Rocket Speed): {:.3f} m/s at {:.2f} s".format(
-                minDifVelocity, minDifTime
-            )
-        )
-        print(
-            "Minimum of (Fin Flutter Mach Number - Rocket Speed): {:.3f} Mach at {:.2f} s".format(
-                minDif, minDifTime
-            )
-        )
-        # print(
-        #    "Altitude of minimum (Fin Flutter Mach Number - Rocket Speed): {:.3f} m (AGL)".format(
-        #        minDifHeight
-        #    )
-        # )
-        print(
-            "Minimum Fin Flutter Safety Factor: {:.3f} at {:.2f} s".format(
-                minSF, minSFTime
-            )
-        )
-        print(
-            "Altitude of minimum Fin Flutter Safety Factor: {:.3f} m (AGL)\n\n".format(
-                minSFHeight
-            )
-        )
-
-        # Create plots
-        fig12 = plt.figure(figsize=(6, 9))
-        ax1 = plt.subplot(311)
-        ax1.plot()
-        ax1.plot(
-            self.flutterMachNumber[:, 0],
-            self.flutterMachNumber[:, 1],
-            label="Fin flutter Mach Number",
-        )
-        ax1.plot(
-            self.MachNumber[:, 0],
-            self.MachNumber[:, 1],
-            label="Rocket Freestream Speed",
-        )
-        ax1.set_xlim(0, self.apogeeTime if self.apogeeTime != 0.0 else self.tFinal)
-        ax1.set_title("Fin Flutter Mach Number x Time(s)")
-        ax1.set_xlabel("Time (s)")
-        ax1.set_ylabel("Mach")
-        ax1.legend()
-        ax1.grid(True)
-
-        ax2 = plt.subplot(312)
-        ax2.plot(self.difference[:, 0], self.difference[:, 1])
-        ax2.set_xlim(0, self.apogeeTime if self.apogeeTime != 0.0 else self.tFinal)
-        ax2.set_title("Mach flutter - Freestream velocity")
-        ax2.set_xlabel("Time (s)")
-        ax2.set_ylabel("Mach")
-        ax2.grid()
-
-        ax3 = plt.subplot(313)
-        ax3.plot(self.safetyFactor[:, 0], self.safetyFactor[:, 1])
-        ax3.set_xlim(self.outOfRailTime, self.apogeeTime)
-        ax3.set_ylim(0, 6)
-        ax3.set_title("Fin Flutter Safety Factor")
-        ax3.set_xlabel("Time (s)")
-        ax3.set_ylabel("Safety Factor")
-        ax3.grid()
-
-        plt.subplots_adjust(hspace=0.5)
-        plt.show()
 
         return None
 

--- a/rocketpy/utilities.py
+++ b/rocketpy/utilities.py
@@ -210,7 +210,7 @@ def fin_flutter_analysis(
     provided by the selected atmospheric model. It considers the Flutter Boundary
     Equation that published in NACA Technical Paper 4197.
     These results are only estimates of a real problem and may not be useful for
-    fins made from non-isotropic materials. 
+    fins made from non-isotropic materials.
     Currently, this function works if only a single set of fins is added, otherwise
     it will use the last set of fins added to the rocket.
 

--- a/rocketpy/utilities.py
+++ b/rocketpy/utilities.py
@@ -7,10 +7,12 @@ import traceback
 import warnings
 
 import numpy as np
+import matplotlib.pyplot as plt
 from scipy.integrate import solve_ivp
 
 from .Environment import Environment
 from .Function import Function
+from .AeroSurfaces import TrapezoidalFins
 
 
 # TODO: Needs tests
@@ -52,7 +54,7 @@ def calculateEquilibriumAltitude(
     env=None,
     eps=1e-3,
     max_step=0.1,
-    seeGraphs=True,
+    see_graphs=True,
     g=9.80665,
     estimated_final_time=10,
 ):
@@ -76,7 +78,7 @@ def calculateEquilibriumAltitude(
         acceptable error in meters.
     max_step: float, optional
         maximum allowed time step size to solve the integration
-    seeGraphs : boolean, optional
+    see_graphs : boolean, optional
         True if you want to see time vs altitude and time vs speed graphs,
         False otherwise.
     g : float, optional
@@ -194,11 +196,241 @@ def calculateEquilibriumAltitude(
         interpolation="linear",
     )
 
-    if seeGraphs:
+    if see_graphs:
         altitudeFunction()
         velocityFunction()
 
     return altitudeFunction, velocityFunction, final_sol
+
+
+def fin_flutter_analysis(
+    fin_thickness, shear_modulus, flight, see_prints=True, see_graphs=True
+):
+    """Calculate and plot the Fin Flutter velocity using the pressure profile
+    provided by the selected atmospheric model. It considers the Flutter Boundary
+    Equation that published in NACA Technical Paper 4197.
+    These results are only estimates of a real problem and may not be useful for
+    fins made from non-isotropic materials. 
+    Currently, this function works if only a single set of fins is added, otherwise
+    it will use the last set of fins added to the rocket.
+
+    Parameters
+    ----------
+    fin_thickness : float
+        The fin thickness, in meters
+    shear_modulus : float
+        Shear Modulus of fins' material, must be given in Pascal
+    flight : rocketpy.Flight
+        Flight object containing the rocket's flight data
+    see_prints : boolean, optional
+        True if you want to see the prints, False otherwise.
+    see_graphs : boolean, optional
+        True if you want to see the graphs, False otherwise. If False, the
+        function will return the vectors containing the data for the graphs.
+
+    Return
+    ------
+    None
+    """
+
+    # First, we need identify if there is at least a fin set in the rocket
+    for aero_surface, _ in flight.rocket.aerodynamicSurfaces:
+        if isinstance(aero_surface, TrapezoidalFins):
+            # s: surface area; ar: aspect ratio; la: lambda
+            root_chord = aero_surface.rootChord
+            s = (aero_surface.tipChord + root_chord) * aero_surface.span / 2
+            ar = aero_surface.span * aero_surface.span / s
+            la = aero_surface.tipChord / root_chord
+
+    # This ensures that a fin set was found in the rocket, if not, break
+    try:
+        s = s
+    except NameError:
+        print("There is no fin set in the rocket, can't run a Flutter Analysis.")
+        return None
+
+    # Calculate the Fin Flutter Mach Number
+    flutter_mach = (
+        (shear_modulus * 2 * (ar + 2) * (fin_thickness / root_chord) ** 3)
+        / (1.337 * (ar**3) * (la + 1) * flight.pressure)
+    ) ** 0.5
+
+    safety_factor = _flutter_safety_factor(flight, flutter_mach)
+
+    # Prints everything
+    if see_prints:
+        _flutter_prints(
+            fin_thickness,
+            shear_modulus,
+            s,
+            ar,
+            la,
+            flutter_mach,
+            safety_factor,
+            flight,
+        )
+
+    # Plots everything
+    if see_graphs:
+        _flutter_plots(flight, flutter_mach, safety_factor)
+        return None
+    else:
+        return flutter_mach, safety_factor
+
+
+def _flutter_safety_factor(flight, flutter_mach):
+    """Calculates the safety factor for the fin flutter analysis.
+
+    Parameters
+    ----------
+    flight : rocketpy.Flight
+        Flight object containing the rocket's flight data
+    flutter_mach : rocketpy.Function
+        Mach Number at which the fin flutter occurs. See the
+        `fin_flutter_analysis` function for more details.
+
+    Returns
+    -------
+    rocketpy.Function
+        The safety factor for the fin flutter analysis.
+    """
+    safety_factor = [[t, 0] for t in flutter_mach[:, 0]]
+    for i in range(len(flutter_mach)):
+        try:
+            safety_factor[i][1] = flutter_mach[i][1] / flight.MachNumber[i][1]
+        except ZeroDivisionError:
+            safety_factor[i][1] = np.nan
+
+    # Function needs to remove NaN and Inf values from the source
+    safety_factor = np.array(safety_factor)
+    safety_factor = safety_factor[~np.isnan(safety_factor).any(axis=1)]
+    safety_factor = safety_factor[~np.isinf(safety_factor).any(axis=1)]
+
+    safety_factor = Function(
+        source=safety_factor,
+        inputs="Time (s)",
+        outputs="Fin Flutter Safety Factor",
+        interpolation="linear",
+    )
+
+    return safety_factor
+
+
+def _flutter_plots(flight, flutter_mach, safety_factor):
+    """Plot the Fin Flutter Mach Number and the Safety Factor for the flutter.
+
+    Parameters
+    ----------
+    flight : rocketpy.Flight
+        Flight object containing the rocket's flight data
+    flutter_mach : rocketpy.Function
+        Function containing the Fin Flutter Mach Number, see fin_flutter_analysis
+        for more details.
+    safety_factor : rocketpy.Function
+        Function containing the Safety Factor for the fin flutter. See
+        fin_flutter_analysis for more details.
+
+    Returns
+    -------
+    None
+    """
+    fig = plt.figure(figsize=(6, 6))
+    ax1 = plt.subplot(211)
+    ax1.plot(
+        flutter_mach[:, 0],
+        flutter_mach[:, 1],
+        label="Fin flutter Mach Number",
+    )
+    ax1.plot(
+        flight.MachNumber[:, 0],
+        flight.MachNumber[:, 1],
+        label="Rocket Freestream Speed",
+    )
+    ax1.set_xlim(0, flight.apogeeTime if flight.apogeeTime != 0.0 else flight.tFinal)
+    ax1.set_title("Fin Flutter Mach Number x Time(s)")
+    ax1.set_xlabel("Time (s)")
+    ax1.set_ylabel("Mach")
+    ax1.legend()
+    ax1.grid()
+
+    ax2 = plt.subplot(212)
+    ax2.plot(safety_factor[:, 0], safety_factor[:, 1])
+    ax2.set_xlim(flight.outOfRailTime, flight.apogeeTime)
+    ax2.set_ylim(0, 6)
+    ax2.set_title("Fin Flutter Safety Factor")
+    ax2.set_xlabel("Time (s)")
+    ax2.set_ylabel("Safety Factor")
+    ax2.grid()
+
+    plt.subplots_adjust(hspace=0.5)
+    plt.show()
+
+    return None
+
+
+def _flutter_prints(
+    fin_thickness,
+    shear_modulus,
+    s,
+    ar,
+    la,
+    flutter_mach,
+    safety_factor,
+    flight,
+):
+    """Prints out the fin flutter analysis results. See fin_flutter_analysis for
+    more details.
+
+    Parameters
+    ----------
+    fin_thickness : float
+        The fin thickness, in meters
+    shear_modulus : float
+        Shear Modulus of fins' material, must be given in Pascal
+    s : float
+        Fin surface area, in squared meters
+    ar : float
+        Fin aspect ratio
+    la : float
+        Fin lambda, defined as the tip_chord / root_chord ratio
+    flutter_mach : rocketpy.Function
+        The Mach Number at which the fin flutter occurs, considering the variation
+        of the speed of sound with altitude. See fin_flutter_analysis for more
+        details.
+    safety_factor : rocketpy.Function
+        The Safety Factor for the fin flutter. Defined as the Fin Flutter Mach
+        Number divided by the Freestream Mach Number.
+    flight : rocketpy.Flight
+        Flight object containing the rocket's flight data
+
+    Returns
+    -------
+    None
+    """
+    time_index = np.argmin(flutter_mach[:, 1])
+    time_min_mach = flutter_mach[time_index, 0]
+    min_mach = flutter_mach[time_index, 1]
+    min_vel = min_mach * flight.speedOfSound(time_min_mach)
+
+    time_index = np.argmin(safety_factor[:, 1])
+    time_min_sf = safety_factor[time_index, 0]
+    min_sf = safety_factor[time_index, 1]
+    altitude_min_sf = flight.z(time_min_sf) - flight.env.elevation
+
+    print("\nFin's parameters")
+    print(f"Surface area (S): {s:.4f} m2")
+    print(f"Aspect ratio (AR): {ar:.3f}")
+    print(f"tip_chord/root_chord ratio = \u03BB = {la:.3f}")
+    print(f"Fin Thickness: {fin_thickness:.5f} m")
+    print(f"Shear Modulus (G): {shear_modulus:.3e} Pa")
+
+    print("\nFin Flutter Analysis")
+    print(f"Minimum Fin Flutter Velocity: {min_vel:.3f} m/s at {time_min_mach:.2f} s")
+    print(f"Minimum Fin Flutter Mach Number: {min_mach:.3f} ")
+    print(f"Minimum Safety Factor: {min_sf:.3f} at {time_min_sf:.2f} s")
+    print(f"Altitude of minimum Safety Factor: {altitude_min_sf:.3f} m (AGL)\n")
+
+    return None
 
 
 def create_dispersion_dictionary(filename):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,14 @@ import datetime
 import numericalunits
 import pytest
 
-from rocketpy import Environment, EnvironmentAnalysis, Function, Rocket, SolidMotor
+from rocketpy import (
+    Environment,
+    EnvironmentAnalysis,
+    Function,
+    Rocket,
+    SolidMotor,
+    Flight,
+)
 
 
 def pytest_addoption(parser):
@@ -52,6 +59,31 @@ def rocket(solid_motor):
     )
     example_rocket.addMotor(solid_motor, position=-1.255)
     return example_rocket
+
+
+@pytest.fixture
+def flight(rocket, example_env):
+
+    rocket.setRailButtons([0.2, -0.5])
+
+    NoseCone = rocket.addNose(
+        length=0.55829, kind="vonKarman", position=1.278, name="NoseCone"
+    )
+    FinSet = rocket.addTrapezoidalFins(
+        4, span=0.100, rootChord=0.120, tipChord=0.040, position=-1.04956
+    )
+    Tail = rocket.addTail(
+        topRadius=0.0635, bottomRadius=0.0435, length=0.060, position=-1.194656
+    )
+
+    flight = Flight(
+        environment=example_env,
+        rocket=rocket,
+        inclination=85,
+        heading=90,
+        terminateOnApogee=True,
+    )
+    return flight
 
 
 @pytest.fixture
@@ -188,25 +220,3 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "slow" in item.keywords:
             item.add_marker(skip_slow)
-
-
-@pytest.fixture
-def example_env():
-    Env = Environment(railLength=5, datum="WGS84")
-    return Env
-
-
-@pytest.fixture
-def example_env_robust():
-    Env = Environment(
-        railLength=5,
-        latitude=32.990254,
-        longitude=-106.974998,
-        elevation=1400,
-        datum="WGS84",
-    )
-    tomorrow = datetime.date.today() + datetime.timedelta(days=1)
-    Env.setDate(
-        (tomorrow.year, tomorrow.month, tomorrow.day, 12)
-    )  # Hour given in UT/C time
-    return Env

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,10 +1,44 @@
-from rocketpy import utilities
+from unittest.mock import patch
+
 import numpy as np
+
+from rocketpy import utilities
 
 
 def test_compute_CdS_from_drop_test():
     assert (
         utilities.compute_CdS_from_drop_test(31.064, 18, 1.0476) == 0.3492311157844522
+    )
+
+
+@patch("matplotlib.pyplot.show")
+def test_fin_flutter_analysis(mock_show, flight):
+    """Tests the fin_flutter_analysis function. It tests the both options of
+    the see_graphs parameter.
+
+    Parameters
+    ----------
+    flight : rocketpy.Flight
+        A Flight object with a rocket with fins. This flight object was created
+        in the conftest.py file.
+    """
+    flutter_mach, safety_factor = utilities.fin_flutter_analysis(
+        fin_thickness=2 / 1000,
+        shear_modulus=10e9,
+        flight=flight,
+        see_graphs=False,
+    )
+
+    assert abs(flutter_mach(15) - 1.085295573) < 1e-6
+    assert abs(safety_factor(15) - 3.373824095) < 1e-6
+    assert (
+        utilities.fin_flutter_analysis(
+            fin_thickness=2 / 1000,
+            shear_modulus=10e9,
+            flight=flight,
+            see_graphs=True,
+        )
+        == None
     )
 
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Code maintenance (refactoring, formatting, renaming, tests)

## Pull request checklist

- Code base maintenance (refactoring, formatting, renaming):

  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?

Fin Flutter Analysis is polluting the Flight.py file!!!

## What is the new behavior?
- A new function `fin_flutter_analysis` was created inside. Some workarounds to handle with divisions by zero but everything is working as expected!
- New test to cover the flutter analysis

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes (The flight class docstring had to be modified, removing the flutter parts)

## Other information

Adding an example to the utilities notebook would be interesting, but I do not see reasons for doing it right now at this PR. It is better to give an example after we get near to the next release.