### PR TITLE
ENH: Add _MotorPlots Inheritance to Motor Plots Classes

### DIFF
--- a/rocketpy/plots/hybrid_motor_plots.py
+++ b/rocketpy/plots/hybrid_motor_plots.py
@@ -1,4 +1,7 @@
-class _HybridMotorPlots:
+from .motor_plots import _MotorPlots
+
+
+class _HybridMotorPlots(_MotorPlots):
     """Class that holds plot methods for HybridMotor class.
 
     Attributes
@@ -20,94 +23,7 @@ class _HybridMotorPlots:
         -------
         None
         """
-
-        self.hybrid_motor = hybrid_motor
-
-        return None
-
-    def thrust(self, lower_limit=None, upper_limit=None):
-        """Plots thrust of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.thrust.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def total_mass(self, lower_limit=None, upper_limit=None):
-        """Plots total_mass of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.total_mass.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def mass_flow_rate(self, lower_limit=None, upper_limit=None):
-        """Plots mass_flow_rate of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.mass_flow_rate.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def exhaust_velocity(self, lower_limit=None, upper_limit=None):
-        """Plots exhaust_velocity of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.exhaust_velocity.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        super().__init__(hybrid_motor)
 
     def grain_inner_radius(self, lower_limit=None, upper_limit=None):
         """Plots grain_inner_radius of the hybrid_motor as a function of time.
@@ -126,11 +42,7 @@ class _HybridMotorPlots:
         None
         """
 
-        self.hybrid_motor.solid.grain_inner_radius.plot(
-            lower=lower_limit, upper=upper_limit
-        )
-
-        return None
+        self.motor.solid.grain_inner_radius.plot(lower=lower_limit, upper=upper_limit)
 
     def grain_height(self, lower_limit=None, upper_limit=None):
         """Plots grain_height of the hybrid_motor as a function of time.
@@ -149,9 +61,7 @@ class _HybridMotorPlots:
         None
         """
 
-        self.hybrid_motor.solid.grain_height.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        self.motor.solid.grain_height.plot(lower=lower_limit, upper=upper_limit)
 
     def burn_rate(self, lower_limit=None, upper_limit=None):
         """Plots burn_rate of the hybrid_motor as a function of time.
@@ -170,9 +80,7 @@ class _HybridMotorPlots:
         None
         """
 
-        self.hybrid_motor.solid.burn_rate.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        self.motor.solid.burn_rate.plot(lower=lower_limit, upper=upper_limit)
 
     def burn_area(self, lower_limit=None, upper_limit=None):
         """Plots burn_area of the hybrid_motor as a function of time.
@@ -191,9 +99,7 @@ class _HybridMotorPlots:
         None
         """
 
-        self.hybrid_motor.solid.burn_area.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        self.motor.solid.burn_area.plot(lower=lower_limit, upper=upper_limit)
 
     def Kn(self, lower_limit=None, upper_limit=None):
         """Plots Kn of the hybrid_motor as a function of time.
@@ -212,156 +118,7 @@ class _HybridMotorPlots:
         None
         """
 
-        self.hybrid_motor.solid.Kn.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def center_of_mass(self, lower_limit=None, upper_limit=None):
-        """Plots center_of_mass of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.center_of_mass.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_11(self, lower_limit=None, upper_limit=None):
-        """Plots I_11 of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.I_11.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_22(self, lower_limit=None, upper_limit=None):
-        """Plots I_22 of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.I_22.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_33(self, lower_limit=None, upper_limit=None):
-        """Plots I_33 of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.I_33.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_12(self, lower_limit=None, upper_limit=None):
-        """Plots I_12 of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.I_12.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_13(self, lower_limit=None, upper_limit=None):
-        """Plots I_13 of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.I_13.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_23(self, lower_limit=None, upper_limit=None):
-        """Plots I_23 of the hybrid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is None, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is None, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.hybrid_motor.I_23.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        self.motor.solid.Kn.plot(lower=lower_limit, upper=upper_limit)
 
     def all(self):
         """Prints out all graphs available about the HybridMotor. It simply calls
