### PR TITLE
MNT: adding example docs to the find_closest() function

### DIFF
--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -1,4 +1,5 @@
-import importlib, importlib.metadata
+import importlib
+import importlib.metadata
 import re
 from bisect import bisect_left
 
@@ -266,14 +267,29 @@ def find_closest(ordered_sequence, value):
     -------
     index : int
         The index of the closest value to the given value within the ordered
-        sequence. If the given value is less than the first value in the
+        sequence. If the given value is lower than the first value in the
         sequence, then 0 is returned. If the given value is greater than the
         last value in the sequence, then the index of the last value in the
         sequence is returned.
-    """
-    if len(ordered_sequence) == 1:
-        return 0
 
+    Examples
+    --------
+    >>> from rocketpy.tools import find_closest
+    >>> find_closest([1, 2, 3, 4, 5], 0)
+    0
+    >>> find_closest([1, 2, 3, 4, 5], 1.5)
+    0
+    >>> find_closest([1, 2, 3, 4, 5], 2.0)
+    1
+    >>> find_closest([1, 2, 3, 4, 5], 2.8)
+    2
+    >>> find_closest([1, 2, 3, 4, 5], 4.9)
+    4
+    >>> find_closest([1, 2, 3, 4, 5], 5.5)
+    4
+    >>> find_closest([], 10)
+    0
+    """
     pivot_index = bisect_left(ordered_sequence, value)
     if pivot_index == 0:
         return pivot_index


### PR DESCRIPTION
## Pull request type

- [x] ReadMe, Docs and GitHub updates

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally

## Current behavior
There is this function `tools.find_closest()` that have been used inside the Flight class. I faced it when working in the last BUG fix #438 . It can be better tested and explained with some examples in its docstring.

## New behavior
The docstring of the function was modified. 
This PR is complementary to the last one, just wanted to put it in here to alleviate last PR. 

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] No

## Additional information
None