### PR TITLE
FIX: optional imports for EnvironmentAnalysis prevent default install.

### DIFF
--- a/rocketpy/EnvironmentAnalysis.py
+++ b/rocketpy/EnvironmentAnalysis.py
@@ -18,18 +18,6 @@ import pytz
 from rocketpy.Environment import Environment
 from rocketpy.Function import Function
 from rocketpy.units import convert_units
-
-try:
-    import ipywidgets as widgets
-    import jsonpickle
-    from timezonefinder import TimezoneFinder
-    from windrose import WindroseAxes
-except ImportError as error:
-    raise ImportError(
-        f"The following error was encountered while importing dependencies: '{error}'. "
-        "Please note that the EnvironmentAnalysis requires additional dependencies, "
-        "which can be installed by running 'pip install rocketpy[env_analysis]'."
-    )
 from .plots.environment_analysis_plots import _EnvironmentAnalysisPlots
 from .prints.environment_analysis_prints import _EnvironmentAnalysisPrints
 from .tools import (
@@ -180,7 +168,19 @@ class EnvironmentAnalysis:
         -------
         None
         """
-
+        # Import optional modules
+        try:
+            import ipywidgets as widgets
+            import jsonpickle
+            from timezonefinder import TimezoneFinder
+            from windrose import WindroseAxes
+        except ImportError as error:
+            raise ImportError(
+                "The following error was encountered while importing dependencies: "
+                f"{error}. Please note that the EnvironmentAnalysis requires additional "
+                "dependencies, which can be installed by running 'pip install "
+                "rocketpy[env_analysis]'."
+            )
         # Save inputs
         self.start_date = start_date
         self.end_date = end_date


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

Please check the type of change your PR introduces:

- [X] Code base additions (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, renaming, tests)
- [ ] ReadMe, Docs and GitHub maintenance
- [ ] Other (please describe):

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [ ] Tests for the changes have been added
  - [ ] Docs have been reviewed and added / updated if needed
  - [X] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [X] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The default `rocketpy` install through `pip` does not install the optional dependencies as intended. However, importing the package loaded the `EnvironmentAnalysis` module that required them, raising an error.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The imports of the optional modules are made lazily, i.e. on instantiation of an `EnvironmentAnalysis` object. Then, the expected install behavior is assured.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The way the imports were done goes against PEP8 convention of only handling imports in top level statements. However, the implemented way is simpler for just these few dependencies. In the long term, if more complex install conditions are needed, an file to process this requirements (as in `pandas` repository) may be considered.