### PR TITLE
ENH: Add Maximum Acceleration During Burn Print

### DIFF
--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -20,7 +20,7 @@ from scipy import integrate
 from .Function import Function, funcify_method
 from .plots.flight_plots import _FlightPlots
 from .prints.flight_prints import _FlightPrints
-from .tools import Matrix, Vector
+from .tools import Matrix, Vector, find_closest
 
 
 class Flight:
@@ -2164,17 +2164,11 @@ class Flight:
     @cached_property
     def max_acceleration_power_on(self):
         """Maximum acceleration reached by the rocket during motor burn."""
-        closest_value = float("inf")
-        index_to_slice = None
-
-        for index, item in enumerate(self.acceleration):
-            if abs(item[0] - self.rocket.motor.burn_out_time) < abs(
-                closest_value - self.rocket.motor.burn_out_time
-            ):
-                closest_value = item[0]
-                index_to_slice = index
+        burn_out_time_index = find_closest(
+            self.acceleration.source[:, 0], self.rocket.motor.burn_out_time
+        )
         max_acceleration_time_index = np.argmax(
-            self.acceleration[: index_to_slice + 1, 1]
+            self.acceleration[:burn_out_time_index, 1]
         )
         return self.acceleration[max_acceleration_time_index, 1]
 
@@ -2182,17 +2176,34 @@ class Flight:
     def max_acceleration_power_on_time(self):
         """Time at which the rocket reaches its maximum acceleration during
         motor burn."""
-        closest_value = float("inf")
-        index_to_slice = None
-
-        for index, item in enumerate(self.acceleration):
-            if abs(item[0] - self.rocket.motor.burn_out_time) < abs(
-                closest_value - self.rocket.motor.burn_out_time
-            ):
-                closest_value = item[0]
-                index_to_slice = index
+        burn_out_time_index = find_closest(
+            self.acceleration.source[:, 0], self.rocket.motor.burn_out_time
+        )
         max_acceleration_time_index = np.argmax(
-            self.acceleration[: index_to_slice + 1, 1]
+            self.acceleration[:burn_out_time_index, 1]
+        )
+        return self.acceleration[max_acceleration_time_index, 0]
+
+    @cached_property
+    def max_acceleration_power_off(self):
+        """Maximum acceleration reached by the rocket after motor burn."""
+        burn_out_time_index = find_closest(
+            self.acceleration.source[:, 0], self.rocket.motor.burn_out_time
+        )
+        max_acceleration_time_index = np.argmax(
+            self.acceleration[burn_out_time_index:, 1]
+        )
+        return self.acceleration[max_acceleration_time_index, 1]
+
+    @cached_property
+    def max_acceleration_power_off_time(self):
+        """Time at which the rocket reaches its maximum acceleration after
+        motor burn."""
+        burn_out_time_index = find_closest(
+            self.acceleration.source[:, 0], self.rocket.motor.burn_out_time
+        )
+        max_acceleration_time_index = np.argmax(
+            self.acceleration[burn_out_time_index:, 1]
         )
         return self.acceleration[max_acceleration_time_index, 0]
 

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -2162,6 +2162,41 @@ class Flight:
         return (self.ax**2 + self.ay**2 + self.az**2) ** 0.5
 
     @cached_property
+    def max_acceleration_power_on(self):
+        """Maximum acceleration reached by the rocket during motor burn."""
+        closest_value = float("inf")
+        index_to_slice = None
+
+        for index, item in enumerate(self.acceleration):
+            if abs(item[0] - self.rocket.motor.burn_out_time) < abs(
+                closest_value - self.rocket.motor.burn_out_time
+            ):
+                closest_value = item[0]
+                index_to_slice = index
+        max_acceleration_time_index = np.argmax(
+            self.acceleration[: index_to_slice + 1, 1]
+        )
+        return self.acceleration[max_acceleration_time_index, 1]
+
+    @cached_property
+    def max_acceleration_power_on_time(self):
+        """Time at which the rocket reaches its maximum acceleration during
+        motor burn."""
+        closest_value = float("inf")
+        index_to_slice = None
+
+        for index, item in enumerate(self.acceleration):
+            if abs(item[0] - self.rocket.motor.burn_out_time) < abs(
+                closest_value - self.rocket.motor.burn_out_time
+            ):
+                closest_value = item[0]
+                index_to_slice = index
+        max_acceleration_time_index = np.argmax(
+            self.acceleration[: index_to_slice + 1, 1]
+        )
+        return self.acceleration[max_acceleration_time_index, 0]
+
+    @cached_property
     def max_acceleration(self):
         """Maximum acceleration reached by the rocket."""
         max_acceleration_time_index = np.argmax(self.acceleration[:, 1])

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -2162,17 +2162,6 @@ class Flight:
         return (self.ax**2 + self.ay**2 + self.az**2) ** 0.5
 
     @cached_property
