### PR TITLE
FIX: funcify titles - pt1

### DIFF
--- a/rocketpy/Function.py
+++ b/rocketpy/Function.py
@@ -83,21 +83,8 @@ class Function:
         # Set source
         self.setSource(source)
         #  Set function title
-        if title:
-            self.setTitle(title)
-        else:
-            if self.__domDim__ == 1:
-                self.setTitle(
-                    self.__outputs__[0].title() + " x " + self.__inputs__[0].title()
-                )
-            elif self.__domDim__ == 2:
-                self.setTitle(
-                    self.__outputs__[0].title()
-                    + " x "
-                    + self.__inputs__[0].title()
-                    + " x "
-                    + self.__inputs__[1].title()
-                )
+        self.setTitle(title)
+
         # Return
         return None
 
@@ -645,6 +632,7 @@ class Function:
         outputs=None,
         interpolation=None,
         extrapolation=None,
+        title=None,
     ):
         """This method allows the user to reset the inputs, outputs, interpolation
         and extrapolation settings of a Function object, all at once, without
@@ -693,6 +681,8 @@ class Function:
             self.setInterpolation(interpolation)
         if extrapolation is not None and extrapolation != self.__extrapolation__:
             self.setExtrapolation(extrapolation)
+
+        self.setTitle(title)
 
         return self
 
@@ -1272,7 +1262,21 @@ class Function:
         )
 
     def setTitle(self, title):
-        self.title = title
+        if title:
+            self.title = title
+        else:
+            if self.__domDim__ == 1:
+                self.title = (
+                    self.__outputs__[0].title() + " x " + self.__inputs__[0].title()
+                )
+            elif self.__domDim__ == 2:
+                self.title = (
+                    self.__outputs__[0].title()
+                    + " x "
+                    + self.__inputs__[0].title()
+                    + " x "
+                    + self.__inputs__[1].title()
+                )
 
     def plot(self, *args, **kwargs):
         """Call Function.plot1D if Function is 1-Dimensional or call


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

Please check the type of change your PR introduces:

- [X] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [ ] Tests for the changes have been added
  - [ ] Docs have been reviewed and added / updated if needed
  - [X] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [X] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `funcify_method` decorator from `Function` did not update the titles for methods that returned `Function` instances.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This issue was fixed by updating the `reset` method from `Function` with a call to `setTitle`.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No