### PR TITLE
BUG: flight.prints.max_values() fails when launching an EmptyMotor

### DIFF
--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -2137,6 +2137,9 @@ class Flight:
         burn_out_time_index = find_closest(
             self.acceleration.source[:, 0], self.rocket.motor.burn_out_time
         )
+        if burn_out_time_index == 0:
+            return 0 # the burn out time is before the first time step
+
         max_acceleration_time_index = np.argmax(
             self.acceleration[:burn_out_time_index, 1]
         )

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -2138,7 +2138,7 @@ class Flight:
             self.acceleration.source[:, 0], self.rocket.motor.burn_out_time
         )
         if burn_out_time_index == 0:
-            return 0 # the burn out time is before the first time step
+            return 0  # the burn out time is before the first time step
 
         max_acceleration_time_index = np.argmax(
             self.acceleration[:burn_out_time_index, 1]

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -141,6 +141,32 @@ def test_initial_solution(mock_show, example_env, calisto_robust):
     assert test_flight.all_info() == None
 
 
+@patch("matplotlib.pyplot.show")
+def test_empty_motor_flight(mock_show, example_env, calisto_motorless):
+    flight = Flight(
+        rocket=calisto_motorless,
+        environment=example_env,
+        rail_length=5,
+        initial_solution=[  # a random flight starting at apogee
+            22.945995194368354,
+            277.80976806186936,
+            353.29457980509113,
+            3856.1112773441596,
+            12.737953434495966,
+            15.524649322067267,
+            -0.00011874766384947776,
+            -0.06086838708814366,
+            0.019695167217632138,
+            -0.35099420532705555,
+            -0.9338841410225396,
+            0.25418555574446716,
+            0.03632002739509155,
+            2.0747266017020563,
+        ],
+    )
+    assert flight.all_info() == None
+
+
 @pytest.mark.parametrize("wind_u, wind_v", [(0, 10), (0, -10), (10, 0), (-10, 0)])
 @pytest.mark.parametrize(
     "static_margin, max_time",
@@ -537,6 +563,7 @@ def test_rail_length(calisto_robust, example_env, rail_length, out_of_rail_time)
     assert abs(test_flight.z(test_flight.out_of_rail_time) - out_of_rail_time) < 1e-6
 
 
+@pytest.mark.slow
 @patch("matplotlib.pyplot.show")
 def test_time_overshoot(mock_show, calisto_robust, example_env_robust):
     """Test the time_overshoot parameter of the Flight class. This basically


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest --runslow`) have passed locally

## Current behavior
- I'm getting an error when initializing a flight object using a motor that has an burn_out_time lower than the initial time step.
- The error happens when trying to access the max acceleration during the burn time 
- This is particularly common for deployable or multi-stage flight simulations.
- ValueError: attempt to get argmax of an empty sequence

## New behavior
A simple code line solved the problem, and I added a simple test to avoid getting this problem again.

## Breaking change

- [x] No

## Additional information
<!-- Include any relevant details or screenshots. -->

Enter text here...
