### PR TITLE
MNT: fix env plots legends

### DIFF
--- a/rocketpy/plots/environment_plots.py
+++ b/rocketpy/plots/environment_plots.py
@@ -121,14 +121,14 @@ class _EnvironmentPlots:
         ax.plot(
             [self.environment.wind_velocity_x(i) for i in self.grid],
             self.grid,
-            label="Wind U",
+            label="wind u",
         )
         ax.plot(
             [self.environment.wind_velocity_y(i) for i in self.grid],
             self.grid,
-            label="Wind V",
+            label="wind v",
         )
-        # ax.legend(loc="best").set_draggable(True)
+        ax.legend(loc="best")
         ax.set_ylabel("Height Above Sea Level (m)")
         ax.set_xlabel("Wind Speed (m/s)")
         ax.grid(True)
@@ -221,7 +221,6 @@ class _EnvironmentPlots:
         # Create wind u and wind v subplot
         ax3 = plt.subplot(223)
         ax3 = self.__wind_components(ax3)
-        # ax3.legend(loc="best").set_draggable(True)
 
         # Create pressure and temperature subplot
         ax4 = plt.subplot(224)
@@ -255,7 +254,6 @@ class _EnvironmentPlots:
                 self.grid,
                 label=i,
             )
-        # ax5.legend(loc='best').set_draggable(True)
         ax5.set_ylabel("Height Above Sea Level (m)")
         ax5.set_xlabel("Wind Speed (m/s)")
         ax5.set_title("Wind U - Ensemble Members")
@@ -270,7 +268,6 @@ class _EnvironmentPlots:
                 self.grid,
                 label=i,
             )
-        # ax6.legend(loc='best').set_draggable(True)
         ax6.set_ylabel("Height Above Sea Level (m)")
         ax6.set_xlabel("Wind Speed (m/s)")
         ax6.set_title("Wind V - Ensemble Members")
@@ -283,7 +280,6 @@ class _EnvironmentPlots:
             ax7.plot(
                 [self.environment.wind_speed(i) for i in self.grid], self.grid, label=i
             )
-        # ax7.legend(loc='best').set_draggable(True)
         ax7.set_ylabel("Height Above Sea Level (m)")
         ax7.set_xlabel("Wind Speed (m/s)")
         ax7.set_title("Wind Speed Magnitude - Ensemble Members")
@@ -298,7 +294,6 @@ class _EnvironmentPlots:
                 self.grid,
                 label=i,
             )
-        # ax8.legend(loc='best').set_draggable(True)
         ax8.set_ylabel("Height Above Sea Level (m)")
         ax8.set_xlabel("Degrees True (°)")
         ax8.set_title("Wind Direction - Ensemble Members")
@@ -311,7 +306,6 @@ class _EnvironmentPlots:
             ax9.plot(
                 [self.environment.pressure(i) for i in self.grid], self.grid, label=i
             )
-        # ax9.legend(loc='best').set_draggable(True)
         ax9.set_ylabel("Height Above Sea Level (m)")
         ax9.set_xlabel("Pressure (P)")
         ax9.set_title("Pressure - Ensemble Members")
@@ -324,7 +318,6 @@ class _EnvironmentPlots:
             ax10.plot(
                 [self.environment.temperature(i) for i in self.grid], self.grid, label=i
             )
-        # ax10.legend(loc='best').set_draggable(True)
         ax10.set_ylabel("Height Above Sea Level (m)")
         ax10.set_xlabel("Temperature (K)")
         ax10.set_title("Temperature - Ensemble Members")


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)
- [x] Code maintenance (refactoring, formatting, tests)
- [x] ReadMe, Docs and GitHub updates
- [x] Other (please describe):

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally

## Current behavior
the wind_u and wind_v labels are not being used for plotting the wind profile in the Environemnt.all_info() method. This makes it impossible to be read.

## New behavior
Simply adding the legend where it is needed.

## Breaking change

- [x] No

## Additional information
Simple fix based on a recent feedback we got at EuRoC this year.