### PR TITLE
BUG: EllipticalFins Roll Damping Factor Calculation

### DIFF
--- a/docs/technical/aerodynamics/elliptical_fins.rst
+++ b/docs/technical/aerodynamics/elliptical_fins.rst
@@ -159,7 +159,7 @@ When :math:`S < r`:
 
 .. math::
 
-    k_{R_{D}} = 1-\frac{r^2 \cdot\left(2 S^3-\pi S^2 r-2 S r^2+\pi r^3+2 r^2 \sqrt{-S^2+r^2} \cdot \operatorname{atan}\left(\frac{S}{\sqrt{-S^2+r^2}}\right)-\pi r^2 \sqrt{-S^2+r^2}\right)}{2 S\left(-S^2+r^2\right)\left(\frac{S^2}{3}+\frac{\pi S r}{4}\right)}
+    k_{R_{D}} = 1-\frac{r^2 \cdot\left(2 s^3-\pi s^2 r-2 s r^2+\pi r^3+2 r^2 \sqrt{-s^2+r^2} \cdot \operatorname{atan}\left(\frac{s}{\sqrt{-s^2+r^2}}\right)-\pi r^2 \sqrt{-s^2+r^2}\right)}{2 s\left(-s^2+r^2\right)\left(\frac{s^2}{3}+\frac{\pi s r}{4}\right)}
 
 And by calculating the limit of the above expressions when :math:`S \rightarrow r` we have that, for :math:`S = r`:
 

--- a/docs/technical/aerodynamics/elliptical_fins.rst
+++ b/docs/technical/aerodynamics/elliptical_fins.rst
@@ -2,9 +2,9 @@
 Elliptical Fins Equations
 =========================
 
+:Author: Mateus Stano Junqueira,
 :Author: Franz Masatoshi Yuri,
 :Author: Kaleb Ramos Wanderley Santos,
-:Author: Mateus Stano Junqueira,
 :Author: Matheus Gonçalvez Doretto,
 :Date:   February 2022
 
@@ -149,10 +149,21 @@ According to [Barrowman]_, the roll damping interference factor can be given by:
 Solving the integrals for elliptical fin geometry, using equations described at
 Chord Length (:math:`c`):
 
+When :math:`S > r`:
 
 .. math:: 
 
-    k_{R_{D}} = 1 + {r}^{2} \cdot \frac{\Bigl[2\cdot {r}^{2} \sqrt{s^2-r^2}\cdot \ln\Bigl(\frac{2s\cdot\sqrt{s^2-r^2}+ 2s^2}{r}\Bigr) - 2{r}^2\sqrt{{s}^2-{r}^2}\cdot \ln(2s) + 2s^{3} - {\pi}rs^{2} - 2r^2s + {\pi}\cdot {r}^3 \Bigr]}{2\cdot {s}^{2} \cdot \Bigl(\frac{s}{3}+\frac{{\pi}\cdot r}{4}\Bigr) \cdot\Bigl(s^2-r^2\Bigr)}
+    k_{R_{D}} = 1 + {r}^{2} \cdot \frac{2\cdot {r}^{2} \sqrt{s^2-r^2}\cdot \ln\Bigl(\frac{2s\cdot\sqrt{s^2-r^2}+ 2s^2}{r}\Bigr) - 2{r}^2\sqrt{{s}^2-{r}^2}\cdot \ln(2s) + 2s^{3} - {\pi}rs^{2} - 2r^2s + {\pi}\cdot {r}^3}{2\cdot {s}^{2} \cdot \Bigl(\frac{s}{3}+\frac{{\pi}\cdot r}{4}\Bigr) \cdot\Bigl(s^2-r^2\Bigr)}
+
+When :math:`S < r`:
+
+.. math::
+
+    k_{R_{D}} = 1-\frac{r^2 \cdot\left(2 S^3-\pi S^2 r-2 S r^2+\pi r^3+2 r^2 \sqrt{-S^2+r^2} \cdot \operatorname{atan}\left(\frac{S}{\sqrt{-S^2+r^2}}\right)-\pi r^2 \sqrt{-S^2+r^2}\right)}{2 S\left(-S^2+r^2\right)\left(\frac{S^2}{3}+\frac{\pi S r}{4}\right)}
+
+And by calculating the limit of the above expressions when :math:`S \rightarrow r` we have that, for :math:`S = r`:
+
+.. math:: k_{R_{D}} = \frac{28-3\pi}{4+3\pi}
 
 References
 ==========

--- a/rocketpy/AeroSurface.py
+++ b/rocketpy/AeroSurface.py
@@ -1299,7 +1299,7 @@ class EllipticalFins(Fins):
                 * (self.span**2 / 3 + np.pi * self.span * self.rocket_radius / 4)
             )
         elif self.span == self.rocket_radius:
