### PR TITLE
MNT: Add __repr__ method to Parachute class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ straightforward as possible.
 
 ### Changed
 
--
+- MNT: Add repr method to Parachute class [#490](https://github.com/RocketPy-Team/RocketPy/pull/490)
 
 ### Fixed
 

--- a/rocketpy/rocket/parachute.py
+++ b/rocketpy/rocket/parachute.py
@@ -220,6 +220,13 @@ class Parachute:
             self.cd_s,
         )
 
+    def __repr__(self):
+        """Representation method for the class, useful when debugging."""
+        return (
+            f"'{self.name}' parachute "
+            + f"(cd_s = {self.cd_s:.4f} m2, trigger = {self.trigger})"
+        )
+
     def info(self):
         """Prints information about the Parachute class."""
         self.prints.all()

--- a/rocketpy/rocket/parachute.py
+++ b/rocketpy/rocket/parachute.py
@@ -223,8 +223,8 @@ class Parachute:
     def __repr__(self):
         """Representation method for the class, useful when debugging."""
         return (
-            f"'{self.name}' parachute "
-            + f"(cd_s = {self.cd_s:.4f} m2, trigger = {self.trigger})"
+            f"<Parachute {self.name} "
+            + f"(cd_s = {self.cd_s:.4f} m2, trigger = {self.trigger})>"
         )
 
     def info(self):


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [ ] Code changes (bugfix, features)
- [x] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Enter text here...

## New behavior
This is useful for debugging or when you simply call `Rocket.parachutes` and want to see something more readable.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
Opening this now, can describe the PR later, sorry.
