### PR TITLE
Bug/flight without rail buttons

### DIFF
--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -2522,7 +2522,9 @@ class Flight:
             rail_buttons_tuple.component.buttons_distance + rail_buttons_tuple.position
         )
         lower_button_position = rail_buttons_tuple.position
-        angular_position_rad = rail_buttons_tuple.component.angular_position * np.pi / 180
+        angular_position_rad = (
+            rail_buttons_tuple.component.angular_position * np.pi / 180
+        )
         D1 = (
             upper_button_position - self.rocket.centerOfDryMassPosition
         ) * self.rocket._csys
@@ -2550,13 +2552,26 @@ class Flight:
         F21.setDiscreteBasedOnModel(model)
         F22.setDiscreteBasedOnModel(model)
 
-        railButton1NormalForce = F11 * np.cos(angular_position_rad) + F12 * np.sin(angular_position_rad)
-        railButton1ShearForce = F11 * -np.sin(angular_position_rad) + F12 * np.cos(angular_position_rad)
-        railButton2NormalForce = F21 * np.cos(angular_position_rad) + F22 * np.sin(angular_position_rad)
-        railButton2ShearForce = F21 * -np.sin(angular_position_rad) + F22 * np.cos(angular_position_rad)
+        railButton1NormalForce = F11 * np.cos(angular_position_rad) + F12 * np.sin(
+            angular_position_rad
+        )
+        railButton1ShearForce = F11 * -np.sin(angular_position_rad) + F12 * np.cos(
+            angular_position_rad
+        )
+        railButton2NormalForce = F21 * np.cos(angular_position_rad) + F22 * np.sin(
+            angular_position_rad
+        )
+        railButton2ShearForce = F21 * -np.sin(angular_position_rad) + F22 * np.cos(
+            angular_position_rad
+        )
 
