### PR TITLE
BUG: Maintaing Extrapolation when Adding Discrete Functions with Constants

### DIFF
--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -1716,8 +1716,9 @@ class Function:
                 outputs = self.__outputs__[0] + " + " + other.__outputs__[0]
                 outputs = "(" + outputs + ")"
                 interpolation = self.__interpolation__
+                extrapolation = self.__extrapolation__
                 # Create new Function object
-                return Function(source, inputs, outputs, interpolation)
+                return Function(source, inputs, outputs, interpolation, extrapolation)
             else:
                 return Function(lambda x: (self.get_value(x) + other(x)))
         # If other is Float except...
@@ -1845,8 +1846,9 @@ class Function:
                 outputs = self.__outputs__[0] + "*" + other.__outputs__[0]
                 outputs = "(" + outputs + ")"
                 interpolation = self.__interpolation__
+                extrapolation = self.__extrapolation__
                 # Create new Function object
-                return Function(source, inputs, outputs, interpolation)
+                return Function(source, inputs, outputs, interpolation, extrapolation)
             else:
                 return Function(lambda x: (self.get_value(x) * other(x)))
         # If other is Float except...
@@ -1863,8 +1865,9 @@ class Function:
                     outputs = self.__outputs__[0] + "*" + str(other)
                     outputs = "(" + outputs + ")"
                     interpolation = self.__interpolation__
+                    extrapolation = self.__extrapolation__
                     # Create new Function object
-                    return Function(source, inputs, outputs, interpolation)
+                    return Function(source, inputs, outputs, interpolation, extrapolation)
                 else:
                     return Function(lambda x: (self.get_value(x) * other))
             # Or if it is just a callable
@@ -1930,8 +1933,9 @@ class Function:
                 outputs = self.__outputs__[0] + "/" + other.__outputs__[0]
                 outputs = "(" + outputs + ")"
                 interpolation = self.__interpolation__
+                extrapolation = self.__extrapolation__
                 # Create new Function object
-                return Function(source, inputs, outputs, interpolation)
+                return Function(source, inputs, outputs, interpolation, extrapolation)
             else:
                 return Function(lambda x: (self.get_value_opt(x) / other(x)))
         # If other is Float except...
@@ -1948,8 +1952,9 @@ class Function:
                     outputs = self.__outputs__[0] + "/" + str(other)
                     outputs = "(" + outputs + ")"
                     interpolation = self.__interpolation__
+                    extrapolation = self.__extrapolation__
                     # Create new Function object
-                    return Function(source, inputs, outputs, interpolation)
+                    return Function(source, inputs, outputs, interpolation, extrapolation)
                 else:
                     return Function(lambda x: (self.get_value_opt(x) / other))
             # Or if it is just a callable
@@ -1983,8 +1988,9 @@ class Function:
                 outputs = str(other) + "/" + self.__outputs__[0]
                 outputs = "(" + outputs + ")"
                 interpolation = self.__interpolation__
+                extrapolation = self.__extrapolation__
                 # Create new Function object
-                return Function(source, inputs, outputs, interpolation)
+                return Function(source, inputs, outputs, interpolation, extrapolation)
             else:
                 return Function(lambda x: (other / self.get_value_opt(x)))
         # Or if it is just a callable
@@ -2032,8 +2038,9 @@ class Function:
                 outputs = self.__outputs__[0] + "**" + other.__outputs__[0]
                 outputs = "(" + outputs + ")"
                 interpolation = self.__interpolation__
+                extrapolation = self.__extrapolation__
                 # Create new Function object
-                return Function(source, inputs, outputs, interpolation)
+                return Function(source, inputs, outputs, interpolation, extrapolation)
             else:
                 return Function(lambda x: (self.get_value_opt(x) ** other(x)))
         # If other is Float except...
@@ -2050,8 +2057,9 @@ class Function:
                     outputs = self.__outputs__[0] + "**" + str(other)
                     outputs = "(" + outputs + ")"
                     interpolation = self.__interpolation__
+                    extrapolation = self.__extrapolation__
                     # Create new Function object
