### PR TITLE
TST: skip tests for draft PRs and non-Python files

### DIFF
--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -1,9 +1,19 @@
 name: PyTest
 
-on: [pull_request]
+on:  
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**.py'
 
 jobs:
-  build:
+  fail_if_pull_request_is_draft:
+      if: github.event.pull_request.draft == true
+      runs-on: ubuntu-18.04
+      steps:
+      - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
+        run: exit 1
+  run_pytest_and_doctest:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
## Pull request type

- [x] ReadMe, Docs and GitHub maintenance

## Pull request checklist

  - [x] Spelling has been verified
  - [x] Code docs are working correctly 

## What is the current behavior?

GitHub Actions runs a PyTest workflow on draft PRs and even when non python files are updated, wasting resources and causing annoyances. 

## What is the new behavior?

- When a PR is in draft mode, no tests are run, saving resources, but the workflow fails indicating that they need to be run later.
- When no python files are updated, no tests are run,

## Does this introduce a breaking change?

- [x] No

## Other information

References:

- https://github.com/orgs/community/discussions/25722
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onevent_nametypes