### PR TITLE
BUG: absolute value of the rail button forces

### DIFF
--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -2623,22 +2623,22 @@ class Flight:
     @property
     def max_rail_button1_normal_force(self):
         """Maximum upper rail button normal force, in Newtons."""
-        return np.abs(self.rail_button1_normal_force).max()
+        return np.abs(self.rail_button1_normal_force.y_array).max()
 
     @property
     def max_rail_button1_shear_force(self):
         """Maximum upper rail button shear force, in Newtons."""
-        return np.abs(self.rail_button1_shear_force).max()
+        return np.abs(self.rail_button1_shear_force.y_array).max()
 
     @property
     def max_rail_button2_normal_force(self):
         """Maximum lower rail button normal force, in Newtons."""
-        return np.abs(self.rail_button2_normal_force).max()
+        return np.abs(self.rail_button2_normal_force.y_array).max()
 
     @property
     def max_rail_button2_shear_force(self):
         """Maximum lower rail button shear force, in Newtons."""
-        return np.abs(self.rail_button2_shear_force).max()
+        return np.abs(self.rail_button2_shear_force.y_array).max()
 
     @funcify_method(
         "Time (s)", "Horizontal Distance to Launch Point (m)", "spline", "constant"

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -2623,22 +2623,22 @@ class Flight:
     @property
     def max_rail_button1_normal_force(self):
         """Maximum upper rail button normal force, in Newtons."""
-        return self.rail_button1_normal_force.max
+        return self.rail_button1_normal_force.max_absolute
 
     @property
     def max_rail_button1_shear_force(self):
         """Maximum upper rail button shear force, in Newtons."""
-        return self.rail_button1_shear_force.max
+        return self.rail_button1_shear_force.max_absolute
 
     @property
     def max_rail_button2_normal_force(self):
         """Maximum lower rail button normal force, in Newtons."""
-        return self.rail_button2_normal_force.max
+        return self.rail_button2_normal_force.max_absolute
 
     @property
     def max_rail_button2_shear_force(self):
         """Maximum lower rail button shear force, in Newtons."""
-        return self.rail_button2_shear_force.max
+        return self.rail_button2_shear_force.max_absolute
 
     @funcify_method(
         "Time (s)", "Horizontal Distance to Launch Point (m)", "spline", "constant"

--- a/rocketpy/Flight.py
+++ b/rocketpy/Flight.py
@@ -2623,22 +2623,22 @@ class Flight:
     @property
     def max_rail_button1_normal_force(self):
         """Maximum upper rail button normal force, in Newtons."""
-        return self.rail_button1_normal_force.max_absolute
+        return np.abs(self.rail_button1_normal_force).max()
 
     @property
     def max_rail_button1_shear_force(self):
         """Maximum upper rail button shear force, in Newtons."""
-        return self.rail_button1_shear_force.max_absolute
+        return np.abs(self.rail_button1_shear_force).max()
 
     @property
     def max_rail_button2_normal_force(self):
         """Maximum lower rail button normal force, in Newtons."""
-        return self.rail_button2_normal_force.max_absolute
+        return np.abs(self.rail_button2_normal_force).max()
 
     @property
     def max_rail_button2_shear_force(self):
         """Maximum lower rail button shear force, in Newtons."""
-        return self.rail_button2_shear_force.max_absolute
+        return np.abs(self.rail_button2_shear_force).max()
 
     @funcify_method(
         "Time (s)", "Horizontal Distance to Launch Point (m)", "spline", "constant"

--- a/rocketpy/Function.py
+++ b/rocketpy/Function.py
@@ -264,6 +264,28 @@ class Function:
         """
         return self.y_array.max()
 
+    @cached_property
+    def min_absolute(self):
+        """Get the minimum absolute value of the Function y_array.
+
+        Returns
+        -------
+        minimum: float.
+            The minimum absolute value of the Function y_array.
+        """        
+        return np.abs(self.y_array).min()
+
+    @cached_property
+    def max_absolute(self):
+        """Get the maximum absolute value of the Function y_array.
+
+        Returns
+        -------
+        maximum: float.
+            The maximum absolute value of the Function y_array.
+        """        
+        return np.abs(self.y_array).max()
+
     def set_interpolation(self, method="spline"):
         """Set interpolation method and process data is method requires.
 

--- a/rocketpy/Function.py
+++ b/rocketpy/Function.py
@@ -264,28 +264,6 @@ class Function:
         """
         return self.y_array.max()
 
-    @cached_property
-    def min_absolute(self):
-        """Get the minimum absolute value of the Function y_array.
-
-        Returns
-        -------
-        minimum: float.
-            The minimum absolute value of the Function y_array.
-        """
-        return np.abs(self.y_array).min()
-
-    @cached_property
-    def max_absolute(self):
-        """Get the maximum absolute value of the Function y_array.
-
-        Returns
-        -------
-        maximum: float.
-            The maximum absolute value of the Function y_array.
-        """
-        return np.abs(self.y_array).max()
-
     def set_interpolation(self, method="spline"):
         """Set interpolation method and process data is method requires.
 

--- a/rocketpy/Function.py
+++ b/rocketpy/Function.py
@@ -272,7 +272,7 @@ class Function:
         -------
         minimum: float.
             The minimum absolute value of the Function y_array.
-        """        
+        """
         return np.abs(self.y_array).min()
 
     @cached_property
@@ -283,7 +283,7 @@ class Function:
         -------
         maximum: float.
             The maximum absolute value of the Function y_array.
-        """        
+        """
         return np.abs(self.y_array).max()
 
     def set_interpolation(self, method="spline"):


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Code base additions (bugfix, features)

## Pull request checklist

- Code base additions (for bug fixes / features):

  - [ ] Tests for the changes have been added
  - [ ] Docs have been reviewed and added / updated if needed
  - [x] Lint (`black rocketpy`) has passed locally and any fixes were made
  - [x] All tests (`pytest --runslow`) have passed locally

## What is the current behavior?
The forces at the rail buttons can be sctricly negative, therefore the arguments that compute the max forces in the rail buttons will return exactly the opposite of what we usually want: the least intense load.

## What is the new behavior?
The Function class now can calculate the maximum (and min) absolute value of a function.

## Does this introduce a breaking change?
- [x] No

## Other information

- I will implement tests in another PR.
- If you think that we should improve documentation (of Flight or Function), please feel free to suggest it.