-        return railButton1NormalForce, railButton1ShearForce, railButton2NormalForce, railButton2ShearForce
-            
+        return (
+            railButton1NormalForce,
+            railButton1ShearForce,
+            railButton2NormalForce,
+            railButton2ShearForce,
+        )
+
     def _calculate_pressure_signal(self):
         """Calculate the pressure signal from the pressure sensor.
         It creates a SignalFunction attribute in the parachute object.

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -2285,22 +2285,22 @@ class Flight:
         alpha = self.__rail_buttons_alpha_angle
         return F21 * -np.sin(alpha) + F22 * np.cos(alpha)
 
-    @cached_property
+    @property
     def maxRailButton1NormalForce(self):
         """Maximum upper rail button normal force, in Newtons."""
         return self.railButton1NormalForce.max
 
-    @cached_property
+    @property
     def maxRailButton1ShearForce(self):
         """Maximum upper rail button shear force, in Newtons."""
         return self.railButton1ShearForce.max
 
-    @cached_property
+    @property
     def maxRailButton2NormalForce(self):
         """Maximum lower rail button normal force, in Newtons."""
         return self.railButton2NormalForce.max
 
-    @cached_property
+    @property
     def maxRailButton2ShearForce(self):
         """Maximum lower rail button shear force, in Newtons."""
         return self.railButton2ShearForce.max

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -1142,6 +1142,7 @@ class Flight:
             # Set unused monitors
             self.outOfRailState = self.initialSolution[1:]
             self.outOfRailTime = self.initialSolution[0]
+            self.outOfRailTimeIndex = 0
             # Set initial derivative for 6-DOF flight phase
             self.initialDerivative = self.uDot
         else:

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -1176,7 +1176,7 @@ class Flight:
             upper_r_button = (
                 rail_buttons.component.buttons_distance + rail_buttons.position
             )
-        except AttributeError:
+        except IndexError:  # No rail buttons defined
             upper_r_button = nozzle
         effective1RL = self.env.railLength - abs(nozzle - upper_r_button)
         return effective1RL
@@ -1189,7 +1189,7 @@ class Flight:
         try:
             rail_buttons = self.rocket.rail_buttons[0]
             lower_r_button = rail_buttons.position
-        except AttributeError:
+        except IndexError:  # No rail buttons defined
             lower_r_button = nozzle
         effective2RL = self.env.railLength - abs(nozzle - lower_r_button)
         return effective2RL

--- a/rocketpy/plots/flight_plots.py
+++ b/rocketpy/plots/flight_plots.py
@@ -381,7 +381,71 @@ class _FlightPlots:
 
         return None
 
-    def trajectory_force_data(self):
+    def rail_buttons_forces(self):
+        """Prints out all Rail Buttons Forces graphs available about the Flight.
+
+        Returns
+        -------
+        None
+        """
+        if len(self.flight.rocket.rail_buttons) == 0:
+            print("No rail buttons were defined. Skipping rail button plots.")
+        elif self.flight.outOfRailTimeIndex == 0:
+            print("No rail phase was found. Skipping rail button plots.")
+        else:
+            fig6 = plt.figure(figsize=(9, 6))
+
+            ax1 = plt.subplot(211)
+            ax1.plot(
+                self.flight.railButton1NormalForce[: self.flight.outOfRailTimeIndex, 0],
+                self.flight.railButton1NormalForce[: self.flight.outOfRailTimeIndex, 1],
+                label="Upper Rail Button",
+            )
+            ax1.plot(
+                self.flight.railButton2NormalForce[: self.flight.outOfRailTimeIndex, 0],
+                self.flight.railButton2NormalForce[: self.flight.outOfRailTimeIndex, 1],
+                label="Lower Rail Button",
+            )
+            ax1.set_xlim(
+                0,
+                self.flight.outOfRailTime
+                if self.flight.outOfRailTime > 0
+                else self.flight.tFinal,
+            )
+            ax1.legend()
+            ax1.grid(True)
+            ax1.set_xlabel(self.flight.railButton1NormalForce.getInputs()[0])
+            ax1.set_ylabel(self.flight.railButton1NormalForce.getOutputs()[0])
+            ax1.set_title("Rail Buttons Normal Force")
+
+            ax2 = plt.subplot(212)
+            ax2.plot(
+                self.flight.railButton1ShearForce[: self.flight.outOfRailTimeIndex, 0],
+                self.flight.railButton1ShearForce[: self.flight.outOfRailTimeIndex, 1],
+                label="Upper Rail Button",
+            )
+            ax2.plot(
+                self.flight.railButton2ShearForce[: self.flight.outOfRailTimeIndex, 0],
+                self.flight.railButton2ShearForce[: self.flight.outOfRailTimeIndex, 1],
+                label="Lower Rail Button",
+            )
+            ax2.set_xlim(
+                0,
+                self.flight.outOfRailTime
+                if self.flight.outOfRailTime > 0
+                else self.flight.tFinal,
+            )
+            ax2.legend()
+            ax2.grid(True)
+            ax2.set_xlabel(self.flight.railButton1ShearForce.__inputs__[0])
+            ax2.set_ylabel(self.flight.railButton1ShearForce.__outputs__[0])
+            ax2.set_title("Rail Buttons Shear Force")
+
+            plt.subplots_adjust(hspace=0.5)
+            plt.show()
+        return None
+
+    def aerodynamic_forces(self):
         """Prints out all Forces and Moments graphs available about the Flight
 
         Parameters
