### PR TITLE
fix and simplify getting started example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ To actually create a Flight object, use:
 test_flight = Flight(rocket=Calisto, environment=Env, inclination=85, heading=0)
 ```
 
-Once the TestFlight object is created, your simulation is done! Use the following code to get a summary of the results:
+Once the Flight object is created, your simulation is done! Use the following code to get a summary of the results:
 
 ```python
 test_flight.info()

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Env = Environment(
     date=(2020, 3, 4, 12) # Tomorrow's date in year, month, day, hour UTC format
 ) 
 
-Env.setAtmosphericModel(type='Forecast', file='GFS')
+Env.setAtmosphericModel(type='StandardAtmosphere', file='GFS')
 ```
 
 This can be followed up by starting a Solid Motor object. To get help on it, just use:
@@ -213,6 +213,7 @@ Pro75M1670 = SolidMotor(
     grainOuterRadius=33/1000,
     grainInitialInnerRadius=15/1000,
     grainInitialHeight=120/1000,
+    grainsCenterOfMassPosition=-0.85704,
     nozzleRadius=33/1000,
     throatRadius=11/1000,
     interpolationMethod='linear'
@@ -236,16 +237,12 @@ Calisto = Rocket(
     powerOffDrag="../../data/calisto/powerOffDragCurve.csv",
     powerOnDrag="../../data/calisto/powerOnDragCurve.csv",
     centerOfDryMassPosition=0,
-    coordinateSystemOrientation="tailToNose",
+    coordinateSystemOrientation="tailToNose"
 )
-
 Calisto.setRailButtons([0.2, -0.5])
-
 Calisto.addMotor(Pro75M1670, position=-1.255)
-
-NoseCone = Calisto.addNose(length=0.55829, kind="vonKarman", position=0.71971 + 0.55829)
-
-FinSet = Calisto.addTrapezoidalFins(
+Calisto.addNose(length=0.55829, kind="vonKarman", position=0.71971 + 0.55829)
+Calisto.addTrapezoidalFins(
     n=4,
     rootChord=0.120,
     tipChord=0.040,
@@ -255,8 +252,7 @@ FinSet = Calisto.addTrapezoidalFins(
     radius=None,
     airfoil=None,
 )
-
-Tail = Calisto.addTail(
+Calisto.addTail(
     topRadius=0.0635, bottomRadius=0.0435, length=0.060, position=-1.194656
 )
 ```
@@ -264,25 +260,22 @@ Tail = Calisto.addTail(
 You may want to add parachutes to your rocket as well:
 
 ```python
-def drogueTrigger(p, y):
-    return True if y[5] < 0 else False
+drogueTrigger = lambda p, y : y[5] < 0
+mainTrigger = lambda p, y : y[5] < 0 and y[2] < 800
 
-def mainTrigger(p, y):
-    return True if y[5] < 0 and y[2] < 800 else False
+Calisto.addParachute('Main',
+                    CdS=10.0,
+                    trigger=mainTrigger, 
+                    samplingRate=105,
+                    lag=1.5,
+                    noise=(0, 8.3, 0.5))
 
-Main = Calisto.addParachute('Main',
-                            CdS=10.0,
-                            trigger=mainTrigger, 
-                            samplingRate=105,
-                            lag=1.5,
-                            noise=(0, 8.3, 0.5))
-
-Drogue = Calisto.addParachute('Drogue',
-                              CdS=1.0,
-                              trigger=drogueTrigger, 
-                              samplingRate=105,
-                              lag=1.5,
-                              noise=(0, 8.3, 0.5))
+Calisto.addParachute('Drogue',
+                      CdS=1.0,
+                      trigger=drogueTrigger, 
+                      samplingRate=105,
+                      lag=1.5,
+                      noise=(0, 8.3, 0.5))
 ```
 
 Finally, you can create a Flight object to simulate your trajectory. To get help on the Flight class, use:
@@ -294,19 +287,19 @@ help(Flight)
 To actually create a Flight object, use:
 
 ```python
-TestFlight = Flight(rocket=Calisto, environment=Env, inclination=85, heading=0)
+test_flight = Flight(rocket=Calisto, environment=Env, inclination=85, heading=0)
 ```
 
 Once the TestFlight object is created, your simulation is done! Use the following code to get a summary of the results:
 
 ```python
-TestFlight.info()
+test_flight.info()
 ```
 
 To see all available results, use:
 
 ```python
-TestFlight.allInfo()
+test_flight.allInfo()
 ```
 
 Here is just a quick taste of what RocketPy is able to calculate. There are hundreds of plots and data points computed by RocketPy to enhance your analyses.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Calisto.addTrapezoidalFins(
     position=-1.04956,
     cantAngle=0,
     radius=None,
-    airfoil=None,
+    airfoil=None
 )
 Calisto.addTail(
     topRadius=0.0635, bottomRadius=0.0435, length=0.060, position=-1.194656

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytz
 timezonefinder
 simplekml
 jsonpickle
+numericalunits


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

- [ ] Code base additions (bugfix, features)
- [X] Code maintenance (refactoring, formatting, renaming, tests)
- [X] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe)

## Pull request checklist

- ReadMe, Docs and GitHub maintenance:

  - [X] Spelling has been verified
  - [X] Code docs are working correctly 

- Code base maintenance (refactoring, formatting, renaming):

  - [X] Docs have been reviewed and added / updated if needed
  - [X] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [X] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Unable to run getting started docs example in README due to missing `grainsCenterOfMassPosition` for SolidMotor.__init__() --> added it inside Pro75M1670 =  SolidMotor() call
- Unable to run `pytest --runslow` locally due to missing `numericalunits` library --> added it to requirements.txt
- Unable to run `pytest --runslow` since python was unable to find rocketpy.plots --> added __init__.py inside tests folder

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Getting started docs working fine
- `pytest --runslow` working fine

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Tests results
<img width="993" alt="Screenshot 2023-05-01 at 16 41 11" src="https://user-images.githubusercontent.com/27734997/235519025-436fac13-172d-4c5b-b82b-ccc07633dba5.png">

OBS: I'm pretty sure these few observed failures are not due to any regression. I guess we have issues with the current testing suite.

