### PR TITLE
MNT: Update interpolation method in linearly_interpolated_func

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1109,11 +1109,11 @@ def linearly_interpolated_func():
     Returns
     -------
     Function
-        Piece-wise linearly interpolated, with constant extrapolation
+        Linearly interpolated Function, with constant extrapolation
     """
     return Function(
         [[0, 0], [1, 7], [2, -3], [3, -1], [4, 3]],
-        interpolation="spline",
+        interpolation="linear",
         extrapolation="constant",
     )
 


### PR DESCRIPTION
linearly_interpolated_func


## Pull request type
<!-- Remove unchecked box items. -->

- [ ] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [ ] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
I found this bug on a pytest fixture.

## New behavior
The `linearly_interpolated_func` fixture is now using the linear interpolation method
Updated the docstring as well.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [ ] No

## Additional information
the tests are passing even if adter the change