### PR TITLE
BUG: fix extrapolation of multivariable functions.

### DIFF
--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -231,8 +231,29 @@ class Function:
 
                 # Finally set data source as source
                 self.source = source
-                if self.__interpolation__ is None:
+
+                # Update extrapolation method
+                if (
+                    self.__extrapolation__ is None
+                    or self.__extrapolation__ == "shepard"
+                ):
+                    self.set_extrapolation("shepard")
+                else:
+                    raise ValueError(
+                        "Multidimensional datasets only support shepard extrapolation."
+                    )
+
+                # Set default multidimensional interpolation if it hasn't
+                if (
+                    self.__interpolation__ is None
+                    or self.__interpolation__ == "shepard"
+                ):
                     self.set_interpolation("shepard")
+                else:
+                    raise ValueError(
+                        "Multidimensional datasets only support shepard interpolation."
+                    )
+
         # Return self
         return self
 

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -235,12 +235,12 @@ class Function:
                 # Update extrapolation method
                 if (
                     self.__extrapolation__ is None
-                    or self.__extrapolation__ == "shepard"
+                    or self.__extrapolation__ == "natural"
                 ):
-                    self.set_extrapolation("shepard")
+                    self.set_extrapolation("natural")
                 else:
                     raise ValueError(
-                        "Multidimensional datasets only support shepard extrapolation."
+                        "Multidimensional datasets only support natural extrapolation."
                     )
 
                 # Set default multidimensional interpolation if it hasn't

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -173,3 +173,73 @@ def test_integral_spline_interpolation(request, func, a, b):
         func.integral(a, b, numerical=True),
         atol=1e-3,
     )
+
+
+@pytest.mark.parametrize("a", [-1, 0, 1])
+@pytest.mark.parametrize("b", [-1, 0, 1])
+def test_multivariable_dataset(a, b):
+    """Test the Function class with a multivariable dataset."""
+    # Test plane f(x,y) = x + y
+    source = [
+        (-1, -1, -2),
+        (-1, 0, -1),
+        (-1, 1, 0),
+        (0, -1, -1),
+        (0, 0, 0),
+        (0, 1, 1),
+        (1, -1, 0),
+        (1, 0, 1),
+        (1, 1, 2),
+    ]
+    func = Function(source=source, inputs=["x", "y"], outputs=["z"])
+
+    # Assert interpolation and extrapolation methods
+    assert func.get_interpolation_method() == "shepard"
+    assert func.get_extrapolation_method() == "natural"
+
+    # Assert values
+    assert np.isclose(func(a, b), a + b, atol=1e-6)
+
+
+@pytest.mark.parametrize("a", [-1, -0.5, 0, 0.5, 1])
+@pytest.mark.parametrize("b", [-1, -0.5, 0, 0.5, 1])
+def test_multivariable_function(a, b):
+    """Test the Function class with a multivariable function."""
+    # Test plane f(x,y) = sin(x + y)
+    source = lambda x, y: np.sin(x + y)
+    func = Function(source=source, inputs=["x", "y"], outputs=["z"])
+
+    # Assert values
+    assert np.isclose(func(a, b), np.sin(a + b), atol=1e-6)
+
+
+@patch("matplotlib.pyplot.show")
+def test_multivariable_dataset_plot(mock_show):
+    """Test the plot method of the Function class with a multivariable dataset."""
+    # Test plane f(x,y) = x - y
+    source = [
+        (-1, -1, -1),
+        (-1, 0, -1),
+        (-1, 1, -2),
+        (0, 1, 1),
+        (0, 0, 0),
+        (0, 1, -1),
+        (1, -1, 2),
+        (1, 0, 1),
+        (1, 1, 0),
+    ]
+    func = Function(source=source, inputs=["x", "y"], outputs=["z"])
+
+    # Assert plot
+    assert func.plot() == None
+
+
+@patch("matplotlib.pyplot.show")
+def test_multivariable_function_plot(mock_show):
+    """Test the plot method of the Function class with a multivariable function."""
+    # Test plane f(x,y) = sin(x + y)
+    source = lambda x, y: np.sin(x * y)
+    func = Function(source=source, inputs=["x", "y"], outputs=["z"])
+
+    # Assert plot
+    assert func.plot() == None


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type

- [X] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist

- [X] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest --runslow`) have passed locally

## Current behavior
<!-- Describe current behavior or link to an issue. -->

The construction of a multivariable `Function` from a dataset (e.g. `[(0,0,0), (0,1,1), ...]`) triggered an extrapolation error since it was being kept `None` when calling `get_value_opt`.

## New behavior
<!-- Describe changes introduced by this PR. -->

The error was fixed by setting the extrapolation type on `set_source` similarly to what occurs when the dataset is one dimensional. Tests for the changes have been added.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No
