### PR TITLE
FIX: Correct timezonefinder import.

### DIFF
--- a/rocketpy/EnvironmentAnalysis.py
+++ b/rocketpy/EnvironmentAnalysis.py
@@ -421,7 +421,7 @@ class EnvironmentAnalysis:
     def __find_preferred_timezone(self):
         if self.preferred_timezone is None:
             try:
-                import timezonefinder as TimezoneFinder
+                from timezonefinder import TimezoneFinder
             except ImportError:
                 raise ImportError(
                     "The timezonefinder package is required to automatically "


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [X] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [ ] Tests for the changes have been added
  - [ ] Docs have been reviewed and added / updated if needed
  - [ ] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [X] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
The usage of the import statement of the module `timezonefinder` was incorrect, raising an error only when `pytest --runslow` is run.

This means that all branches derived from `beta/v1.0.0` did not pass the runslow tests.

## What is the new behavior?
The import was corrected, now all tests of `pytest --runslow` run successfully.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No