### PR TITLE
TST: solid_motor.py testing refactors

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ def cesaroni_m1670():  # old name: solid_motor
     )
     return example_motor
 
+
 @pytest.fixture
 def cesaroni_m1670_shifted():  # old name: solid_motor
     """Create a simple object of the SolidMotor class to be used in the tests.
@@ -141,7 +142,8 @@ def cesaroni_m1670_shifted():  # old name: solid_motor
         coordinate_system_orientation="nozzle_to_combustion_chamber",
         reshape_thrust_curve=(5, 3000),
     )
-    return example_motor 
+    return example_motor
+
 
 @pytest.fixture
 def calisto_motorless():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,39 @@ def cesaroni_m1670():  # old name: solid_motor
     )
     return example_motor
 
+@pytest.fixture
+def cesaroni_m1670_shifted():  # old name: solid_motor
+    """Create a simple object of the SolidMotor class to be used in the tests.
+    This is the same motor that has been used in the getting started guide for
+    years. The difference relies in the thrust_source, which was shifted for
+    testing purposes.
+
+    Returns
+    -------
+    rocketpy.SolidMotor
+        A simple object of the SolidMotor class
+    """
+    example_motor = SolidMotor(
+        thrust_source="tests/fixtures/motor/Cesaroni_M1670_shifted.eng",
+        burn_time=3.9,
+        dry_mass=1.815,
+        dry_inertia=(0.125, 0.125, 0.002),
+        center_of_dry_mass_position=0.317,
+        nozzle_position=0,
+        grain_number=5,
+        grain_density=1815,
+        nozzle_radius=33 / 1000,
+        throat_radius=11 / 1000,
+        grain_separation=5 / 1000,
+        grain_outer_radius=33 / 1000,
+        grain_initial_height=120 / 1000,
+        grains_center_of_mass_position=0.397,
+        grain_initial_inner_radius=15 / 1000,
+        interpolation_method="linear",
+        coordinate_system_orientation="nozzle_to_combustion_chamber",
+        reshape_thrust_curve=(5, 3000),
+    )
+    return example_motor 
 
 @pytest.fixture
 def calisto_motorless():

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -232,23 +232,29 @@ def test_integral_spline_interpolation(request, func, a, b):
         atol=1e-3,
     )
 
+@pytest.mark.parametrize(
+    "func_input, derivative_input, expected_derivative",
+    [
+        (1, 0, 0),               # Test case 1: Function(1)
+        (lambda x: x, 0, 1),     # Test case 2: Function(lambda x: x)
+        (lambda x: x**2, 1, 2),  # Test case 3: Function(lambda x: x**2)
+    ],
+)
+def test_differentiate(func_input, derivative_input, expected_derivative):
+    """Test the differentiate method of the Function class.
 
-def test_differentiate():
-    """Tests the differentiation method of the Function class.
-    Both with respect to return instances and expected behaviour.
+    Parameters
+    ----------
+    func_input : function
+        A function object created from a list of values.
+    derivative_input : int
+        Point at which to differentiate.
+    expected_derivative : float
+        Expected value of the derivative.
     """
-    func = Function(1)
-    assert isinstance(func.differentiate(0), float)
-    assert np.isclose(func.differentiate(5), 0)
-
-    func_x = Function(lambda x: x)
-    assert isinstance(func_x.differentiate(0), float)
-    assert np.isclose(func_x.differentiate(0), 1)
-
-    f_square = Function(lambda x: x**2)
-    assert isinstance(f_square.differentiate(1), float)
-    assert np.isclose(f_square.differentiate(1), 2)
-
+    func = Function(func_input)
+    assert isinstance(func.differentiate(derivative_input), float)
+    assert np.isclose(func.differentiate(derivative_input), expected_derivative)
 
 def test_get_value():
     """Tests the get_value method of the Function class.

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -232,11 +232,12 @@ def test_integral_spline_interpolation(request, func, a, b):
         atol=1e-3,
     )
 
+
 @pytest.mark.parametrize(
     "func_input, derivative_input, expected_derivative",
     [
-        (1, 0, 0),               # Test case 1: Function(1)
-        (lambda x: x, 0, 1),     # Test case 2: Function(lambda x: x)
+        (1, 0, 0),  # Test case 1: Function(1)
+        (lambda x: x, 0, 1),  # Test case 2: Function(lambda x: x)
         (lambda x: x**2, 1, 2),  # Test case 3: Function(lambda x: x**2)
     ],
 )
@@ -255,6 +256,7 @@ def test_differentiate(func_input, derivative_input, expected_derivative):
     func = Function(func_input)
     assert isinstance(func.differentiate(derivative_input), float)
     assert np.isclose(func.differentiate(derivative_input), expected_derivative)
+
 
 def test_get_value():
     """Tests the get_value method of the Function class.

--- a/tests/test_solidmotor.py
+++ b/tests/test_solidmotor.py
@@ -254,11 +254,14 @@ def tests_export_eng_asserts_exported_values_correct(cesaroni_m1670):
         [3.9, 0.0],
     ]
 
+
 @pytest.mark.parametrize("tuple_parametric", [(5, 3000)])
-def test_reshape_thrust_curve_asserts_resultant_thrust_curve_correct(cesaroni_m1670_shifted, tuple_parametric, linear_func):
-    """Tests the reshape_thrust_curve. It checks whether the resultant 
-    thrust curve is correct when the user passes a certain tuple to the 
-    reshape_thrust_curve attribute. Also checking for the correct return 
+def test_reshape_thrust_curve_asserts_resultant_thrust_curve_correct(
+    cesaroni_m1670_shifted, tuple_parametric, linear_func
+):
+    """Tests the reshape_thrust_curve. It checks whether the resultant
+    thrust curve is correct when the user passes a certain tuple to the
+    reshape_thrust_curve attribute. Also checking for the correct return
     data type.
 
     Parameters
@@ -269,7 +272,9 @@ def test_reshape_thrust_curve_asserts_resultant_thrust_curve_correct(cesaroni_m1
         Tuple passed to the reshape_thrust_curve method.
     """
 
-    assert isinstance(cesaroni_m1670_shifted.reshape_thrust_curve(linear_func, 1, 3000), Function)
+    assert isinstance(
+        cesaroni_m1670_shifted.reshape_thrust_curve(linear_func, 1, 3000), Function
+    )
     thrust_reshaped = cesaroni_m1670_shifted.thrust.get_source()
 
     assert thrust_reshaped[1][0] == 0.155 * (tuple_parametric[0] / 4)


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [ ] Code changes (bugfix, features)
- [X] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [ ] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

1. Currently, test_solidmotor.py creates a motor inside the testing module called 'test_reshape_thrust_curve_asserts_resultant_thrust_curve_correct', which is not adequate. This method also does not contains comments.

2. Inside the test_function.py testing module the 'test_differentiate' method relies on manually passing the inputs. 

## New behavior
<!-- Describe changes introduced by this PR. -->

1. The solution employed was to create a motor in conftest.py, which was called 'cesaroni_m1670_shifted', and which was used in the test method called 'test_reshape_thrust_curve_asserts_resultant_thrust_curve_correct'. Comments were also made.

2. It was properly refactored and new comments were made. Also, @pytest.mark.parametrize was introduced to make the test method ready to handle more test cases. This test was introduced in https://github.com/RocketPy-Team/RocketPy/pull/467.


## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

This PR is part of the effort of reorganizing the test suite. It does so by making sure that the tests which could certainly be classified as unit tests are properly refactored and implemented before the test suite is reorganized. For more info, check https://github.com/RocketPy-Team/RocketPy/issues/480.
