### PR TITLE
HOTFIX: Negative Static Margin

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2023, RocketPy Team"
 author = "RocketPy Team"
 
 # The full version, including alpha/beta/rc tags
-release = "1.1.0"
+release = "1.1.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -19,7 +19,7 @@ If you want to choose a specific version to guarantee compatibility, you may ins
 
 .. code-block:: shell
 
-    pip install rocketpy==1.1.0
+    pip install rocketpy==1.1.1
 
 
 Optional Installation Method: ``conda``

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -543,7 +543,6 @@ class Rocket:
         self.static_margin.set_source(
             lambda time: (self.center_of_mass(time) - self.cp_position(0))
             / (2 * self.radius)
-            * self._csys
         )
         # Change sign if coordinate system is upside down
         self.static_margin *= self._csys

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ env_analysis_require = [
 
 setuptools.setup(
     name="rocketpy",
-    version="1.1.0",
+    version="1.1.1",
     install_requires=necessary_require,
     extras_require={
         "env_analysis": env_analysis_require,

--- a/tests/test_rocket.py
+++ b/tests/test_rocket.py
@@ -25,9 +25,8 @@ def test_aero_surfaces_infos(
     assert calisto_trapezoidal_fins.draw() == None
 
 
-@patch("matplotlib.pyplot.show")
 def test_coordinate_system_orientation(
-    mock_show, calisto_nose_cone, cesaroni_m1670, calisto_trapezoidal_fins
+    calisto_nose_cone, cesaroni_m1670, calisto_trapezoidal_fins
 ):
     """Test if the coordinate system orientation is working properly. This test
     basically checks if the static margin is the same for the same rocket with
@@ -35,8 +34,6 @@ def test_coordinate_system_orientation(
 
     Parameters
     ----------
-    mock_show : mock
-        Mock of matplotlib.pyplot.show
     calisto_nose_cone : rocketpy.NoseCone
         Nose cone of the rocket
     cesaroni_m1670 : rocketpy.SolidMotor

--- a/tests/test_rocket.py
+++ b/tests/test_rocket.py
@@ -51,7 +51,7 @@ def test_coordinate_system_orientation(
         burn_time=3.9,
         dry_mass=1.815,
         dry_inertia=(0.125, 0.125, 0.002),
-        center_of_dry_mass_position=0.317,
+        center_of_dry_mass_position=-0.317,
         nozzle_position=0,
         grain_number=5,
         grain_density=1815,
@@ -60,7 +60,7 @@ def test_coordinate_system_orientation(
         grain_separation=5 / 1000,
         grain_outer_radius=33 / 1000,
         grain_initial_height=120 / 1000,
-        grains_center_of_mass_position=0.397,
+        grains_center_of_mass_position=-0.397,
         grain_initial_inner_radius=15 / 1000,
         interpolation_method="linear",
         coordinate_system_orientation="combustion_chamber_to_nozzle",
@@ -81,7 +81,7 @@ def test_coordinate_system_orientation(
     rocket_tail_to_nose.aerodynamic_surfaces.add(calisto_nose_cone, 1.160)
     rocket_tail_to_nose.aerodynamic_surfaces.add(calisto_trapezoidal_fins, -1.168)
 
-    static_margin_tail_to_nose = rocket_tail_to_nose.static_margin(0)
+    static_margin_tail_to_nose = rocket_tail_to_nose.static_margin
 
     rocket_nose_to_tail = Rocket(
         radius=0.0635,
@@ -98,13 +98,9 @@ def test_coordinate_system_orientation(
     rocket_nose_to_tail.aerodynamic_surfaces.add(calisto_nose_cone, -1.160)
     rocket_nose_to_tail.aerodynamic_surfaces.add(calisto_trapezoidal_fins, 1.168)
 
-    static_margin_nose_to_tail = rocket_nose_to_tail.static_margin(0)
+    static_margin_nose_to_tail = rocket_nose_to_tail.static_margin
 
-    assert (
-        rocket_tail_to_nose.all_info() == None
-        or rocket_nose_to_tail.all_info() == None
-        or not abs(static_margin_tail_to_nose - static_margin_nose_to_tail) < 0.0001
-    )
+    assert np.array_equal(static_margin_tail_to_nose, static_margin_nose_to_tail)
 
 
 @patch("matplotlib.pyplot.show")


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally

## Current behavior

When using the `nose_to_tail` coordinate system for the `Rocket` class, the sign of the static margin was inverted since a sign correction was applied twice, as noticed by @MateusStano.

## New behavior

Things just work now. One of the sign corrections was removed. Ironically, we had tests for this, but they were not working properly. This has also been fixed.

Version has been bumped up to v1.1.1 so that a hotfix can be released.

## Breaking change

- [x] No

## Additional information

This bug was reported by Bob Brown [D&W] (MΦNK3Y#2638) through our Discord server.
