### PR TITLE
FIX: changes Generic Motor exhaust velocity to cached property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,14 +42,14 @@ straightforward as possible.
 
 -
 
-## [v1.1.3] - 2023-11-29
+## [v1.1.3] - 2023-11-30
 
-Here we write upgrading notes for brands. It's a team effort to make them as
-straightforward as possible.
+You can install this version by running `pip install rocketpy==1.1.3`
 
 ### Fixed
 
--  FIX: Broken Function.get_value_opt for N-Dimensional Functions [#492](https://github.com/RocketPy-Team/RocketPy/pull/492/files) 
+-  FIX: Broken Function.get_value_opt for N-Dimensional Functions [#492](https://github.com/RocketPy-Team/RocketPy/pull/492) 
+-  FIX: Never ending Flight simulations when using a GenericMotor [#497](https://github.com/RocketPy-Team/RocketPy/pull/497) 
 
 ## [v1.1.2] - 2023-11-25
 

--- a/rocketpy/motors/hybrid_motor.py
+++ b/rocketpy/motors/hybrid_motor.py
@@ -1,4 +1,4 @@
-from ..mathutils.function import funcify_method, reset_funcified_methods
+from ..mathutils.function import Function, funcify_method, reset_funcified_methods
 from ..plots.hybrid_motor_plots import _HybridMotorPlots
 from ..prints.hybrid_motor_prints import _HybridMotorPrints
 from .liquid_motor import LiquidMotor
@@ -372,7 +372,9 @@ class HybridMotor(Motor):
         self.exhaust_velocity : Function
             Gas exhaust velocity of the motor.
         """
-        return self.total_impulse / self.propellant_initial_mass
+        return Function(
+            self.total_impulse / self.propellant_initial_mass
+        ).set_discrete_based_on_model(self.thrust)
 
     @funcify_method("Time (s)", "Mass (kg)")
     def propellant_mass(self):

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -1214,7 +1214,7 @@ class GenericMotor(Motor):
         """
         return self.propellant_initial_mass
 
-    @funcify_method("Time (s)", "Exhaust velocity (m/s)")
+    @cached_property
     def exhaust_velocity(self):
         """Exhaust velocity by assuming it as a constant. The formula used is
         total impulse/propellant initial mass.

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -1214,7 +1214,7 @@ class GenericMotor(Motor):
         """
         return self.propellant_initial_mass
 
-    @cached_property
+    @funcify_method("Time (s)", "Exhaust velocity (m/s)")
     def exhaust_velocity(self):
         """Exhaust velocity by assuming it as a constant. The formula used is
         total impulse/propellant initial mass.

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -450,7 +450,11 @@ class Motor(ABC):
         rate should not be greater than `total_mass_flow_rate`, otherwise the
         grains mass flow rate will be negative, losing physical meaning.
         """
-        return -1 * self.thrust / self.exhaust_velocity
+        return (
+            -1
+            * self.thrust
+            / self.exhaust_velocity.set_discrete_based_on_model(self.thrust)
+        )
 
     @property
     @abstractmethod
@@ -1232,7 +1236,11 @@ class GenericMotor(Motor):
         velocity. The formula used is the opposite of thrust divided by
         exhaust velocity.
         """
-        return -1 * self.thrust / self.exhaust_velocity
+        return (
+            -1
+            * self.thrust
+            / self.exhaust_velocity.set_discrete_based_on_model(self.thrust)
+        )
 
     @funcify_method("Time (s)", "center of mass (m)")
     def center_of_propellant_mass(self):

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -450,11 +450,7 @@ class Motor(ABC):
         rate should not be greater than `total_mass_flow_rate`, otherwise the
         grains mass flow rate will be negative, losing physical meaning.
         """
-        return (
-            -1
-            * self.thrust
-            / self.exhaust_velocity.set_discrete_based_on_model(self.thrust)
-        )
+        return -1 * self.thrust / self.exhaust_velocity
 
     @property
     @abstractmethod
@@ -1228,7 +1224,9 @@ class GenericMotor(Motor):
         self.exhaust_velocity : Function
             Gas exhaust velocity of the motor.
         """
-        return self.total_impulse / self.propellant_initial_mass
+        return Function(
+            self.total_impulse / self.propellant_initial_mass
+        ).set_discrete_based_on_model(self.thrust)
 
     @funcify_method("Time (s)", "Mass Flow Rate (kg/s)")
     def mass_flow_rate(self):
@@ -1236,11 +1234,7 @@ class GenericMotor(Motor):
         velocity. The formula used is the opposite of thrust divided by
         exhaust velocity.
         """
-        return (
-            -1
-            * self.thrust
-            / self.exhaust_velocity.set_discrete_based_on_model(self.thrust)
-        )
+        return -1 * self.thrust / self.exhaust_velocity
 
     @funcify_method("Time (s)", "center of mass (m)")
     def center_of_propellant_mass(self):

--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -381,7 +381,9 @@ class SolidMotor(Motor):
         self.exhaust_velocity : Function
             Gas exhaust velocity of the motor.
         """
-        return self.total_impulse / self.propellant_initial_mass
+        return Function(
+            self.total_impulse / self.propellant_initial_mass
+        ).set_discrete_based_on_model(self.thrust)
 
     @property
     def propellant_initial_mass(self):


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [ ] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior

`GenericMotor.exhaust_velocity` is being decorated by `funcify_method`, which makes it (a float essentially) into a `lambda` defined `Function`. This causes everything that depends on it algebraically to become `lambda` defined `Functions` as well.

More specifically, this contaminates `GenericMotor.mass_flow_rate`, which in turn contaminates `GenericMotor.propellant_mass` (which actually includes an `integral_function` of the `lambda` `GenericMotor.exhaust_velocity` 🫣). Well, in the end, this contaminates `Rocket.total_mass`, which is used extensively by the `Flight` class during a simulation.

In summary, this use of `funcify_method` causes the `Flight` class to take forever (literally) to run.

## New behavior

What can I say? Changing the decorator from `funcify_method` to `cached_property` makes the sun shine once again, solving everything.

## Breaking change

- [x] No

