### PR TITLE
DOC: Change from % to ! in the first cell to run properly in Colab.

### DIFF
--- a/docs/notebooks/getting_started_colab.ipynb
+++ b/docs/notebooks/getting_started_colab.ipynb
@@ -22,10 +22,9 @@
     "We start by setting up our environment. To run this notebook, we will need:\n",
     "\n",
     "- RocketPy\n",
-    "- netCDF4 (to get weather forecasts)\n",
     "- Data files (we will clone RocketPy's repository for these)\n",
     "\n",
-    "Therefore, let's run the following lines of code:\n"
+    "Therefore, let's run the following lines of code:"
    ]
   },
   {
@@ -38,8 +37,8 @@
    },
    "outputs": [],
    "source": [
-    "%pip install rocketpy netCDF4\n",
-    "%git clone https://github.com/giovaniceotto/RocketPy.git"
+    "!pip install rocketpy\n",
+    "!git clone https://github.com/giovaniceotto/RocketPy.git"
    ]
   },
   {
@@ -72,16 +71,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 1,
    "metadata": {
     "colab": {},
@@ -101,7 +90,7 @@
     "id": "ImgkhEkZNVE8"
    },
    "source": [
-    "If you are using Jupyter Notebooks, it is recommended to run the following line to make matplotlib plots which will be shown later interactive and higher quality.\n"
+    "It is recommended to run the following line to make matplotlib plots which will be shown later interactive and higher quality.\n"
    ]
   },
   {


### PR DESCRIPTION
## Pull request type

- [x] ReadMe, Docs and GitHub updates

## Checklist

- [x] Docs have been reviewed and added / updated

## Current behavior

The first code cell of our Google Colab Getting Started Notebook fails because it is using `%` instead of `!` to execute shell commands.

## New behavior

1. In the first code cell, `%` was replaced by `!` and `netCDF` was removed from `pip install` since it is already installed when RocketPy is installed now.
2. ``%load_ext autoreload` was removed since it is not relevant for the Getting Started notebook.
3. Text cells were adjusted accordingly. 

## Breaking change

- [x] No

## Additional information

This does not affect the RocketPy package in PyPI, so a new release is not necessary. As it affects only an example referenced in the ReadMe, I suggest merging it directly to master soon.

You can run the new fixed notebook here: https://colab.research.google.com/github/RocketPy-Team/rocketpy/blob/doc/fix-getting-started-colab-notebook-error/docs/notebooks/getting_started_colab.ipynb
