### PR TITLE
ENH: Add mass_flow_rate() to GenericMotor class

### DIFF
--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -439,6 +439,8 @@ class Motor(ABC):
         - The ``LiquidMotor`` class favors the more accurate data from the
           Tanks's mass flow rates. Therefore this value is numerically
           independent of the ``LiquidMotor.mass_flow_rate``.
+        - The ``GenericMotor`` class considers the total_mass_flow_rate as the
+        same as the mass_flow_rate.
 
         It should be noted that, for hybrid motors, the oxidizer mass flow
         rate should not be greater than `total_mass_flow_rate`, otherwise the
@@ -1218,6 +1220,14 @@ class GenericMotor(Motor):
             Gas exhaust velocity of the motor.
         """
         return self.total_impulse / self.propellant_initial_mass
+
+    @funcify_method("Time (s)", "Mass Flow Rate (kg/s)")
+    def mass_flow_rate(self):
+        """Time derivative of propellant mass. Assumes constant exhaust
+        velocity. The formula used is the opposite of thrust divided by
+        exhaust velocity.
+        """
+        return -1 * self.thrust / self.exhaust_velocity
 
     @funcify_method("Time (s)", "center of mass (m)")
     def center_of_propellant_mass(self):


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist

- [ ] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally

## Current behavior
There was a small issue when using the `GenericMotor` class and trying to plot its mass_flow_rate.

## New behavior

Now we can finally have a mass_flow_rate in the GenericMotor class

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## Additional information
The idea of separating mass_flow_rate from total_mass_flow_rate is still weird to me