@@ -372,23 +129,19 @@ class _HybridMotorPlots:
         None
         """
 
-        self.thrust(*self.hybrid_motor.burn_time)
-        self.total_mass(*self.hybrid_motor.burn_time)
-        self.mass_flow_rate(*self.hybrid_motor.burn_time)
-        self.exhaust_velocity(*self.hybrid_motor.burn_time)
-        self.grain_inner_radius(*self.hybrid_motor.burn_time)
-        self.grain_height(*self.hybrid_motor.burn_time)
-        self.burn_rate(
-            self.hybrid_motor.burn_time[0], self.hybrid_motor.solid.grain_burn_out
-        )
-        self.burn_area(*self.hybrid_motor.burn_time)
+        self.thrust(*self.motor.burn_time)
+        self.total_mass(*self.motor.burn_time)
+        self.center_of_mass(*self.motor.burn_time)
+        self.mass_flow_rate(*self.motor.burn_time)
+        self.exhaust_velocity(*self.motor.burn_time)
+        self.grain_inner_radius(*self.motor.burn_time)
+        self.grain_height(*self.motor.burn_time)
+        self.burn_rate(self.motor.burn_time[0], self.motor.solid.grain_burn_out)
+        self.burn_area(*self.motor.burn_time)
         self.Kn()
-        self.center_of_mass(*self.hybrid_motor.burn_time)
-        self.I_11(*self.hybrid_motor.burn_time)
-        self.I_22(*self.hybrid_motor.burn_time)
-        self.I_33(*self.hybrid_motor.burn_time)
-        self.I_12(*self.hybrid_motor.burn_time)
-        self.I_13(*self.hybrid_motor.burn_time)
-        self.I_23(*self.hybrid_motor.burn_time)
-
-        return None
+        self.I_11(*self.motor.burn_time)
+        self.I_22(*self.motor.burn_time)
+        self.I_33(*self.motor.burn_time)
+        self.I_12(*self.motor.burn_time)
+        self.I_13(*self.motor.burn_time)
+        self.I_23(*self.motor.burn_time)

--- a/rocketpy/plots/liquid_motor_plots.py
+++ b/rocketpy/plots/liquid_motor_plots.py
@@ -33,12 +33,12 @@ class _LiquidMotorPlots(_MotorPlots):
         -------
         None
         """
-
         self.thrust(*self.motor.burn_time)
-        self.total_mass(*self.motor.burn_time)
-        self.center_of_mass(*self.motor.burn_time)
         self.mass_flow_rate(*self.motor.burn_time)
         self.exhaust_velocity(*self.motor.burn_time)
+        self.total_mass(*self.motor.burn_time)
+        self.propellant_mass(*self.motor.burn_time)
+        self.center_of_mass(*self.motor.burn_time)
         self.I_11(*self.motor.burn_time)
         self.I_22(*self.motor.burn_time)
         self.I_33(*self.motor.burn_time)

--- a/rocketpy/plots/liquid_motor_plots.py
+++ b/rocketpy/plots/liquid_motor_plots.py
@@ -1,4 +1,7 @@
-class _LiquidMotorPlots:
+from .motor_plots import _MotorPlots
+
+
+class _LiquidMotorPlots(_MotorPlots):
     """Class that holds plot methods for LiquidMotor class.
 
     Attributes
@@ -20,241 +23,7 @@ class _LiquidMotorPlots:
         -------
         None
         """
-
-        self.liquid_motor = liquid_motor
-
-        return None
-
-    def thrust(self, lower_limit=None, upper_limit=None):
-        """Plots thrust of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.thrust.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def total_mass(self, lower_limit=None, upper_limit=None):
-        """Plots total_mass of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.total_mass.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def mass_flow_rate(self, lower_limit=None, upper_limit=None):
-        """Plots mass_flow_rate of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.mass_flow_rate.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def exhaust_velocity(self, lower_limit=None, upper_limit=None):
-        """Plots exhaust_velocity of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.exhaust_velocity.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def center_of_mass(self, lower_limit=None, upper_limit=None):
-        """Plots center_of_mass of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.center_of_mass.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_11(self, lower_limit=None, upper_limit=None):
-        """Plots I_11 of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.I_11.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_22(self, lower_limit=None, upper_limit=None):
-        """Plots I_22 of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.I_22.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_33(self, lower_limit=None, upper_limit=None):
-        """Plots I_33 of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.I_33.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_12(self, lower_limit=None, upper_limit=None):
-        """Plots I_12 of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.I_12.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_13(self, lower_limit=None, upper_limit=None):
-        """Plots I_13 of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.I_13.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_23(self, lower_limit=None, upper_limit=None):
-        """Plots I_23 of the liquid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is None, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is None, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.liquid_motor.I_23.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        super().__init__(liquid_motor)
 
     def all(self):
         """Prints out all graphs available about the LiquidMotor. It simply calls