-    def max_acceleration_power_on(self):
-        """Maximum acceleration reached by the rocket during motor burn."""
-        burn_out_time_index = find_closest(
-            self.acceleration.source[:, 0], self.rocket.motor.burn_out_time
-        )
-        max_acceleration_time_index = np.argmax(
-            self.acceleration[:burn_out_time_index, 1]
-        )
-        return self.acceleration[max_acceleration_time_index, 1]
-
-    @cached_property
     def max_acceleration_power_on_time(self):
         """Time at which the rocket reaches its maximum acceleration during
         motor burn."""
@@ -2185,15 +2174,9 @@ class Flight:
         return self.acceleration[max_acceleration_time_index, 0]
 
     @cached_property
-    def max_acceleration_power_off(self):
-        """Maximum acceleration reached by the rocket after motor burn."""
-        burn_out_time_index = find_closest(
-            self.acceleration.source[:, 0], self.rocket.motor.burn_out_time
-        )
-        max_acceleration_time_index = np.argmax(
-            self.acceleration[burn_out_time_index:, 1]
-        )
-        return self.acceleration[max_acceleration_time_index, 1]
+    def max_acceleration_power_on(self):
+        """Maximum acceleration reached by the rocket during motor burn."""
+        return self.acceleration(self.max_acceleration_power_on_time)
 
     @cached_property
     def max_acceleration_power_off_time(self):
@@ -2208,16 +2191,21 @@ class Flight:
         return self.acceleration[max_acceleration_time_index, 0]
 
     @cached_property
-    def max_acceleration(self):
-        """Maximum acceleration reached by the rocket."""
-        max_acceleration_time_index = np.argmax(self.acceleration[:, 1])
-        return self.acceleration[max_acceleration_time_index, 1]
+    def max_acceleration_power_off(self):
+        """Maximum acceleration reached by the rocket after motor burn."""
+        return self.acceleration(self.max_acceleration_power_off_time)
 
     @cached_property
     def max_acceleration_time(self):
         """Time at which the rocket reaches its maximum acceleration."""
         max_acceleration_time_index = np.argmax(self.acceleration[:, 1])
         return self.acceleration[max_acceleration_time_index, 0]
+
+    @cached_property
+    def max_acceleration(self):
+        """Maximum acceleration reached by the rocket."""
+        max_acceleration_time_index = np.argmax(self.acceleration[:, 1])
+        return self.acceleration[max_acceleration_time_index, 1]
 
     @funcify_method("Time (s)", "Horizontal Speed (m/s)")
     def horizontal_speed(self):

--- a/rocketpy/prints/flight_prints.py
+++ b/rocketpy/prints/flight_prints.py
@@ -369,6 +369,28 @@ class _FlightPrints:
                 self.flight.max_acceleration_time,
             )
         )
