### PR TITLE
ENH: airfoil outputs (resolve #144)

### DIFF
--- a/rocketpy/AeroSurface.py
+++ b/rocketpy/AeroSurface.py
@@ -566,24 +566,24 @@ class Fins(AeroSurface):
         """
         if not self.airfoil:
             # Defines clalpha2D as 2*pi for planar fins
-            clalpha2D = Function(lambda mach: 2 * np.pi / self.__beta(mach))
+            clalpha2D_incompressible = 2 * np.pi
         else:
-            # Defines clalpha2D as the derivative of the
-            # lift coefficient curve for a specific airfoil
+            # Defines clalpha2D as the derivative of the lift coefficient curve
+            # for the specific airfoil
             self.airfoil_cl = Function(
                 self.airfoil[0],
                 interpolation="linear",
             )
 
             # Differentiating at alpha = 0 to get cl_alpha
-            clalpha2D = self.airfoil_cl.differentiate(x=1e-3, dx=1e-3)
+            clalpha2D_incompressible = self.airfoil_cl.differentiate(x=1e-3, dx=1e-3)
 
             # Convert to radians if needed
             if self.airfoil[1] == "degrees":
-                clalpha2D *= 180 / np.pi
+                clalpha2D_incompressible *= 180 / np.pi
 
-            # Correcting for compressible flow (apply Prandtl-Glauert correction)
-            clalpha2D = Function(lambda mach: clalpha2D / self.__beta(mach))
+        # Correcting for compressible flow (apply Prandtl-Glauert correction)
+        clalpha2D = Function(lambda mach: clalpha2D_incompressible / self.__beta(mach))
 
         # Diederich's Planform Correlation Parameter
         FD = 2 * np.pi * self.AR / (clalpha2D * np.cos(self.gamma_c))

--- a/rocketpy/AeroSurface.py
+++ b/rocketpy/AeroSurface.py
@@ -576,14 +576,14 @@ class Fins(AeroSurface):
             )
 
             # Differentiating at x = 0 to get cl_alpha
-            clalpha2D_mach0 = self.airfoil_cl.differentiate(x=1e-3, dx=1e-3)
+            clalpha2D_alpha0 = self.airfoil_cl.differentiate(x=1e-3, dx=1e-3)
 
             # Convert to radians if needed
             if self.airfoil[1] == "degrees":
-                clalpha2D_mach0 *= 180 / np.pi
+                clalpha2D_alpha0 *= 180 / np.pi
 
             # Correcting for compressible flow
-            clalpha2D = Function(lambda mach: clalpha2D_mach0 / self.__beta(mach))
+            clalpha2D = Function(lambda mach: clalpha2D_alpha0 / self.__beta(mach))
 
         # Diederich's Planform Correlation Parameter
         FD = 2 * np.pi * self.AR / (clalpha2D * np.cos(self.gamma_c))

--- a/rocketpy/AeroSurface.py
+++ b/rocketpy/AeroSurface.py
@@ -575,15 +575,15 @@ class Fins(AeroSurface):
                 interpolation="linear",
             )
 
-            # Differentiating at x = 0 to get cl_alpha
-            clalpha2D_alpha0 = self.airfoil_cl.differentiate(x=1e-3, dx=1e-3)
+            # Differentiating at alpha = 0 to get cl_alpha
+            clalpha2D = self.airfoil_cl.differentiate(x=1e-3, dx=1e-3)
 
             # Convert to radians if needed
             if self.airfoil[1] == "degrees":
-                clalpha2D_alpha0 *= 180 / np.pi
+                clalpha2D *= 180 / np.pi
 
-            # Correcting for compressible flow
-            clalpha2D = Function(lambda mach: clalpha2D_alpha0 / self.__beta(mach))
+            # Correcting for compressible flow (apply Prandtl-Glauert correction)
+            clalpha2D = Function(lambda mach: clalpha2D / self.__beta(mach))
 
         # Diederich's Planform Correlation Parameter
         FD = 2 * np.pi * self.AR / (clalpha2D * np.cos(self.gamma_c))

--- a/rocketpy/plots/aero_surface_plots.py
+++ b/rocketpy/plots/aero_surface_plots.py
@@ -111,8 +111,9 @@ class _FinPlots(_AeroSurfacePlots):
         None
         """
 
-        if self.aero_surface.airfoil:  # TODO: see issue #144
-            self.aero_surface.airfoil_cl.plot1D()
+        if self.aero_surface.airfoil:
+            print("Airfoil lift curve:")
+            self.aero_surface.airfoil_cl.plot1D(force_data=True)
         return None
 
     def roll(self):
@@ -122,7 +123,8 @@ class _FinPlots(_AeroSurfacePlots):
         -------
         None
         """
-        # lacks a title in the plots
+        print("Roll parameters:")
+        # TODO: lacks a title in the plots
         self.aero_surface.roll_parameters[0]()
         self.aero_surface.roll_parameters[1]()
         return None
@@ -138,6 +140,7 @@ class _FinPlots(_AeroSurfacePlots):
         -------
         None
         """
+        print("Lift coefficient:")
         self.aero_surface.cl()
         self.aero_surface.clalpha_single_fin()
         self.aero_surface.clalpha_multiple_fins()

--- a/rocketpy/prints/aero_surface_prints.py
+++ b/rocketpy/prints/aero_surface_prints.py
@@ -142,7 +142,12 @@ class _FinsPrints(_AeroSurfacePrints):
         if self.aero_surface.airfoil:
             print(f"Airfoil information:")
             print(f"--------------------")
-            print(f"Hey, this will be implemented later!\n")  # TODO: issue #144
+            print(
+                f"Number of points defining the lift curve: {len(self.aero_surface.airfoil_cl.x_array)}"
+            )
+            print(
+                f"Lift coefficient derivative at Mach 0 and AoA 0: {self.aero_surface.clalpha(0):.5f} 1/rad\n"
+            )
         return None
 
     def roll(self):
@@ -166,7 +171,7 @@ class _FinsPrints(_AeroSurfacePrints):
             f"Damping interference factor: {self.aero_surface.roll_damping_interference_factor:.3f} rad"
         )
         print(
-            "Forcing interference factor: {self.aero_surface.rollForcingInterferenceFactor:.3f} rad\n"
+            f"Forcing interference factor: {self.aero_surface.roll_forcing_interference_factor:.3f} rad\n"
         )
         return None
 


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base additions (for bug fixes / features):

  - [ ] Tests for the changes have been added
  - [ ] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
You give an airfoil curve as input, but RocketPy do not let you to check if the curve is correct.

## What is the new behavior?
A few more plots or prints were added to improve the visualization of airfoil data when it is used.
This closes #144 

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] No

## Other information
Easy to review.