-            roll_damping_interference_factor = (28-3*np.pi)/(4+3*np.pi)
+            roll_damping_interference_factor = (28 - 3 * np.pi) / (4 + 3 * np.pi)
 
         roll_forcing_interference_factor = (1 / np.pi**2) * (
             (np.pi**2 / 4) * ((tau + 1) ** 2 / tau**2)

--- a/rocketpy/AeroSurface.py
+++ b/rocketpy/AeroSurface.py
@@ -1242,36 +1242,65 @@ class EllipticalFins(Fins):
         # Fin–body interference correction parameters
         tau = (self.span + self.rocket_radius) / self.rocket_radius
         lift_interference_factor = 1 + 1 / tau
-        roll_damping_interference_factor = 1 + (
-            (self.rocket_radius**2)
-            * (
-                2
-                * (self.rocket_radius**2)
-                * np.sqrt(self.span**2 - self.rocket_radius**2)
-                * np.log(
-                    (
-                        2
-                        * self.span
-                        * np.sqrt(self.span**2 - self.rocket_radius**2)
-                        + 2 * self.span**2
+        if self.span > self.rocket_radius:
+            roll_damping_interference_factor = 1 + (
+                (self.rocket_radius**2)
+                * (
+                    2
+                    * (self.rocket_radius**2)
+                    * np.sqrt(self.span**2 - self.rocket_radius**2)
+                    * np.log(
+                        (
+                            2
+                            * self.span
+                            * np.sqrt(self.span**2 - self.rocket_radius**2)
+                            + 2 * self.span**2
+                        )
+                        / self.rocket_radius
                     )
-                    / self.rocket_radius
+                    - 2
+                    * (self.rocket_radius**2)
+                    * np.sqrt(self.span**2 - self.rocket_radius**2)
+                    * np.log(2 * self.span)
+                    + 2 * self.span**3
+                    - np.pi * self.rocket_radius * self.span**2
+                    - 2 * (self.rocket_radius**2) * self.span
+                    + np.pi * self.rocket_radius**3
                 )
-                - 2
-                * (self.rocket_radius**2)
-                * np.sqrt(self.span**2 - self.rocket_radius**2)
-                * np.log(2 * self.span)
-                + 2 * self.span**3
-                - np.pi * self.rocket_radius * self.span**2
-                - 2 * (self.rocket_radius**2) * self.span
-                + np.pi * self.rocket_radius**3
+            ) / (
+                2
+                * (self.span**2)
+                * (self.span / 3 + np.pi * self.rocket_radius / 4)
+                * (self.span**2 - self.rocket_radius**2)
             )
-        ) / (
-            2
-            * (self.span**2)
-            * (self.span / 3 + np.pi * self.rocket_radius / 4)
-            * (self.span**2 - self.rocket_radius**2)
-        )
+        elif self.span < self.rocket_radius:
+            roll_damping_interference_factor = 1 - (
+                self.rocket_radius**2
+                * (
+                    2 * self.span**3
+                    - np.pi * self.span**2 * self.rocket_radius
+                    - 2 * self.span * self.rocket_radius**2
+                    + np.pi * self.rocket_radius**3
+                    + 2
+                    * self.rocket_radius**2
+                    * np.sqrt(-self.span**2 + self.rocket_radius**2)
+                    * np.arctan(
+                        (self.span)
+                        / (np.sqrt(-self.span**2 + self.rocket_radius**2))
+                    )
+                    - np.pi
+                    * self.rocket_radius**2
+                    * np.sqrt(-self.span**2 + self.rocket_radius**2)
+                )
+            ) / (
+                2
+                * self.span
+                * (-self.span**2 + self.rocket_radius**2)
+                * (self.span**2 / 3 + np.pi * self.span * self.rocket_radius / 4)
+            )
+        elif self.span == self.rocket_radius:
+            roll_damping_interference_factor = (28-3*np.pi)/(4+3*np.pi)
+
         roll_forcing_interference_factor = (1 / np.pi**2) * (
             (np.pi**2 / 4) * ((tau + 1) ** 2 / tau**2)
             + ((np.pi * (tau**2 + 1) ** 2) / (tau**2 * (tau - 1) ** 2))


### PR DESCRIPTION
## Pull request type

- [x] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

  - [x] Tests for the changes have been added
  - [x] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?

An `EllipticalFins` object could be defined if it had the span smaller than the rocket radius, as stated in Issue #390. This was due to the expression used to evaluate the `roll_damping_interference_factor` that wasn't defined at that domain.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

With a whole bunch of calculus, I got the correct expressions for when the span is bigger to the rocket radius and for when the span is equal to the radius. 

The new expressions have been added to the documentation and added to the code accordingly

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No