@@ -265,16 +34,14 @@ class _LiquidMotorPlots:
         None
         """
 
-        self.thrust(*self.liquid_motor.burn_time)
-        self.total_mass(*self.liquid_motor.burn_time)
-        self.mass_flow_rate(*self.liquid_motor.burn_time)
-        self.exhaust_velocity(*self.liquid_motor.burn_time)
-        self.center_of_mass(*self.liquid_motor.burn_time)
-        self.I_11(*self.liquid_motor.burn_time)
-        self.I_22(*self.liquid_motor.burn_time)
-        self.I_33(*self.liquid_motor.burn_time)
-        self.I_12(*self.liquid_motor.burn_time)
-        self.I_13(*self.liquid_motor.burn_time)
-        self.I_23(*self.liquid_motor.burn_time)
-
-        return None
+        self.thrust(*self.motor.burn_time)
+        self.total_mass(*self.motor.burn_time)
+        self.center_of_mass(*self.motor.burn_time)
+        self.mass_flow_rate(*self.motor.burn_time)
+        self.exhaust_velocity(*self.motor.burn_time)
+        self.I_11(*self.motor.burn_time)
+        self.I_22(*self.motor.burn_time)
+        self.I_33(*self.motor.burn_time)
+        self.I_12(*self.motor.burn_time)
+        self.I_13(*self.motor.burn_time)
+        self.I_23(*self.motor.burn_time)

--- a/rocketpy/plots/motor_plots.py
+++ b/rocketpy/plots/motor_plots.py
@@ -23,8 +23,6 @@ class _MotorPlots:
 
         self.motor = motor
 
-        return None
-
     def thrust(self, lower_limit=None, upper_limit=None):
         """Plots thrust of the motor as a function of time.
 
@@ -43,8 +41,6 @@ class _MotorPlots:
         """
 
         self.motor.thrust.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
 
     def total_mass(self, lower_limit=None, upper_limit=None):
         """Plots total_mass of the motor as a function of time.
@@ -65,8 +61,6 @@ class _MotorPlots:
 
         self.motor.total_mass.plot(lower=lower_limit, upper=upper_limit)
 
-        return None
-
     def center_of_mass(self, lower_limit=None, upper_limit=None):
         """Plots center_of_mass of the motor as a function of time.
 
@@ -86,7 +80,43 @@ class _MotorPlots:
 
         self.motor.center_of_mass.plot(lower=lower_limit, upper=upper_limit)
 
-        return None
+    def mass_flow_rate(self, lower_limit=None, upper_limit=None):
+        """Plots mass_flow_rate of the motor as a function of time.
+
+        Parameters
+        ----------
+        lower_limit : float
+            Lower limit of the plot. Default is none, which means that the plot
+            limits will be automatically calculated.
+        upper_limit : float
+            Upper limit of the plot. Default is none, which means that the plot
+            limits will be automatically calculated.
+
+        Return
+        ------
+        None
+        """
+
+        self.motor.mass_flow_rate.plot(lower=lower_limit, upper=upper_limit)
+
+    def exhaust_velocity(self, lower_limit=None, upper_limit=None):
+        """Plots exhaust_velocity of the motor as a function of time.
+
+        Parameters
+        ----------
+        lower_limit : float
+            Lower limit of the plot. Default is none, which means that the plot
+            limits will be automatically calculated.
+        upper_limit : float
+            Upper limit of the plot. Default is none, which means that the plot
+            limits will be automatically calculated.
+
+        Return
+        ------
+        None
+        """
+
+        self.motor.exhaust_velocity.plot(lower=lower_limit, upper=upper_limit)
 
     def I_11(self, lower_limit=None, upper_limit=None):
         """Plots I_11 of the motor as a function of time.
@@ -107,8 +137,6 @@ class _MotorPlots:
 
         self.motor.I_11.plot(lower=lower_limit, upper=upper_limit)
 
-        return None
-
     def I_22(self, lower_limit=None, upper_limit=None):
         """Plots I_22 of the motor as a function of time.
 
@@ -127,8 +155,6 @@ class _MotorPlots:
         """
 
         self.motor.I_22.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
 
     def I_33(self, lower_limit=None, upper_limit=None):
         """Plots I_33 of the motor as a function of time.
@@ -149,8 +175,6 @@ class _MotorPlots:
 
         self.motor.I_33.plot(lower=lower_limit, upper=upper_limit)
 
-        return None
-
     def I_12(self, lower_limit=None, upper_limit=None):
         """Plots I_12 of the motor as a function of time.
 