@@ -392,58 +456,6 @@ class _FlightPlots:
         ------
         None
         """
-
-        # Rail Button Forces
-        fig6 = plt.figure(figsize=(9, 6))
-
-        ax1 = plt.subplot(211)
-        ax1.plot(
-            self.flight.railButton1NormalForce[: self.flight.outOfRailTimeIndex, 0],
-            self.flight.railButton1NormalForce[: self.flight.outOfRailTimeIndex, 1],
-            label="Upper Rail Button",
-        )
-        ax1.plot(
-            self.flight.railButton2NormalForce[: self.flight.outOfRailTimeIndex, 0],
-            self.flight.railButton2NormalForce[: self.flight.outOfRailTimeIndex, 1],
-            label="Lower Rail Button",
-        )
-        ax1.set_xlim(
-            0,
-            self.flight.outOfRailTime
-            if self.flight.outOfRailTime > 0
-            else self.flight.tFinal,
-        )
-        ax1.legend()
-        ax1.grid(True)
-        ax1.set_xlabel("Time (s)")
-        ax1.set_ylabel("Normal Force (N)")
-        ax1.set_title("Rail Buttons Normal Force")
-
-        ax2 = plt.subplot(212)
-        ax2.plot(
-            self.flight.railButton1ShearForce[: self.flight.outOfRailTimeIndex, 0],
-            self.flight.railButton1ShearForce[: self.flight.outOfRailTimeIndex, 1],
-            label="Upper Rail Button",
-        )
-        ax2.plot(
-            self.flight.railButton2ShearForce[: self.flight.outOfRailTimeIndex, 0],
-            self.flight.railButton2ShearForce[: self.flight.outOfRailTimeIndex, 1],
-            label="Lower Rail Button",
-        )
-        ax2.set_xlim(
-            0,
-            self.flight.outOfRailTime
-            if self.flight.outOfRailTime > 0
-            else self.flight.tFinal,
-        )
-        ax2.legend()
-        ax2.grid(True)
-        ax2.set_xlabel("Time (s)")
-        ax2.set_ylabel("Shear Force (N)")
-        ax2.set_title("Rail Buttons Shear Force")
-
-        plt.subplots_adjust(hspace=0.5)
-        plt.show()
 
         # Aerodynamic force and moment plots
         fig7 = plt.figure(figsize=(9, 12))
@@ -855,8 +867,11 @@ class _FlightPlots:
         print("\n\nTrajectory Angular Velocity and Acceleration Plots\n")
         self.angular_kinematics_data()
 
-        print("\n\nTrajectory Force Plots\n")
-        self.trajectory_force_data()
+        print("\n\nAerodynamic Forces Plots\n")
+        self.aerodynamic_forces()
+
+        print("\n\nRail Buttons Forces Plots\n")
+        self.rail_buttons_forces()
 
         print("\n\nTrajectory Energy Plots\n")
         self.energy_data()

--- a/rocketpy/prints/flight_prints.py
+++ b/rocketpy/prints/flight_prints.py
@@ -362,26 +362,32 @@ class _FlightPrints:
                 self.flight.maxAccelerationTime,
             )
         )
-        print(
-            "Maximum Upper Rail Button Normal Force: {:.3f} N".format(
-                self.flight.maxRailButton1NormalForce
+        if (
+            len(self.flight.rocket.rail_buttons) == 0
+            or self.flight.outOfRailTimeIndex == 0
+        ):
+            pass
+        else:
+            print(
+                "Maximum Upper Rail Button Normal Force: {:.3f} N".format(
+                    self.flight.maxRailButton1NormalForce
+                )
             )
-        )
-        print(
-            "Maximum Upper Rail Button Shear Force: {:.3f} N".format(
-                self.flight.maxRailButton1ShearForce
+            print(
+                "Maximum Upper Rail Button Shear Force: {:.3f} N".format(
+                    self.flight.maxRailButton1ShearForce
+                )
             )
-        )
-        print(
-            "Maximum Lower Rail Button Normal Force: {:.3f} N".format(
-                self.flight.maxRailButton2NormalForce
+            print(
+                "Maximum Lower Rail Button Normal Force: {:.3f} N".format(
+                    self.flight.maxRailButton2NormalForce
+                )
             )
-        )
-        print(
-            "Maximum Lower Rail Button Shear Force: {:.3f} N".format(
-                self.flight.maxRailButton2ShearForce
+            print(
+                "Maximum Lower Rail Button Shear Force: {:.3f} N".format(
+                    self.flight.maxRailButton2ShearForce
+                )
             )
-        )
         return None
 
     def all(self):


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [x] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
- Try to create a flight using a rocket without rail buttons, and then try to access the rail button forces, you're going to have a bug since the class cannot access rail buttons positions (given that there's no rail button defined).

## What is the new behavior?
- I improved the conditions to capture errors when a "buttonless" rocket is being provided to the Flight Class.
- Rail buttons forces are only calculated when there's a rail button phase and a rail button pair present.
- In case you try to access rail buttons forces without properly defining rail buttons, you are going to know exactly the reasons of any error, and the forces will be equals to zero in some cases.

## Does this introduce a breaking change?
- [x] No

## Other information
- I need this to be reviewed and merged before proceeding with the #378 