### PR TITLE
BUG: fix standard atmosphere

### DIFF
--- a/rocketpy/Environment.py
+++ b/rocketpy/Environment.py
@@ -2903,7 +2903,6 @@ class Environment:
         # Convert geopotential height to geometric height
         ER = self.earthRadius
         height = [ER * H / (ER - H) for H in geopotential_height]
-        height = geopotential_height
 
         # Save international standard atmosphere temperature profile
         self.temperatureISA = Function(
@@ -2917,12 +2916,12 @@ class Environment:
         g = self.standard_g
         R = self.airGasConstant
 
-        # Create function to compute pressure profile
+        # Create function to compute pressure at a given geometric height
         def pressure_function(h):
             # Convert geometric to geopotential height
             H = ER * h / (ER + h)
-            H = h
 
+            # Check if height is within bounds, return extrapolated value if not
             if H < -2000:
                 return pressure[0]
             elif H > 80000:
@@ -3019,6 +3018,8 @@ class Environment:
         """Compute the dynamic viscosity of the atmosphere as a function of
         height by using the formula given in ISO 2533 u = B*T^(1.5)/(T+S).
         This function is automatically called whenever a new atmospheric model is set.
+        Warning: This equation is invalid for very high or very low temperatures
+        and under conditions occurring at altitudes above 90 km.
 
         Parameters
         ----------


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base maintenance (refactoring, formatting, renaming):

  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?

@MateusStano recently caught an inconsistency with the geopotential <=> geometric altitudes in the Environment Class.
I hereby confirm that is currently a BUG and the code has not been working properly so far.

## What is the new behavior?

I verified every equation in the Standard Atmosphere model, comparing each of them with the ISO 2533 available online.
All the inconsistencies were removed.
A few comments were provided to warn users of model limitations.

## Does this introduce a breaking change?

- [x] Yes (it modifies a basic calculation regarding environment pressure profile and temperature in ISA. As the difference between geopotential and geometric altitudes are usually lower and 1%, the impact will be very small. It doesn't even affects the current acceptance and unit tests).

## Other information

* It is not hard to find the ISO-2533 online, just google it including "pdf". However, it seems that it was update in 2021 but only a paid version can be found so far: https://www.iso.org/standard/7472.html 
* For future reference: something that **really** annoys me is that the code consider height as a synonym of altitude. Technically they are different things, and I would agree with a quick name refactoring in the future. As a rule of thumb, whenever we wrote "height", just replace to "altitude" and we will be more accurate.