### PR TITLE
FIX: Motors UnitTesting Warnings

### DIFF
--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -2229,7 +2229,7 @@ class Function:
             ans = np.trapz(y_integration_data, x_integration_data)
         else:
             # Integrate numerically
-            ans, _ = integrate.quad(self, a, b, epsabs=0.001, limit=10000)
+            ans, _ = integrate.quad(self, a, b, epsabs=1e-4, epsrel=1e-3, limit=1000)
         return integration_sign * ans
 
     def differentiate(self, x, dx=1e-6, order=1):

--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -494,8 +494,8 @@ class SolidMotor(Motor):
             factor = volume_diff / (2 * np.pi * (rO**2 - rI**2 + rI * h) ** 2)
             drI_dot_drI = factor * (h - 2 * rI)
             drI_dot_dh = factor * rI
-            dh_dot_drI = -2 * factor * (h - 2 * rI)
-            dh_dot_dh = -2 * factor * rI
+            dh_dot_drI = -2 * drI_dot_drI
+            dh_dot_dh = -2 * drI_dot_dh
 
             return [[drI_dot_drI, drI_dot_dh], [dh_dot_drI, dh_dot_dh]]
 

--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -479,10 +479,10 @@ class SolidMotor(Motor):
             # Compute state vector derivative
             rI, h = y
             burn_area = 2 * np.pi * (rO**2 - rI**2 + rI * h)
-            rIDot = -volume_diff / burn_area
-            hDot = -2 * rIDot
+            rI_dot = -volume_diff / burn_area
+            h_dot = -2 * rI_dot
 
-            return [rIDot, hDot]
+            return [rI_dot, h_dot]
 
         # Define jacobian of the system of differential equations
         def geometry_jacobian(t, y):

--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -469,17 +469,19 @@ class SolidMotor(Motor):
 
         density = self.grain_density
         rO = self.grain_outer_radius
+        n_grain = self.grain_number
 
         # Define system of differential equations
         def geometry_dot(t, y):
-            grain_mass_dot = self.mass_flow_rate(t) / self.grain_number
+            # Store physical parameters
+            volume_diff = self.mass_flow_rate(t) / (n_grain * density)
+
+            # Compute state vector derivative
             rI, h = y
-            rIDot = (
-                -0.5 * grain_mass_dot / (density * np.pi * (rO**2 - rI**2 + rI * h))
-            )
-            hDot = (
-                1.0 * grain_mass_dot / (density * np.pi * (rO**2 - rI**2 + rI * h))
-            )
+            burn_area = 2 * np.pi * (rO**2 - rI**2 + rI * h)
+            rIDot = -volume_diff / burn_area
+            hDot = -2 * rIDot
+
             return [rIDot, hDot]
 
         def terminate_burn(t, y):

--- a/tests/acceptance/test_ndrt_2020_rocket.py
+++ b/tests/acceptance/test_ndrt_2020_rocket.py
@@ -27,7 +27,7 @@ def test_ndrt_2020_rocket_data_asserts_acceptance():
         "rocket_mass": (23.321 - 2.475 - 1, 0.010),
         # propulsion details
         "impulse": (4895.050, 0.033 * 4895.050),
-        "burn_time": (3.51, 0.1),
+        "burn_time": (3.45, 0.1),
         "nozzle_radius": (49.5 / 2000, 0.001),
         "throat_radius": (21.5 / 2000, 0.001),
         "grain_separation": (3 / 1000, 0.001),

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -585,6 +585,7 @@ def test_liquid_motor_flight(mock_show, calisto_liquid_modded):
         rail_length=5,
         inclination=85,
         heading=0,
+        max_time_step=0.25,
     )
 
     assert test_flight.all_info() == None
@@ -609,6 +610,7 @@ def test_hybrid_motor_flight(mock_show, calisto_hybrid_modded):
         rail_length=5,
         inclination=85,
         heading=0,
+        max_time_step=0.25,
     )
 
     assert test_flight.all_info() == None


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

- [X] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest --runslow`) have passed locally

## Current behavior
<!-- Describe current behavior or link to an issue. -->

The conventional `pytest` run raised some warnings regarding wrong `burn_time` input and integration precision not being achieved.

Furthermore, the way the `SolidMotor` grain regression ODE was written could be improved a bit both in speed and readability with better local variable naming/choice.

## New behavior
<!-- Describe changes introduced by this PR. -->

The `pytest` warnings were solved and, locally, they do not show up anymore. In order to improve the `SolidMotor` grain regression ODE, the local variable scheme was changed and the simulation jacobian was added following `scipy.solve_ivp` recomendation for the `LSODA` solver.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No