@@ -169,8 +193,6 @@ class _MotorPlots:
         """
 
         self.motor.I_12.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
 
     def I_13(self, lower_limit=None, upper_limit=None):
         """Plots I_13 of the motor as a function of time.
@@ -191,8 +213,6 @@ class _MotorPlots:
 
         self.motor.I_13.plot(lower=lower_limit, upper=upper_limit)
 
-        return None
-
     def I_23(self, lower_limit=None, upper_limit=None):
         """Plots I_23 of the motor as a function of time.
 
@@ -212,7 +232,8 @@ class _MotorPlots:
 
         self.motor.I_23.plot(lower=lower_limit, upper=upper_limit)
 
-        return None
+    def draw(self):
+        """Place holder for drawing the motor."""
 
     def all(self):
         """Prints out all graphs available about the Motor. It simply calls
@@ -224,14 +245,13 @@ class _MotorPlots:
         """
 
         # Show plots
-        self.thrust()
-        self.total_mass()
-        self.center_of_mass()
-        self.I_11()
-        self.I_22()
-        self.I_33()
-        self.I_12()
-        self.I_13()
-        self.I_23()
-
-        return None
+        self.thrust(*self.motor.burn_time)
+        self.total_mass(*self.motor.burn_time)
+        self.center_of_mass(*self.motor.burn_time)
+        self.exhaust_velocity(*self.motor.burn_time)
+        self.I_11(*self.motor.burn_time)
+        self.I_22(*self.motor.burn_time)
+        self.I_33(*self.motor.burn_time)
+        self.I_12(*self.motor.burn_time)
+        self.I_13(*self.motor.burn_time)
+        self.I_23(*self.motor.burn_time)

--- a/rocketpy/plots/motor_plots.py
+++ b/rocketpy/plots/motor_plots.py
@@ -20,7 +20,6 @@ class _MotorPlots:
         -------
         None
         """
-
         self.motor = motor
 
     def thrust(self, lower_limit=None, upper_limit=None):
@@ -39,7 +38,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.thrust.plot(lower=lower_limit, upper=upper_limit)
 
     def total_mass(self, lower_limit=None, upper_limit=None):
@@ -58,8 +56,25 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.total_mass.plot(lower=lower_limit, upper=upper_limit)
+
+    def propellant_mass(self, lower_limit=None, upper_limit=None):
+        """Plots propellant_mass of the motor as a function of time.
+
+        Parameters
+        ----------
+        lower_limit : float
+            Lower limit of the plot. Default is None, which means that the plot
+            limits will be automatically calculated.
+        upper_limit : float
+            Upper limit of the plot. Default is None, which means that the plot
+            limits will be automatically calculated.
+
+        Return
+        ------
+        None
+        """
+        self.motor.propellant_mass.plot(lower=lower_limit, upper=upper_limit)
 
     def center_of_mass(self, lower_limit=None, upper_limit=None):
         """Plots center_of_mass of the motor as a function of time.
@@ -77,7 +92,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.center_of_mass.plot(lower=lower_limit, upper=upper_limit)
 
     def mass_flow_rate(self, lower_limit=None, upper_limit=None):
@@ -96,7 +110,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.mass_flow_rate.plot(lower=lower_limit, upper=upper_limit)
 
     def exhaust_velocity(self, lower_limit=None, upper_limit=None):
@@ -115,7 +128,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.exhaust_velocity.plot(lower=lower_limit, upper=upper_limit)
 
     def I_11(self, lower_limit=None, upper_limit=None):
@@ -134,7 +146,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.I_11.plot(lower=lower_limit, upper=upper_limit)
 
     def I_22(self, lower_limit=None, upper_limit=None):
@@ -153,7 +164,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.I_22.plot(lower=lower_limit, upper=upper_limit)
 
     def I_33(self, lower_limit=None, upper_limit=None):
@@ -172,7 +182,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.I_33.plot(lower=lower_limit, upper=upper_limit)
 
     def I_12(self, lower_limit=None, upper_limit=None):
@@ -191,7 +200,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.I_12.plot(lower=lower_limit, upper=upper_limit)
 
     def I_13(self, lower_limit=None, upper_limit=None):
@@ -210,7 +218,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.I_13.plot(lower=lower_limit, upper=upper_limit)
 
     def I_23(self, lower_limit=None, upper_limit=None):
@@ -229,7 +236,6 @@ class _MotorPlots:
         ------
         None
         """
