### PR TITLE
ENH: Environment changes for Dispersion

### DIFF
--- a/docs/notebooks/topography_usage.ipynb
+++ b/docs/notebooks/topography_usage.ipynb
@@ -139,7 +139,7 @@
             "metadata": {},
             "outputs": [],
             "source": [
-                "elevation = Env.getElevationFromTopographicProfile(Env.lat, Env.lon)\n"
+                "elevation = Env.getElevationFromTopographicProfile(Env.latitude, Env.longitude)\n"
             ]
         },
         {
@@ -262,10 +262,10 @@
                 }
             ],
             "source": [
-                "eRadius = Env.calculateEarthRadius(Env.lat, Env.datum)\n",
+                "eRadius = Env.calculateEarthRadius(Env.latitude, Env.datum)\n",
                 "\n",
                 "print(\n",
-                "    \"The Earth radius at latitude {:.6f}°:  {:.2f} km\".format(Env.lat, eRadius / 1000)\n",
+                "    \"The Earth radius at latitude {:.6f}°:  {:.2f} km\".format(Env.latitude, eRadius / 1000)\n",
                 ")\n"
             ]
         }
@@ -286,7 +286,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.10.9"
+            "version": "3.10.5"
         },
         "vscode": {
             "interpreter": {

--- a/docs/notebooks/topography_usage.ipynb
+++ b/docs/notebooks/topography_usage.ipynb
@@ -262,7 +262,7 @@
                 }
             ],
             "source": [
-                "eRadius = Env.calculateEarthRadius(Env.latitude, Env.datum)\n",
+                "eRadius = Env.calculateEarthRadius(Env.latitude)\n",
                 "\n",
                 "print(\n",
                 "    \"The Earth radius at latitude {:.6f}°:  {:.2f} km\".format(Env.latitude, eRadius / 1000)\n",

--- a/rocketpy/Environment.py
+++ b/rocketpy/Environment.py
@@ -3268,7 +3268,6 @@ class Environment:
             ],
             "latitude": self.latitude,
             "longitude": self.longitude,
-
             "elevation": self.elevation,
             "datum": self.datum,
             "timeZone": self.timeZone,

--- a/rocketpy/Environment.py
+++ b/rocketpy/Environment.py
@@ -370,7 +370,7 @@ class Environment:
         if latitude != None and longitude != None:
             self.setLocation(latitude, longitude)
         else:
-            self.lat, self.lon = None, None
+            self.latitude, self.longitude = None, None
 
         # Save date
         if date != None:
@@ -404,7 +404,7 @@ class Environment:
 
         # Store launch site coordinates referenced to UTM projection system
         if self.latitude > -80 and self.latitude < 84:
-            convert = self.geodesicToUtm(self.latitude, self.longitude, self.datum)
+            convert = self.geodesicToUtm(self.latitude, self.longitude)
 
             self.initialNorth = convert[1]
             self.initialEast = convert[0]
@@ -418,7 +418,7 @@ class Environment:
         self.setElevation(elevation)
 
         # Recalculate Earth Radius
-        self.earthRadius = self.calculateEarthRadius(self.latitude, self.datum)  # in m
+        self.earthRadius = self.calculateEarthRadius(self.latitude)  # in m
 
         # Initialize plots and prints object
         self.plots = _EnvironmentPlots(self)
@@ -541,7 +541,7 @@ class Environment:
         first_ecc_sqrd = 6.694379990141e-3  # square of first eccentricity
 
         # Compute quantities
