### PR TITLE
TST: env analysis tests on slow option opens matplotlib (solve #380) 

### DIFF
--- a/tests/test_environment_analysis.py
+++ b/tests/test_environment_analysis.py
@@ -160,7 +160,8 @@ def test_animation_plots(mock_show, env_analysis):
 
 
 @pytest.mark.slow
-def test_exports(env_analysis):
+@patch("matplotlib.pyplot.show")
+def test_exports(mock_show, env_analysis):
     """Check the export methods of the EnvironmentAnalysis class. It
     only checks if the method runs without errors. It does not check if the
     files are correct, as this would require a lot of work and would be


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Other (please describe): fixing bugs in the tests

## Pull request checklist

Please check if your PR fulfills the following requirements, depending on the type of PR:

- Code base maintenance (refactoring, formatting, renaming):

  - [ ] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
You get 60 matplotlib windows when running "pytest --runslow"

## What is the new behavior?
Nice catch by @phmbressan , the code was missing one patching decorator.

## Does this introduce a breaking change?
- [x] Absolutely not

## Other information
The largest PR ever 😁