-
         self.motor.I_23.plot(lower=lower_limit, upper=upper_limit)
 
     def draw(self):
@@ -243,12 +249,12 @@ class _MotorPlots:
         -------
         None
         """
-
-        # Show plots
         self.thrust(*self.motor.burn_time)
-        self.total_mass(*self.motor.burn_time)
-        self.center_of_mass(*self.motor.burn_time)
+        # self.mass_flow_rate(*self.motor.burn_time)
         self.exhaust_velocity(*self.motor.burn_time)
+        self.total_mass(*self.motor.burn_time)
+        self.propellant_mass(*self.motor.burn_time)
+        self.center_of_mass(*self.motor.burn_time)
         self.I_11(*self.motor.burn_time)
         self.I_22(*self.motor.burn_time)
         self.I_33(*self.motor.burn_time)

--- a/rocketpy/plots/solid_motor_plots.py
+++ b/rocketpy/plots/solid_motor_plots.py
@@ -1,4 +1,7 @@
-class _SolidMotorPlots:
+from .motor_plots import _MotorPlots
+
+
+class _SolidMotorPlots(_MotorPlots):
     """Class that holds plot methods for SolidMotor class.
 
     Attributes
@@ -21,93 +24,7 @@ class _SolidMotorPlots:
         None
         """
 
-        self.solid_motor = solid_motor
-
-        return None
-
-    def thrust(self, lower_limit=None, upper_limit=None):
-        """Plots thrust of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.thrust.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def total_mass(self, lower_limit=None, upper_limit=None):
-        """Plots total_mass of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.total_mass.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def mass_flow_rate(self, lower_limit=None, upper_limit=None):
-        """Plots mass_flow_rate of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.mass_flow_rate.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def exhaust_velocity(self, lower_limit=None, upper_limit=None):
-        """Plots exhaust_velocity of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.exhaust_velocity.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        super().__init__(solid_motor)
 
     def grain_inner_radius(self, lower_limit=None, upper_limit=None):
         """Plots grain_inner_radius of the solid_motor as a function of time.
@@ -126,9 +43,7 @@ class _SolidMotorPlots:
         None
         """
 
-        self.solid_motor.grain_inner_radius.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        self.motor.grain_inner_radius.plot(lower=lower_limit, upper=upper_limit)
 
     def grain_height(self, lower_limit=None, upper_limit=None):
         """Plots grain_height of the solid_motor as a function of time.
@@ -147,9 +62,7 @@ class _SolidMotorPlots:
         None
         """
 
-        self.solid_motor.grain_height.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        self.motor.grain_height.plot(lower=lower_limit, upper=upper_limit)
 
     def burn_rate(self, lower_limit=None, upper_limit=None):
         """Plots burn_rate of the solid_motor as a function of time.
@@ -168,9 +81,7 @@ class _SolidMotorPlots:
         None
         """
 
-        self.solid_motor.burn_rate.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        self.motor.burn_rate.plot(lower=lower_limit, upper=upper_limit)
 
     def burn_area(self, lower_limit=None, upper_limit=None):
         """Plots burn_area of the solid_motor as a function of time.
@@ -189,9 +100,7 @@ class _SolidMotorPlots:
         None
         """
 
-        self.solid_motor.burn_area.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        self.motor.burn_area.plot(lower=lower_limit, upper=upper_limit)
 
     def Kn(self, lower_limit=None, upper_limit=None):
         """Plots Kn of the solid_motor as a function of time.
