### PR TITLE
FIX: cp_position call in rocket.draw to work with mach dependent cp_position

### DIFF
--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -393,7 +393,7 @@ class _RocketPlots:
         ax.scatter(cm, 0, color="black", label="Center of Mass", s=30)
         ax.scatter(cm, 0, facecolors="none", edgecolors="black", s=100)
 
-        cp = self.rocket.cp_position
+        cp = self.rocket.cp_position(0)
         ax.scatter(cp, 0, label="Center Of Pressure", color="red", s=30, zorder=10)
         ax.scatter(cp, 0, facecolors="none", edgecolors="red", s=100, zorder=10)
 


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] *N.A.* Tests for the changes have been added (if needed)
- [x] *N.A.* Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Since the introduction of `Rocket.draw` and the change of `Rocket.cp_position` as a Mach dependent function were done in parallel (both merged with only one day difference, without proper rebasing or merging the develop branch before approval), a specific part of the code introduced in #419 was not up to date with the changes made in #377. 

This made it so a bug was created where `Rocket.draw` failed.

## New behavior

The bug was fixed.

## Breaking change

- [x] No

