### PR TITLE
FIX: Broken Function.get_value_opt for N-Dimensional Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ straightforward as possible.
 
 -
 
+## [v1.1.3] - 2023-11-29
+
+Here we write upgrading notes for brands. It's a team effort to make them as
+straightforward as possible.
+
+### Fixed
+
+-  FIX: Broken Function.get_value_opt for N-Dimensional Functions [#492](https://github.com/RocketPy-Team/RocketPy/pull/492/files) 
+
 ## [v1.1.2] - 2023-11-25
 
 You can install this version by running `pip install rocketpy==1.1.2`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = "2023, RocketPy Team"
 author = "RocketPy Team"
 
 # The full version, including alpha/beta/rc tags
-release = "1.1.2"
+release = "1.1.3"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -19,7 +19,7 @@ If you want to choose a specific version to guarantee compatibility, you may ins
 
 .. code-block:: shell
 
-    pip install rocketpy==1.1.2
+    pip install rocketpy==1.1.3
 
 
 Optional Installation Method: ``conda``

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -480,6 +480,7 @@ class Function:
 
         elif self.__interpolation__ == "shepard":
             x_data = self.source[:, 0:-1]  # Support for N-Dimensions
+            y_data = self.source[:, -1]
             len_y_data = len(y_data)  # A little speed up
 
             # change the function's name to avoid mypy's error

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ env_analysis_require = [
 
 setuptools.setup(
     name="rocketpy",
-    version="1.1.2",
+    version="1.1.3",
     install_requires=necessary_require,
     extras_require={
         "env_analysis": env_analysis_require,

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -73,8 +73,8 @@ def test_getters(func_from_csv, func_2d_from_csv):
     assert func_2d_from_csv.get_outputs() == ["Scalar"]
     assert func_2d_from_csv.get_interpolation_method() == "shepard"
     assert func_2d_from_csv.get_extrapolation_method() == "natural"
-    assert np.isclose(func_2d_from_csv.get_value(0, 0), 0.0, atol=1e-6)
-    assert np.isclose(func_2d_from_csv.get_value_opt(0, 0), 0.0, atol=1e-6)
+    assert np.isclose(func_2d_from_csv.get_value(0.1, 0.8), 0.058, atol=1e-6)
+    assert np.isclose(func_2d_from_csv.get_value_opt(0.1, 0.8), 0.058, atol=1e-6)
 
 
 def test_setters(func_from_csv, func_2d_from_csv):


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior

As reported by @styris00, the following code shows an error with `Function.get_value_opt` when used with 2D functions.

```
import numpy as np
from rocketpy import Function

arr = np.array([(1, 1, 2), (3, 6, 8),
            (8, 8, 9)])

myFun = Function(
    arr,
    interpolation="shepard",
    extrapolation="natural",
    title="myFun"
)

myFun.set_get_value_opt()

print(myFun.get_value(1, 1)
print(myFun.get_value_opt(1, 1))
```

Output is:

```
2.0
1.0
```

## New behavior

The bug was fixed.

## Breaking change

- [x] No
