### PR TITLE
BUG: Time Overshoot False not working

### DIFF
--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -731,11 +731,11 @@ class Flight:
                     hAGL = (
                         self.env.pressure.find_input(
                             pressure + noise,
-                            overshootable_node.y[2],
+                            self.y_sol[2],
                         )
                         - self.env.elevation
                     )
-                    if parachute.trigger(pressure + noise, hAGL, self.ySol):
+                    if parachute.trigger(pressure + noise, hAGL, self.y_sol):
                         # print('\nEVENT DETECTED')
                         # print('Parachute Triggered')
                         # print('Name: ', parachute.name, ' | Lag: ', parachute.lag)

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -517,3 +517,32 @@ def test_rail_length(calisto_robust, example_env, rail_length, out_of_rail_time)
         terminate_on_apogee=True,
     )
     assert abs(test_flight.z(test_flight.out_of_rail_time) - out_of_rail_time) < 1e-6
+
+
+@patch("matplotlib.pyplot.show")
+def test_time_overshoot(mock_show, calisto_robust, example_env_robust):
+    """Test the time_overshoot parameter of the Flight class. This basically
+    calls the all_info() method for a simulation without time_overshoot and
+    checks if it returns None. It is not testing if the values are correct,
+    just if the flight simulation is not breaking.
+
+    Parameters
+    ----------
+    calisto_robust : rocketpy.Rocket
+        The rocket to be simulated. In this case, the fixture rocket is used.
+        See the conftest.py file for more information.
+    example_env_robust : rocketpy.Environment
+        The environment to be simulated. In this case, the fixture environment
+        is used. See the conftest.py file for more information.
+    """
+
+    test_flight = Flight(
+        rocket=calisto_robust,
+        environment=example_env_robust,
+        rail_length=5.2,
+        inclination=85,
+        heading=0,
+        time_overshoot=False,
+    )
+
+    assert test_flight.all_info() == None


### PR DESCRIPTION
## Pull request type

- [x] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

  - [x] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is new?

Running a Flight simulation with `time_overshoot=False` was not working. This was due to a wrong variable being accesed to calculate the `hAGL` that is passed to the trigger function.

The bug isnow fixed and a test that runs flight with `time_overshoot=False` has been added.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No