-        sin_lat_sqrd = (np.sin(self.lat * np.pi / 180)) ** 2
+        sin_lat_sqrd = (np.sin(self.latitude * np.pi / 180)) ** 2
 
         gravity_somgl = g_e * (
             (1 + k_somgl * sin_lat_sqrd) / (np.sqrt(1 - first_ecc_sqrd * sin_lat_sqrd))

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -619,8 +619,12 @@ class Flight:
         # Modifying Rail Length for a better out of rail condition
         upperButtonPosition, lowerButtonPosition = self.rocket.railButtons.position
         nozzlePosition = self.rocket.motorPosition
-        self.effective1RL = self.env.railLength - abs(nozzlePosition - upperButtonPosition)
-        self.effective2RL = self.env.railLength - abs(nozzlePosition - lowerButtonPosition)
+        self.effective1RL = self.env.railLength - abs(
+            nozzlePosition - upperButtonPosition
+        )
+        self.effective2RL = self.env.railLength - abs(
+            nozzlePosition - lowerButtonPosition
+        )
 
         # Flight initialization
         self.__init_post_process_variables()

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -619,8 +619,8 @@ class Flight:
         # Modifying Rail Length for a better out of rail condition
         upperButtonPosition, lowerButtonPosition = self.rocket.railButtons.position
         nozzlePosition = self.rocket.motorPosition
-        self.effective1RL = self.env.rL - abs(nozzlePosition - upperButtonPosition)
-        self.effective2RL = self.env.rL - abs(nozzlePosition - lowerButtonPosition)
+        self.effective1RL = self.env.railLength - abs(nozzlePosition - upperButtonPosition)
+        self.effective2RL = self.env.railLength - abs(nozzlePosition - lowerButtonPosition)
 
         # Flight initialization
         self.__init_post_process_variables()
@@ -1164,7 +1164,7 @@ class Flight:
             upperRButton = max(self.rocket.railButtons[0])
         except AttributeError:  # If there is no rail button
             upperRButton = nozzle
-        effective1RL = self.env.rL - abs(nozzle - upperRButton)
+        effective1RL = self.env.railLength - abs(nozzle - upperRButton)
 
         return effective1RL
 
@@ -1178,7 +1178,7 @@ class Flight:
             lowerRButton = min(self.rocket.railButtons[0])
         except AttributeError:
             lowerRButton = nozzle
-        effective2RL = self.env.rL - abs(nozzle - lowerRButton)
+        effective2RL = self.env.railLength - abs(nozzle - lowerRButton)
         return effective2RL
 
     @cached_property
@@ -2329,7 +2329,7 @@ class Flight:
     @funcify_method("Time (s)", "Latitude (°)", "linear", "constant")
     def latitude(self):
         """Rocket latitude coordinate, in degrees, as a rocketpy.Function of time."""
-        lat1 = np.deg2rad(self.env.lat)  # Launch lat point converted to radians
+        lat1 = np.deg2rad(self.env.latitude)  # Launch lat point converted to radians
 
         # Applies the haversine equation to find final lat/lon coordinates
         latitude = np.rad2deg(
@@ -2345,8 +2345,8 @@ class Flight:
     @funcify_method("Time (s)", "Longitude (°)", "linear", "constant")
     def longitude(self):
         """Rocket longitude coordinate, in degrees, as a rocketpy.Function of time."""
-        lat1 = np.deg2rad(self.env.lat)  # Launch lat point converted to radians
-        lon1 = np.deg2rad(self.env.lon)  # Launch lon point converted to radians
+        lat1 = np.deg2rad(self.env.latitude)  # Launch lat point converted to radians
+        lon1 = np.deg2rad(self.env.longitude)  # Launch lon point converted to radians
 
         # Applies the haversine equation to find final lat/lon coordinates
         longitude = np.rad2deg(

--- a/rocketpy/prints/environment_prints.py
+++ b/rocketpy/prints/environment_prints.py
@@ -59,21 +59,28 @@ class _EnvironmentPrints:
         None
         """
         print("\nLaunch Site Details\n")
-        print("Launch Rail Length:", self.environment.rL, " m")
+        print("Launch Rail Length:", self.environment.railLength, " m")
         time_format = "%Y-%m-%d %H:%M:%S"
-        if self.environment.date != None and "UTC" not in self.environment.timeZone:
+        if (
+            self.environment.datetime_date != None
+            and "UTC" not in self.environment.timeZone
+        ):
             print(
                 "Launch Date:",
-                self.environment.date.strftime(time_format),
+                self.environment.datetime_date.strftime(time_format),
                 "UTC |",
                 self.environment.localDate.strftime(time_format),
                 self.environment.timeZone,
             )
-        elif self.environment.date != None:
-            print("Launch Date:", self.environment.date.strftime(time_format), "UTC")
-        if self.environment.lat != None and self.environment.lon != None:
-            print("Launch Site Latitude: {:.5f}°".format(self.environment.lat))
-            print("Launch Site Longitude: {:.5f}°".format(self.environment.lon))
+        elif self.environment.datetime_date != None:
+            print(
+                "Launch Date:",
+                self.environment.datetime_date.strftime(time_format),
+                "UTC",
+            )
+        if self.environment.latitude != None and self.environment.longitude != None:
+            print("Launch Site Latitude: {:.5f}°".format(self.environment.latitude))
+            print("Launch Site Longitude: {:.5f}°".format(self.environment.longitude))
         print("Reference Datum: " + self.environment.datum)
         print(
             "Launch Site UTM coordinates: {:.2f} ".format(self.environment.initialEast)
@@ -193,8 +200,8 @@ class _EnvironmentPrints:
         """
         # Print launch site details
         # print("Launch Site Details")
-        # print("Launch Site Latitude: {:.5f}°".format(self.environment.lat))
-        # print("Launch Site Longitude: {:.5f}°".format(self.environment.lon))
+        # print("Launch Site Latitude: {:.5f}°".format(self.environment.latitude))
+        # print("Launch Site Longitude: {:.5f}°".format(self.environment.longitude))
         # print("Reference Datum: " + self.environment.datum)
         # print("Launch Site UTM coordinates: {:.2f} ".format(self.environment.initialEast)
         #    + self.environment.initialEW + "    {:.2f} ".format(self.environment.initialNorth) + self.environment.initialHemisphere

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -12,7 +12,7 @@ from rocketpy import Environment
 def test_env_set_date(example_env):
     tomorrow = datetime.date.today() + datetime.timedelta(days=1)
     example_env.setDate((tomorrow.year, tomorrow.month, tomorrow.day, 12))
-    assert example_env.date == datetime.datetime(
+    assert example_env.datetime_date == datetime.datetime(
         tomorrow.year, tomorrow.month, tomorrow.day, 12, tzinfo=pytz.utc
     )
 
@@ -26,12 +26,12 @@ def test_env_set_date_time_zone(example_env):
     timezone = pytz.timezone("America/New_York")
     dateAwareLocalDate = timezone.localize(dateNaive)
     dateAwareUTC = dateAwareLocalDate.astimezone(pytz.UTC)
-    assert example_env.date == dateAwareUTC
+    assert example_env.datetime_date == dateAwareUTC
 
 
 def test_env_set_location(example_env):
     example_env.setLocation(-21.960641, -47.482122)
-    assert example_env.lat == -21.960641 and example_env.lon == -47.482122
+    assert example_env.latitude == -21.960641 and example_env.longitude == -47.482122
 
 
 def test_set_elevation(example_env):
@@ -47,7 +47,9 @@ def test_set_topographic_profile(example_env):
         dictionary="netCDF4",
     )
     assert (
-        example_env.getElevationFromTopographicProfile(example_env.lat, example_env.lon)
+        example_env.getElevationFromTopographicProfile(
+            example_env.latitude, example_env.longitude
+        )
         == 1565
     )
 

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -712,10 +712,10 @@ def test_latlon_conversions(mock_show):
 
     # Check for initial and final lat/lon coordinates based on launch pad coordinates
     test_flight.postProcess()
-    assert abs(test_flight.latitude(0)) - abs(test_flight.env.lat) < 1e-6
-    assert abs(test_flight.longitude(0)) - abs(test_flight.env.lon) < 1e-6
-    assert test_flight.latitude(test_flight.tFinal) > test_flight.env.lat
-    assert test_flight.longitude(test_flight.tFinal) > test_flight.env.lon
+    assert abs(test_flight.latitude(0)) - abs(test_flight.env.latitude) < 1e-6
+    assert abs(test_flight.longitude(0)) - abs(test_flight.env.longitude) < 1e-6
+    assert test_flight.latitude(test_flight.tFinal) > test_flight.env.latitude
+    assert test_flight.longitude(test_flight.tFinal) > test_flight.env.longitude
 
 
 @patch("matplotlib.pyplot.show")


### PR DESCRIPTION
## Pull request checklist

  - [x] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## Discussion

Some of the arguments in the `Environment` class are being saved on `self` with a different name, e.g. the argument `railLength` is saved with `self.rL = railLength`.

If `getattr` is run with the name of the arguments it will not be able to get the `railLength` value inputted. This is a huge problem for the `Dispersion` class, since it is heavilydependent in `getattr`.

The following attributes were changed:

- `self.rL` --> `self.railLenght`
- `self.lat` --> `self.latitude`
- `self.lon` --> `self.longitude`
- created `self.datetime_date`, which is what `self.date` was before these changes. Meaning, it is the argument `date` transformed into a datetime object with the inputted timezone
- made `self.date` save the exact argument inputted in `date`

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

`self.g` is also a problem here but it is already being fixed in #338 