### PR TITLE
ENH: Function Reverse Arithmetic Priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ straightforward as possible.
 
 ### Changed
 
--
+- ENH: Function Reverse Arithmetic Priority [#488](https://github.com/RocketPy-Team/RocketPy/pull/488)
 
 ### Fixed
 

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -1840,7 +1840,9 @@ class Function:
                 return Function(lambda x: (self.get_value(x) + other(x)))
         # If other is Float except...
         except AttributeError:
-            if isinstance(other, (float, int, complex, np.ndarray)):
+            if isinstance(
+                other, (float, int, complex, np.ndarray, np.integer, np.floating)
+            ):
                 # Check if Function object source is array or callable
                 if isinstance(self.source, np.ndarray):
                     # Operate on grid values
@@ -1970,7 +1972,9 @@ class Function:
                 return Function(lambda x: (self.get_value(x) * other(x)))
         # If other is Float except...
         except AttributeError:
-            if isinstance(other, (float, int, complex, np.ndarray)):
+            if isinstance(
+                other, (float, int, complex, np.ndarray, np.integer, np.floating)
+            ):
                 # Check if Function object source is array or callable
                 if isinstance(self.source, np.ndarray):
                     # Operate on grid values
@@ -2059,7 +2063,9 @@ class Function:
                 return Function(lambda x: (self.get_value_opt(x) / other(x)))
         # If other is Float except...
         except AttributeError:
-            if isinstance(other, (float, int, complex, np.ndarray)):
+            if isinstance(
+                other, (float, int, complex, np.ndarray, np.integer, np.floating)
+            ):
                 # Check if Function object source is array or callable
                 if isinstance(self.source, np.ndarray):
                     # Operate on grid values
@@ -2098,7 +2104,9 @@ class Function:
             A Function object which gives the result of other(x)/self(x).
         """
         # Check if Function object source is array and other is float
-        if isinstance(other, (float, int, complex, np.ndarray)):
+        if isinstance(
+            other, (float, int, complex, np.ndarray, np.integer, np.floating)
+        ):
             if isinstance(self.source, np.ndarray):
                 # Operate on grid values
                 ys = other / self.y_array
@@ -2166,7 +2174,9 @@ class Function:
                 return Function(lambda x: (self.get_value_opt(x) ** other(x)))
         # If other is Float except...
         except AttributeError:
-            if isinstance(other, (float, int, complex, np.ndarray)):
+            if isinstance(
+                other, (float, int, complex, np.ndarray, np.integer, np.floating)
+            ):
                 # Check if Function object source is array or callable
                 if isinstance(self.source, np.ndarray):
                     # Operate on grid values
@@ -2205,7 +2215,9 @@ class Function:
             A Function object which gives the result of other(x)**self(x).
         """
         # Check if Function object source is array and other is float
-        if isinstance(other, (float, int, complex, np.ndarray)):
+        if isinstance(
+            other, (float, int, complex, np.ndarray, np.integer, np.floating)
+        ):
             if isinstance(self.source, np.ndarray):
                 # Operate on grid values
                 ys = other**self.y_array

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -24,6 +24,9 @@ class Function:
     extrapolation, plotting and algebra.
     """
 
+    # Arithmetic priority
+    __array_ufunc__ = None
+
     def __init__(
         self,
         source,
@@ -1837,7 +1840,7 @@ class Function:
                 return Function(lambda x: (self.get_value(x) + other(x)))
         # If other is Float except...
         except AttributeError:
-            if isinstance(other, (float, int, complex)):
+            if isinstance(other, (float, int, complex, np.ndarray)):
                 # Check if Function object source is array or callable
                 if isinstance(self.source, np.ndarray):
                     # Operate on grid values
@@ -1967,7 +1970,7 @@ class Function:
                 return Function(lambda x: (self.get_value(x) * other(x)))
         # If other is Float except...
         except AttributeError:
-            if isinstance(other, (float, int, complex)):
+            if isinstance(other, (float, int, complex, np.ndarray)):
                 # Check if Function object source is array or callable
                 if isinstance(self.source, np.ndarray):
                     # Operate on grid values
@@ -2056,7 +2059,7 @@ class Function:
                 return Function(lambda x: (self.get_value_opt(x) / other(x)))
         # If other is Float except...
         except AttributeError:
-            if isinstance(other, (float, int, complex)):
+            if isinstance(other, (float, int, complex, np.ndarray)):
                 # Check if Function object source is array or callable
                 if isinstance(self.source, np.ndarray):
                     # Operate on grid values
@@ -2095,7 +2098,7 @@ class Function:
             A Function object which gives the result of other(x)/self(x).
         """
         # Check if Function object source is array and other is float
-        if isinstance(other, (float, int, complex)):
+        if isinstance(other, (float, int, complex, np.ndarray)):
             if isinstance(self.source, np.ndarray):
                 # Operate on grid values
                 ys = other / self.y_array
@@ -2163,7 +2166,7 @@ class Function:
                 return Function(lambda x: (self.get_value_opt(x) ** other(x)))
         # If other is Float except...
         except AttributeError:
-            if isinstance(other, (float, int, complex)):
+            if isinstance(other, (float, int, complex, np.ndarray)):
                 # Check if Function object source is array or callable
                 if isinstance(self.source, np.ndarray):
                     # Operate on grid values
@@ -2202,7 +2205,7 @@ class Function:
             A Function object which gives the result of other(x)**self(x).
         """
         # Check if Function object source is array and other is float
-        if isinstance(other, (float, int, complex)):
+        if isinstance(other, (float, int, complex, np.ndarray)):
             if isinstance(self.source, np.ndarray):
                 # Operate on grid values
                 ys = other**self.y_array

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -392,17 +392,81 @@ def test_shepard_interpolation(x, y, z_expected):
     assert np.isclose(z, z_expected, atol=1e-8).all()
 
 
-def test_arithmetic_priority():
-    """Test the arithmetic priority of the Function class, specially
-    comparing to the numpy array operations.
+@pytest.mark.parametrize("other", [1, 0.1, np.int_(1), np.float_(0.1), np.array([1])])
+def test_sum_arithmetic_priority(other):
+    """Test the arithmetic priority of the add operation of the Function class,
+    specially comparing to the numpy array operations.
     """
     func_lambda = Function(lambda x: x**2)
     func_array = Function([(0, 0), (1, 1), (2, 4)])
-    array = np.array([1])
 
     assert isinstance(func_lambda + func_array, Function)
     assert isinstance(func_array + func_lambda, Function)
-    assert isinstance(func_lambda + array, Function)
-    assert isinstance(array + func_lambda, Function)
-    assert isinstance(func_array + array, Function)
-    assert isinstance(array + func_array, Function)
+    assert isinstance(func_lambda + other, Function)
+    assert isinstance(other + func_lambda, Function)
+    assert isinstance(func_array + other, Function)
+    assert isinstance(other + func_array, Function)
+
+
+@pytest.mark.parametrize("other", [1, 0.1, np.int_(1), np.float_(0.1), np.array([1])])
+def test_sub_arithmetic_priority(other):
+    """Test the arithmetic priority of the sub operation of the Function class,
+    specially comparing to the numpy array operations.
+    """
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)])
+
+    assert isinstance(func_lambda - func_array, Function)
+    assert isinstance(func_array - func_lambda, Function)
+    assert isinstance(func_lambda - other, Function)
+    assert isinstance(other - func_lambda, Function)
+    assert isinstance(func_array - other, Function)
+    assert isinstance(other - func_array, Function)
+
+
+@pytest.mark.parametrize("other", [1, 0.1, np.int_(1), np.float_(0.1), np.array([1])])
+def test_mul_arithmetic_priority(other):
+    """Test the arithmetic priority of the mul operation of the Function class,
+    specially comparing to the numpy array operations.
+    """
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)])
+
+    assert isinstance(func_lambda * func_array, Function)
+    assert isinstance(func_array * func_lambda, Function)
+    assert isinstance(func_lambda * other, Function)
+    assert isinstance(other * func_lambda, Function)
+    assert isinstance(func_array * other, Function)
+    assert isinstance(other * func_array, Function)
+
+
+@pytest.mark.parametrize("other", [1, 0.1, np.int_(1), np.float_(0.1), np.array([1])])
+def test_truediv_arithmetic_priority(other):
+    """Test the arithmetic priority of the truediv operation of the Function class,
+    specially comparing to the numpy array operations.
+    """
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(1, 1), (2, 4)])
+
+    assert isinstance(func_lambda / func_array, Function)
+    assert isinstance(func_array / func_lambda, Function)
+    assert isinstance(func_lambda / other, Function)
+    assert isinstance(other / func_lambda, Function)
+    assert isinstance(func_array / other, Function)
+    assert isinstance(other / func_array, Function)
+
+
+@pytest.mark.parametrize("other", [1, 0.1, np.int_(1), np.float_(0.1), np.array([1])])
+def test_pow_arithmetic_priority(other):
+    """Test the arithmetic priority of the pow operation of the Function class,
+    specially comparing to the numpy array operations.
+    """
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)])
+
+    assert isinstance(func_lambda**func_array, Function)
+    assert isinstance(func_array**func_lambda, Function)
+    assert isinstance(func_lambda**other, Function)
+    assert isinstance(other**func_lambda, Function)
+    assert isinstance(func_array**other, Function)
+    assert isinstance(other**func_array, Function)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -390,3 +390,19 @@ def test_shepard_interpolation(x, y, z_expected):
     func = Function(source=source, inputs=["x", "y"], outputs=["z"])
     z = func(x, y)
     assert np.isclose(z, z_expected, atol=1e-8).all()
+
+
+def test_arithmetic_priority():
+    """Test the arithmetic priority of the Function class, specially
+    comparing to the numpy array operations.
+    """
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)])
+    array = np.array([1])
+
+    assert isinstance(func_lambda + func_array, Function)
+    assert isinstance(func_array + func_lambda, Function)
+    assert isinstance(func_lambda + array, Function)
+    assert isinstance(array + func_lambda, Function)
+    assert isinstance(func_array + array, Function)
+    assert isinstance(array + func_array, Function)


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [X] Tests for the changes have been added (if needed)
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Operations that involve reverse `Function` operations with `numpy.ndarrays` result, usually unexpectedly, in a `numpy.ndarray` as a result. This happens since `numpy.ndarray` implement an `__radd__` that overrides `Function.__radd__` operation. 

## New behavior
<!-- Describe changes introduced by this PR. -->

The variable `__array_ufunc__` is a way to enforce `Function` priority regarding reverse operations.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [X] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

This same issue was found during `mathutils.vector` and `mathutils.matrix` development and the same fix was applied (using `__array_ufunc__`).
