### PR TITLE
ENH: new Flight.get_solution_at_time() method

### DIFF
--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1934,7 +1934,7 @@ class Flight:
         """Returns time array from solution."""
         return self.solution_array[:, 0]
 
-    def get_solution_at_time(self, t):
+    def get_solution_at_time(self, t, atol=1e-3):
         """Returns the solution state vector at a given time. If the time is
         not found in the solution, the closest time is used and a warning is
         raised.
@@ -1943,6 +1943,10 @@ class Flight:
         ----------
         t : float
             Time in seconds.
+        atol : float, optional
+            Absolute tolerance for time comparison. Default is 1e-3. If the
+            difference between the time and the closest time in the solution
+            is greater than this value, a warning is raised.
 
         Returns
         -------
@@ -1953,7 +1957,7 @@ class Flight:
 
         """
         time_index = find_closest(self.time, t)
-        if abs(self.time[time_index] - t) > 1e-5:
+        if abs(self.time[time_index] - t) > atol:
             warnings.warn(
                 f"Time {t} not found in solution. Closest time is "
                 f"{self.time[time_index]}. Using closest time.",

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1948,7 +1948,7 @@ class Flight:
         -------
         solution : np.array
             Solution state at time t. The array follows the format of the
-            solution array, with the first column being time like this: 
+            solution array, with the first column being time like this:
             [t, x, y, z, vx, vy, vz, e0, e1, e2, e3, omega1, omega2, omega3].
 
         """
@@ -1956,7 +1956,8 @@ class Flight:
         if abs(self.time[time_index] - t) > 1e-5:
             warnings.warn(
                 f"Time {t} not found in solution. Closest time is "
-                f"{self.time[time_index]}. Using closest time.", UserWarning
+                f"{self.time[time_index]}. Using closest time.",
+                UserWarning,
             )
         return self.solution_array[time_index, :]
 

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1934,6 +1934,32 @@ class Flight:
         """Returns time array from solution."""
         return self.solution_array[:, 0]
 
+    def get_solution_at_time(self, t):
+        """Returns the solution state vector at a given time. If the time is
+        not found in the solution, the closest time is used and a warning is
+        raised.
+
+        Parameters
+        ----------
+        t : float
+            Time in seconds.
+
+        Returns
+        -------
+        solution : np.array
+            Solution state at time t. The array follows the format of the
+            solution array, with the first column being time like this: 
+            [t, x, y, z, vx, vy, vz, e0, e1, e2, e3, omega1, omega2, omega3].
+
+        """
+        time_index = find_closest(self.time, t)
+        if abs(self.time[time_index] - t) > 1e-5:
+            warnings.warn(
+                f"Time {t} not found in solution. Closest time is "
+                f"{self.time[time_index]}. Using closest time.", UserWarning
+            )
+        return self.solution_array[time_index, :]
+
     # Process first type of outputs - state vector
     # Transform solution array into Functions
     @funcify_method("Time (s)", "X (m)", "spline", "constant")

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -164,7 +164,7 @@ def test_get_solution_at_time(flight_calisto):
             [
                 48.4313533,
                 0.0,
-                985.755944,
+                985.7665845,
                 -0.00000229951048,
                 0.0,
                 11.2223284,
@@ -178,8 +178,8 @@ def test_get_solution_at_time(flight_calisto):
                 0.0,
             ]
         ),
-        rtol=1e-05,
-        atol=1e-05,
+        rtol=1e-02,
+        atol=5e-03,
     )
 
 

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -141,6 +141,48 @@ def test_initial_solution(mock_show, example_env, calisto_robust):
     assert test_flight.all_info() == None
 
 
+def test_get_solution_at_time(flight_calisto):
+    """Test the get_solution_at_time method of the Flight class. This test
+    simply calls the method at the initial and final time and checks if the
+    returned values are correct.
+
+    Parameters
+    ----------
+    flight_calisto : rocketpy.Flight
+        Flight object to be tested. See the conftest.py file for more info
+        regarding this pytest fixture.
+    """    
+    assert np.allclose(
+        flight_calisto.get_solution_at_time(0),
+        np.array([0, 0, 0, 0, 0, 0, 0, 0.99904822, -0.04361939, 0, 0, 0, 0, 0]),
+        rtol=1e-05,
+        atol=1e-08,
+    )
+    assert np.allclose(
+        flight_calisto.get_solution_at_time(flight_calisto.t_final),
+        np.array(
+            [
+                48.4313533,
+                0.0,
+                985.755944,
+                -0.00000229951048,
+                0.0,
+                11.2223284,
+                -341.028803,
+                0.999048222,
+                -0.0436193874,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+            ]
+        ),
+        rtol=1e-05,
+        atol=1e-05,
+    )
+
+
 @pytest.mark.parametrize("wind_u, wind_v", [(0, 10), (0, -10), (10, 0), (-10, 0)])
 @pytest.mark.parametrize(
     "static_margin, max_time",

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -151,7 +151,7 @@ def test_get_solution_at_time(flight_calisto):
     flight_calisto : rocketpy.Flight
         Flight object to be tested. See the conftest.py file for more info
         regarding this pytest fixture.
-    """    
+    """
     assert np.allclose(
         flight_calisto.get_solution_at_time(0),
         np.array([0, 0, 0, 0, 0, 0, 0, 0.99904822, -0.04361939, 0, 0, 0, 0, 0]),


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally

## Current behavior
If by any chance you want to know the state vector that corresponds to a specific time of the flight, there's no easy way to do so.

## New behavior
There's this new method that returns the numpy array of the solution state at a specific time. If the user choose a time that do not exists in the timesteps, a warning is raised and the code automatically changes to the closest time step.

## Breaking change

- [x] No

## Additional information
- This feature is particularly important for us to work on multi-stage and deployable flights.
- I was not sure if it was better to return the np.array object or a list. I chose array because I thought it could be more useful and faster, but honestly this was arbitrary and I don't think there is a big difference between the two options.
- as I am creating this PR on windows, I wonder if the integrators of the Flight class will give the exact same behavior on linux when I upload this to github actions. Let's see!