### PR TITLE
BUG: Fix find_input() Function to Return a Single Value

### DIFF
--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -2648,7 +2648,7 @@ class Function:
             The value of the input which gives the output closest to val.
         """
         return optimize.root(
-            lambda x: self.get_value(x) - val,
+            lambda x: self.get_value(x)[0] - val,
             start,
             tol=tol,
         ).x[0]


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally


## New behavior
<!-- Describe changes introduced by this PR. -->

Scipy's  `optimize.root` gives an array of length 1 to the Function object inside `find_input`. Currently if a Function receives an Iterable, it returns a list. This was not always the case before #451.

Now `find_input` should always work, independent of the Function source