+        # check if max acceleration during burn is different than overall
+        # max acceleration
+        if (
+            self.flight.max_acceleration_time
+            != self.flight.max_acceleration_power_on_time
+        ):
+            print(
+                "Maximum Acceleration During Motor Burn: {:.3f} m/s² at {:.2f} s".format(
+                    self.flight.max_acceleration_power_on,
+                    self.flight.max_acceleration_power_on_time,
+                )
+            )
+            print(
+                "Maximum Gs During Motor Burn: {:.3f} g at {:.2f} s".format(
+                    self.flight.max_acceleration_power_on
+                    / self.flight.env.gravity(
+                        self.flight.z(self.flight.max_acceleration_power_on_time)
+                    ),
+                    self.flight.max_acceleration_power_on_time,
+                )
+            )
+
         if (
             len(self.flight.rocket.rail_buttons) == 0
             or self.flight.out_of_rail_time_index == 0

--- a/rocketpy/prints/flight_prints.py
+++ b/rocketpy/prints/flight_prints.py
@@ -356,40 +356,35 @@ class _FlightPrints:
             )
         )
         print(
-            "Maximum Acceleration: {:.3f} m/s² at {:.2f} s".format(
-                self.flight.max_acceleration, self.flight.max_acceleration_time
+            "Maximum Acceleration During Motor Burn: {:.3f} m/s² at {:.2f} s".format(
+                self.flight.max_acceleration_power_on,
+                self.flight.max_acceleration_power_on_time,
             )
         )
         print(
-            "Maximum Gs: {:.3f} g at {:.2f} s".format(
-                self.flight.max_acceleration
+            "Maximum Gs During Motor Burn: {:.3f} g at {:.2f} s".format(
+                self.flight.max_acceleration_power_on
                 / self.flight.env.gravity(
-                    self.flight.z(self.flight.max_acceleration_time)
+                    self.flight.z(self.flight.max_acceleration_power_on_time)
                 ),
-                self.flight.max_acceleration_time,
+                self.flight.max_acceleration_power_on_time,
             )
         )
-        # check if max acceleration during burn is different than overall
-        # max acceleration
-        if (
-            self.flight.max_acceleration_time
-            != self.flight.max_acceleration_power_on_time
-        ):
-            print(
-                "Maximum Acceleration During Motor Burn: {:.3f} m/s² at {:.2f} s".format(
-                    self.flight.max_acceleration_power_on,
-                    self.flight.max_acceleration_power_on_time,
-                )
+        print(
+            "Maximum Acceleration After Motor Burn: {:.3f} m/s² at {:.2f} s".format(
+                self.flight.max_acceleration_power_off,
+                self.flight.max_acceleration_power_off_time,
             )
-            print(
-                "Maximum Gs During Motor Burn: {:.3f} g at {:.2f} s".format(
-                    self.flight.max_acceleration_power_on
-                    / self.flight.env.gravity(
-                        self.flight.z(self.flight.max_acceleration_power_on_time)
-                    ),
-                    self.flight.max_acceleration_power_on_time,
-                )
+        )
+        print(
+            "Maximum Gs After Motor Burn: {:.3f} g at {:.2f} s".format(
+                self.flight.max_acceleration_power_off
+                / self.flight.env.gravity(
+                    self.flight.z(self.flight.max_acceleration_power_off_time)
+                ),
+                self.flight.max_acceleration_power_off_time,
             )
+        )
 
         if (
             len(self.flight.rocket.rail_buttons) == 0

--- a/rocketpy/prints/flight_prints.py
+++ b/rocketpy/prints/flight_prints.py
@@ -363,10 +363,7 @@ class _FlightPrints:
         )
         print(
             "Maximum Gs During Motor Burn: {:.3f} g at {:.2f} s".format(
-                self.flight.max_acceleration_power_on
-                / self.flight.env.gravity(
-                    self.flight.z(self.flight.max_acceleration_power_on_time)
-                ),
+                self.flight.max_acceleration_power_on / self.flight.env.standard_g,
                 self.flight.max_acceleration_power_on_time,
             )
         )
@@ -378,10 +375,7 @@ class _FlightPrints:
         )
         print(
             "Maximum Gs After Motor Burn: {:.3f} g at {:.2f} s".format(
-                self.flight.max_acceleration_power_off
-                / self.flight.env.gravity(
-                    self.flight.z(self.flight.max_acceleration_power_off_time)
-                ),
+                self.flight.max_acceleration_power_off / self.flight.env.standard_g,
                 self.flight.max_acceleration_power_off_time,
             )
         )

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -6,6 +6,7 @@ _NOT_FOUND = object()
 import numpy as np
 import pytz
 from cftime import num2pydate
+from bisect import bisect_left
 
 
 class cached_property:
@@ -1194,6 +1195,40 @@ def geopotential_to_height_agl(geopotential, elevation, radius=63781370, g=9.806
     9198.792680243916
     """
     return geopotential_to_height_asl(geopotential, radius, g) - elevation
+
+
+def find_closest(ordered_sequence, value):
+    """Find the index of the closest value to a given value within an ordered
+    sequence.
+
+    Parameters
+    ----------
+    ordered_sequence : list
+        A sequence of values that is ordered from smallest to largest.
+    value : float
+        The value to which you want to find the closest value.
+
+    Returns
+    -------
+    index : int
+        The index of the closest value to the given value within the ordered
+        sequence. If the given value is less than the first value in the
+        sequence, then 0 is returned. If the given value is greater than the
+        last value in the sequence, then the index of the last value in the
+        sequence is returned.
+    """
+    if len(ordered_sequence) == 1:
+        return 0
+
+    pivot_index = bisect_left(ordered_sequence, value)
+    if pivot_index == 0:
+        return pivot_index
+    if pivot_index == len(ordered_sequence):
+        return pivot_index - 1
+
+    smaller, greater = ordered_sequence[pivot_index - 1], ordered_sequence[pivot_index]
+
+    return pivot_index - 1 if value - smaller <= greater - value else pivot_index
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Pull request type

- [x] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

  - [x] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If a flight simulation happens to have a parachute whose trigger generates an acceleration bigger than the acceleration generated by the motor, only the acceleration due to the parachute trigger will be printed out in the `info` and `all_info` methods

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Now, a print is added in cases where the motor acceleration is not what caused the highest acceleration:

![image](https://github.com/RocketPy-Team/RocketPy/assets/69485049/ffaab0c6-6429-4b92-969a-9767ef4bad00)

Note that when the maximum acceleration **is** caused by the motor, the extra printed lines are not added

- [ ] Yes
- [x] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

I also tried adding a print for the acceleration at the `open_time` of the parachute, but the acceleration at that time is not the max acceleration caused by the parachute opening. The max only happens a bit of time after the event and can not easily be determined.