@@ -210,156 +119,7 @@ class _SolidMotorPlots:
         None
         """
 
-        self.solid_motor.Kn.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def center_of_mass(self, lower_limit=None, upper_limit=None):
-        """Plots center_of_mass of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.center_of_mass.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_11(self, lower_limit=None, upper_limit=None):
-        """Plots I_11 of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.I_11.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_22(self, lower_limit=None, upper_limit=None):
-        """Plots I_22 of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.I_22.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_33(self, lower_limit=None, upper_limit=None):
-        """Plots I_33 of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.I_33.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_12(self, lower_limit=None, upper_limit=None):
-        """Plots I_12 of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.I_12.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_13(self, lower_limit=None, upper_limit=None):
-        """Plots I_13 of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is none, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.I_13.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
-
-    def I_23(self, lower_limit=None, upper_limit=None):
-        """Plots I_23 of the solid_motor as a function of time.
-
-        Parameters
-        ----------
-        lower_limit : float
-            Lower limit of the plot. Default is None, which means that the plot
-            limits will be automatically calculated.
-        upper_limit : float
-            Upper limit of the plot. Default is None, which means that the plot
-            limits will be automatically calculated.
-
-        Return
-        ------
-        None
-        """
-
-        self.solid_motor.I_23.plot(lower=lower_limit, upper=upper_limit)
-
-        return None
+        self.motor.Kn.plot(lower=lower_limit, upper=upper_limit)
 
     def all(self):
         """Prints out all graphs available about the SolidMotor. It simply calls
@@ -370,21 +130,19 @@ class _SolidMotorPlots:
         None
         """
 
-        self.thrust(*self.solid_motor.burn_time)
-        self.total_mass(*self.solid_motor.burn_time)
-        self.mass_flow_rate(*self.solid_motor.burn_time)
-        self.exhaust_velocity(*self.solid_motor.burn_time)
-        self.grain_inner_radius(*self.solid_motor.burn_time)
-        self.grain_height(*self.solid_motor.burn_time)
-        self.burn_rate(self.solid_motor.burn_time[0], self.solid_motor.grain_burn_out)
-        self.burn_area(*self.solid_motor.burn_time)
+        self.thrust(*self.motor.burn_time)
+        self.total_mass(*self.motor.burn_time)
+        self.center_of_mass(*self.motor.burn_time)
+        self.mass_flow_rate(*self.motor.burn_time)
+        self.exhaust_velocity(*self.motor.burn_time)
+        self.grain_inner_radius(*self.motor.burn_time)
+        self.grain_height(*self.motor.burn_time)
+        self.burn_rate(self.motor.burn_time[0], self.motor.grain_burn_out)
+        self.burn_area(*self.motor.burn_time)
         self.Kn()
-        self.center_of_mass(*self.solid_motor.burn_time)
-        self.I_11(*self.solid_motor.burn_time)
-        self.I_22(*self.solid_motor.burn_time)
-        self.I_33(*self.solid_motor.burn_time)
-        self.I_12(*self.solid_motor.burn_time)
-        self.I_13(*self.solid_motor.burn_time)
-        self.I_23(*self.solid_motor.burn_time)
-
-        return None
+        self.I_11(*self.motor.burn_time)
+        self.I_22(*self.motor.burn_time)
+        self.I_33(*self.motor.burn_time)
+        self.I_12(*self.motor.burn_time)
+        self.I_13(*self.motor.burn_time)
+        self.I_23(*self.motor.burn_time)

--- a/rocketpy/plots/solid_motor_plots.py
+++ b/rocketpy/plots/solid_motor_plots.py
@@ -129,12 +129,12 @@ class _SolidMotorPlots(_MotorPlots):
         -------
         None
         """
-
         self.thrust(*self.motor.burn_time)
-        self.total_mass(*self.motor.burn_time)
-        self.center_of_mass(*self.motor.burn_time)
         self.mass_flow_rate(*self.motor.burn_time)
         self.exhaust_velocity(*self.motor.burn_time)
+        self.total_mass(*self.motor.burn_time)
+        self.propellant_mass(*self.motor.burn_time)
+        self.center_of_mass(*self.motor.burn_time)
         self.grain_inner_radius(*self.motor.burn_time)
         self.grain_height(*self.motor.burn_time)
         self.burn_rate(self.motor.burn_time[0], self.motor.grain_burn_out)


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

- [x] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally

## Current behavior
<!-- Describe current behavior or link to an issue. -->

A lot of repeated code in the motors' plots classes

## New behavior
<!-- Describe changes introduced by this PR. -->

`_SolidMotorPlots`, `_HybridMotorPlots` and `_LiquidMotorPlots` now inherit `_MotorPlots`

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. -->

There are a lot of repeated code in `_SolidMotorPlots` and `_HybridMotorPlots` I could not find a good solution for it. I tried using multiple inheritance in `_HybridMotorPlots` but it went south really fast

Also, this is really useful for Motor Draws #436 