### PR TITLE
ENH: add " ' " to Function __repr__

### DIFF
--- a/rocketpy/Function.py
+++ b/rocketpy/Function.py
@@ -564,7 +564,7 @@ class Function:
         interpolations.
 
         >>> g.setDiscreteBasedOnModel(f)
-        Function from R1 to R1 : (Scalar) → (Scalar)
+        'Function from R1 to R1 : (Scalar) → (Scalar)'
         >>> h = f * g
         >>> h.source
         array([[ 0.,  0.],

--- a/rocketpy/Function.py
+++ b/rocketpy/Function.py
@@ -1223,8 +1223,8 @@ class Function:
 
     def __repr__(self):
         "Return a string representation of the Function"
-        return (
-            "'Function from R"
+        return repr(
+            "Function from R"
             + str(self.__domDim__)
             + " to R"
             + str(self.__imgDim__)
@@ -1232,7 +1232,7 @@ class Function:
             + ", ".join(self.__inputs__)
             + ") → ("
             + ", ".join(self.__outputs__)
-            + ")'"
+            + ")"
         )
 
     def setTitle(self, title):

--- a/rocketpy/Function.py
+++ b/rocketpy/Function.py
@@ -5,6 +5,7 @@ __copyright__ = "Copyright 20XX, RocketPy Team"
 __license__ = "MIT"
 
 from inspect import signature
+from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -147,8 +148,8 @@ class Function:
         -------
         self : Function
         """
-        # Import CSV if source is a string and convert values to ndarray
-        if isinstance(source, str):
+        # Import CSV if source is a string or Path and convert values to ndarray
+        if isinstance(source, (str, Path)):
             # Read file and check for headers
             f = open(source, "r")
             firstLine = f.readline()
@@ -642,9 +643,9 @@ class Function:
         >>> v.getInputs(), v.getOutputs()
         (['t'], ['v'])
         >>> kinetic_energy
-        Function from R1 to R1 : (x) → (Scalar)
+        'Function from R1 to R1 : (x) → (Scalar)'
         >>> kinetic_energy.reset(inputs='t', outputs='Kinetic Energy');
-        Function from R1 to R1 : (t) → (Kinetic Energy)
+        'Function from R1 to R1 : (t) → (Kinetic Energy)'
 
         Returns
         -------
@@ -1208,7 +1209,7 @@ class Function:
 
     def __str__(self):
         "Return a string representation of the Function"
-        return (
+        return str(
             "Function from R"
             + str(self.__domDim__)
             + " to R"
@@ -1223,7 +1224,7 @@ class Function:
     def __repr__(self):
         "Return a string representation of the Function"
         return (
-            "Function from R"
+            "'Function from R"
             + str(self.__domDim__)
             + " to R"
             + str(self.__imgDim__)
@@ -1231,7 +1232,7 @@ class Function:
             + ", ".join(self.__inputs__)
             + ") → ("
             + ", ".join(self.__outputs__)
-            + ")"
+            + ")'"
         )
 
     def setTitle(self, title):
@@ -2773,7 +2774,7 @@ def funcify_method(*args, **kwargs):
     ...         return lambda x: x**2
     >>> example = Example()
     >>> example.f
-    Function from R1 to R1 : (x) → (y)
+    'Function from R1 to R1 : (x) → (y)'
 
     Normal algebra can be performed afterwards:
 
@@ -2792,7 +2793,7 @@ def funcify_method(*args, **kwargs):
     ...         return g / f
     >>> example = Example()
     >>> example.cube
-    Function from R1 to R1 : (x) → (x**3)
+    'Function from R1 to R1 : (x) → (x**3)'
 
     3. Method which is itself a valid rocketpy.Function source argument.
 
@@ -2802,7 +2803,7 @@ def funcify_method(*args, **kwargs):
     ...         return x**2
     >>> example = Example()
     >>> example.f
-    Function from R1 to R1 : (x) → (f(x))
+    'Function from R1 to R1 : (x) → (f(x))'
 
     In order to reset the cache, just delete de attribute from the instance:
 
@@ -2811,7 +2812,7 @@ def funcify_method(*args, **kwargs):
     Once it is requested again, it will be re-created as a new Function object:
 
     >>> example.f
-    Function from R1 to R1 : (x) → (f(x))
+    'Function from R1 to R1 : (x) → (f(x))'
     """
     func = None
     if len(args) == 1 and callable(args[0]):

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -23,7 +23,7 @@ def test_function_from_csv(func_from_csv):
     # Check the __str__ method
     assert func_from_csv.__str__() == "Function from R1 to R1 : (Scalar) → (Scalar)"
     # Check the __repr__ method
-    assert func_from_csv.__repr__() == "Function from R1 to R1 : (Scalar) → (Scalar)"
+    assert func_from_csv.__repr__() == "'Function from R1 to R1 : (Scalar) → (Scalar)'"
 
 
 def test_getters(func_from_csv):


### PR DESCRIPTION
## Pull request checklist

  - [x] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## Discussion

There is a problem in the Dispersion class when it comes to saving Function objects in the `.txt` files. This is a special problem in the `.disp_inputs.txt` files, since the values of `powerOffDrag`, `powerOnDrag` and others are received as Functions.

What happens in these cases is, when saving in the `.txt` file we simply pass a dictionary, which contains the info of the simulation inputs, into the `write` function. The interaction between the `write` function and the `Function` class is so that what gets saved in the file is the `Function` `__repr__`. For example:

```python
 { ... "powerOffDrag": Function from R1 to R1 : (Scalar) → (Scalar), ... }
```

Further on, in the dispersion class, there is an attribute called `inputs_log` that generates, from the input file, a list in which each item is a line of the file. A list of dictionaries with all the inputs necessary to recreate any iteration of the simulation.

Now, two problems arise from this:

- The way `Function`s are saved is not "redefinable", so we can't recreate that `Function` object just with its `__repr__` information. I believe the only way to do this (from what I know) would be to start using `pickle`. Unfortunately, that is out of the scope of v1.0 since it would take some extra effort to implement
- When the `inputs_log` is created, it can not interpret each line of the file because `Function from R1 to R1 : (Scalar) → (Scalar)` is not a recognizable Python object. It is not a string.


The temporary solution I found for this was to just change add a `'` as the first and last character of the `__repr__` string. This way, it gets saved in the `.txt` as string and can be read by as a python object:

```python
 { ... "powerOffDrag": 'Function from R1 to R1 : (Scalar) → (Scalar)', ... }
```

I am creating this PR to both ask if there is any better way to do this, or if this is an okay solution to the problem

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No