### PR TITLE
MNT: add codecov integration

### DIFF
--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -48,3 +48,7 @@ jobs:
           pytest
           cd rocketpy
           pytest --doctest-modules
+      - name: Upload reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -25,6 +25,9 @@ jobs:
         python-version:
           - 3.8
           - 3.12
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -47,14 +50,15 @@ jobs:
         run: |
           pytest --cov=rocketpy --cov-report=xml
           cd rocketpy
-          pytest --doctest-modules --cov=rocketpy --cov-report=xml --cov-append
+          pytest --doctest-modules --cov=rocketpy --cov-report=xml
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
         with:
-          file: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage/reports/
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+          files: ./coverage.xml, ./rocketpy/coverage.xml
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: true
           verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -45,10 +45,16 @@ jobs:
           pip install -r requirements-tests.txt
       - name: Test with pytest
         run: |
-          pytest
+          pytest --cov=rocketpy --cov-report=xml
           cd rocketpy
-          pytest --doctest-modules
-      - name: Upload reports to Codecov
+          pytest --doctest-modules --cov=rocketpy --cov-report=xml --cov-append
+      - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: true
+          verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/RocketPy-Team/rocketpy/blob/master/docs/notebooks/getting_started_colab.ipynb)
 [![PyPI](https://img.shields.io/pypi/v/rocketpy?color=g)](https://pypi.org/project/rocketpy/)
 [![Documentation Status](https://readthedocs.org/projects/rocketpyalpha/badge/?version=latest)](https://docs.rocketpy.org/en/latest/?badge=latest)
+[![codecov](https://codecov.io/gh/RocketPy-Team/RocketPy/graph/badge.svg?token=Ecc3bsHFeP)](https://codecov.io/gh/RocketPy-Team/RocketPy)
 [![Contributors](https://img.shields.io/github/contributors/RocketPy-Team/rocketpy)](https://github.com/RocketPy-Team/RocketPy/graphs/contributors)
 [![Chat on Discord](https://img.shields.io/discord/765037887016140840?logo=discord)](https://discord.gg/b6xYnNh)
 [![Sponsor RocketPy](https://img.shields.io/static/v1?label=Sponsor&message=%E2%9D%A4&logo=GitHub&color=%23fe8e86)](https://github.com/sponsors/RocketPy-Team)


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

- [ ] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [x] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [ ] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest --runslow`) have passed locally

## Current behavior
We run tests everytime but we don't see the code coverage percentage

## New behavior
Adding codecoverage integration according to this: https://app.codecov.io/gh/RocketPy-Team/RocketPy/new.
This still needs to be tested before merging.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Additional information
None