-                    return Function(source, inputs, outputs, interpolation)
+                    return Function(source, inputs, outputs, interpolation, extrapolation)
                 else:
                     return Function(lambda x: (self.get_value(x) ** other))
             # Or if it is just a callable
@@ -2085,8 +2093,9 @@ class Function:
                 outputs = str(other) + "**" + self.__outputs__[0]
                 outputs = "(" + outputs + ")"
                 interpolation = self.__interpolation__
+                extrapolation = self.__extrapolation__
                 # Create new Function object
-                return Function(source, inputs, outputs, interpolation)
+                return Function(source, inputs, outputs, interpolation, extrapolation)
             else:
                 return Function(lambda x: (other ** self.get_value(x)))
         # Or if it is just a callable
@@ -2326,7 +2335,7 @@ class Function:
             outputs = f"d({self.__outputs__[0]})/d({inputs[0]})"
 
         # Create new Function object
-        return Function(source, inputs, outputs, self.__interpolation__)
+        return Function(source, inputs, outputs, self.__interpolation__, self.__extrapolation__)
 
     def integral_function(self, lower=None, upper=None, datapoints=100):
         """Returns a Function object representing the integral of the Function
@@ -2494,6 +2503,7 @@ class Function:
             inputs=self.__outputs__,
             outputs=self.__inputs__,
             interpolation=self.__interpolation__,
+            extrapolation=self.__extrapolation__,
         )
 
     def find_input(self, val, start, tol=1e-4):

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -1734,8 +1734,11 @@ class Function:
                     outputs = self.__outputs__[0] + " + " + str(other)
                     outputs = "(" + outputs + ")"
                     interpolation = self.__interpolation__
+                    extrapolation = self.__extrapolation__
                     # Create new Function object
-                    return Function(source, inputs, outputs, interpolation)
+                    return Function(
+                        source, inputs, outputs, interpolation, extrapolation
+                    )
                 else:
                     return Function(lambda x: (self.get_value(x) + other))
             # Or if it is just a callable

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -1867,7 +1867,9 @@ class Function:
                     interpolation = self.__interpolation__
                     extrapolation = self.__extrapolation__
                     # Create new Function object
-                    return Function(source, inputs, outputs, interpolation, extrapolation)
+                    return Function(
+                        source, inputs, outputs, interpolation, extrapolation
+                    )
                 else:
                     return Function(lambda x: (self.get_value(x) * other))
             # Or if it is just a callable
@@ -1954,7 +1956,9 @@ class Function:
                     interpolation = self.__interpolation__
                     extrapolation = self.__extrapolation__
                     # Create new Function object
-                    return Function(source, inputs, outputs, interpolation, extrapolation)
+                    return Function(
+                        source, inputs, outputs, interpolation, extrapolation
+                    )
                 else:
                     return Function(lambda x: (self.get_value_opt(x) / other))
             # Or if it is just a callable
@@ -2059,7 +2063,9 @@ class Function:
                     interpolation = self.__interpolation__
                     extrapolation = self.__extrapolation__
                     # Create new Function object
-                    return Function(source, inputs, outputs, interpolation, extrapolation)
+                    return Function(
+                        source, inputs, outputs, interpolation, extrapolation
+                    )
                 else:
                     return Function(lambda x: (self.get_value(x) ** other))
             # Or if it is just a callable
@@ -2335,7 +2341,9 @@ class Function:
             outputs = f"d({self.__outputs__[0]})/d({inputs[0]})"
 
         # Create new Function object
-        return Function(source, inputs, outputs, self.__interpolation__, self.__extrapolation__)
+        return Function(
+            source, inputs, outputs, self.__interpolation__, self.__extrapolation__
+        )
 
     def integral_function(self, lower=None, upper=None, datapoints=100):
         """Returns a Function object representing the integral of the Function


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally

## Current behavior & New behavior
<!-- Describe current behavior or link to an issue. -->

When adding a constant value to a discrete Function, the extrapolation method is not maintained. This PR fixes this issue