### PR TITLE
MNT: clearly specify the rocket mass in utilities

### DIFF
--- a/rocketpy/utilities.py
+++ b/rocketpy/utilities.py
@@ -572,7 +572,7 @@ def apogee_by_mass(flight, min_mass, max_mass, points=10, plot=True):
     source = np.array(list(zip(x, y)), dtype=np.float64)
 
     retfunc = Function(
-        source, inputs="Rocket Dry Mass (kg)", outputs="Estimated Apogee AGL (m)"
+        source, inputs="Rocket Mass without motor (kg)", outputs="Apogee AGL (m)"
     )
     if plot:
         retfunc.plot(min_mass, max_mass, points)
@@ -636,7 +636,7 @@ def liftoff_speed_by_mass(flight, min_mass, max_mass, points=10, plot=True):
     source = np.array(list(zip(x, y)), dtype=np.float64)
 
     retfunc = Function(
-        source, inputs="Rocket Dry Mass (kg)", outputs="Liftoff Speed (m/s)"
+        source, inputs="Rocket Mass without motor (kg)", outputs="Out of Rail Speed (m/s)"
     )
     if plot:
         retfunc.plot(min_mass, max_mass, points)

--- a/rocketpy/utilities.py
+++ b/rocketpy/utilities.py
@@ -636,7 +636,9 @@ def liftoff_speed_by_mass(flight, min_mass, max_mass, points=10, plot=True):
     source = np.array(list(zip(x, y)), dtype=np.float64)
 
     retfunc = Function(
-        source, inputs="Rocket Mass without motor (kg)", outputs="Out of Rail Speed (m/s)"
+        source,
+        inputs="Rocket Mass without motor (kg)",
+        outputs="Out of Rail Speed (m/s)",
     )
     if plot:
         retfunc.plot(min_mass, max_mass, points)


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [ ] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest --runslow`) have passed locally

## Current behavior

The apogee by mass function prints "Rocket Dry Mass (kg)" when it is stilll modifying the Rocket Mass (without the motor). 

I think this is not exactly a bug, but the current behavior is giving false ideas to the final user.

## New behavior
2 code lines solving the problem

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Additional information

Bug reported via private message today
