### PR TITLE
ENH: Parachute trigger doesn't work if "Apogee" is used instead of "apogee"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ straightforward as possible.
 
 ### Fixed
 
--
+- ENH: Parachute trigger doesn't work if "Apogee" is used instead of "apogee" [#489](https://github.com/RocketPy-Team/RocketPy/pull/489)
 
 ## [v1.1.2] - 2023-11-25
 

--- a/rocketpy/rocket/parachute.py
+++ b/rocketpy/rocket/parachute.py
@@ -171,11 +171,17 @@ class Parachute:
 
         self.prints = _ParachutePrints(self)
 
-        # evaluate the trigger
+        self.__evaluate_trigger_function(trigger)
+
+    def __evaluate_trigger_function(self, trigger):
+        """This is used to set the triggerfunc attribute that will be used to
+        interact with the Flight class.
+        """
         if callable(trigger):
             self.triggerfunc = trigger
+
         elif isinstance(trigger, (int, float)):
-            # trigger is interpreted as the absolute height at which the parachute will be ejected
+            # The parachute is deployed at a given height
             def triggerfunc(p, h, y):
                 # p = pressure considering parachute noise signal
                 # h = height above ground level considering parachute noise signal
@@ -185,7 +191,7 @@ class Parachute:
             self.triggerfunc = triggerfunc
 
         elif trigger.lower() == "apogee":
-            # trigger for apogee
+            # The parachute is deployed at apogee
             def triggerfunc(p, h, y):
                 # p = pressure considering parachute noise signal
                 # h = height above ground level considering parachute noise signal
@@ -194,7 +200,12 @@ class Parachute:
 
             self.triggerfunc = triggerfunc
 
-        return None
+        else:
+            raise ValueError(
+                f"Unable to set the trigger function for parachute '{self.name}'. "
+                + "Trigger must be a callable, a float value or the string 'apogee'. "
+                + "See the Parachute class documentation for mor information."
+            )
 
     def __str__(self):
         """Returns a string representation of the Parachute class.

--- a/rocketpy/rocket/parachute.py
+++ b/rocketpy/rocket/parachute.py
@@ -38,7 +38,7 @@ class Parachute:
         case, the parachute will be ejected when the rocket reaches this height
         above ground level.
 
-        - The string "apogee," which triggers the parachute at apogee, i.e.,
+        - The string "apogee" which triggers the parachute at apogee, i.e.,
         when the rocket reaches its highest point and starts descending.
 
         Note: The function will be called according to the sampling rate
@@ -126,7 +126,7 @@ class Parachute:
             case, the parachute will be ejected when the rocket reaches this
             height above ground level.
 
-            - The string "apogee," which triggers the parachute at apogee, i.e.,
+            - The string "apogee" which triggers the parachute at apogee, i.e.,
             when the rocket reaches its highest point and starts descending.
 
             Note: The function will be called according to the sampling rate

--- a/rocketpy/rocket/parachute.py
+++ b/rocketpy/rocket/parachute.py
@@ -184,7 +184,7 @@ class Parachute:
 
             self.triggerfunc = triggerfunc
 
-        elif trigger == "apogee":
+        elif trigger.lower() == "apogee":
             # trigger for apogee
             def triggerfunc(p, h, y):
                 # p = pressure considering parachute noise signal

--- a/rocketpy/rocket/parachute.py
+++ b/rocketpy/rocket/parachute.py
@@ -204,7 +204,7 @@ class Parachute:
             raise ValueError(
                 f"Unable to set the trigger function for parachute '{self.name}'. "
                 + "Trigger must be a callable, a float value or the string 'apogee'. "
-                + "See the Parachute class documentation for mor information."
+                + "See the Parachute class documentation for more information."
             )
 
     def __str__(self):

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -1092,7 +1092,7 @@ class Rocket:
             case, the parachute will be ejected when the rocket reaches this height
             above ground level.
 
-            - The string "apogee," which triggers the parachute at apogee, i.e.,
+            - The string "apogee" which triggers the parachute at apogee, i.e.,
             when the rocket reaches its highest point and starts descending.
 
             Note: The function will be called according to the sampling rate


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code maintenance (refactoring, formatting, tests)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
- The parachute trigger option "apogee" is case sensitive, so the triggerfunc is not set if you use "Apogee" or "APOGEE" instead of the expoected "apogee" value.
- Worse is that the Parachute class doesn't raise any error is the user pass a string like "Apogee" or "AnyOtherThing", so the user just gets an error message when simulating the Flight class

## New behavior
- Refactor the Parachute class init just a bit. 
- Using the built-in lower() method to compare the string without being case-sensitive.
- You're gonna know if the triggerfunc cannot be set after initializing the Parachute class.

## Breaking change
- [x] No

## Additional information

Reported by jackson.dendy on discord tonight, from the univ of Tenesse.