### PR TITLE
BUG: EmptyMotor is breaking  the Rocket.draw() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ straightforward as possible.
 ### Fixed
 
 - ENH: Parachute trigger doesn't work if "Apogee" is used instead of "apogee" [#489](https://github.com/RocketPy-Team/RocketPy/pull/489)
+- FIX: EmptyMotor is breaking the Rocket.draw() method [#516](https://github.com/RocketPy-Team/RocketPy/pull/516)
 
 ## [v1.1.4] - 2023-12-07
 

--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 
-from rocketpy.motors import HybridMotor, LiquidMotor, SolidMotor
+from rocketpy.motors import EmptyMotor, HybridMotor, LiquidMotor, SolidMotor
 from rocketpy.rocket.aero_surface import Fins, NoseCone, Tail
 
 
@@ -332,10 +332,6 @@ class _RocketPlots:
             self.rocket.motor_position + self.rocket.motor.nozzle_position * total_csys
         )
 
-        nozzle = self.rocket.motor.plots._generate_nozzle(
-            translate=(nozzle_position, 0), csys=self.rocket._csys
-        )
-
         # List of motor patches
         motor_patches = []
 
@@ -414,14 +410,18 @@ class _RocketPlots:
                 motor_patches += [tank]
 
         # add nozzle last so it is in front of the other patches
-        motor_patches += [nozzle]
-        outline = self.rocket.motor.plots._generate_motor_region(
-            list_of_patches=motor_patches
-        )
-        # add outline first so it is behind the other patches
-        ax.add_patch(outline)
-        for patch in motor_patches:
-            ax.add_patch(patch)
+        if not isinstance(self.rocket.motor, EmptyMotor):
+            nozzle = self.rocket.motor.plots._generate_nozzle(
+                translate=(nozzle_position, 0), csys=self.rocket._csys
+            )
+            motor_patches += [nozzle]
+            outline = self.rocket.motor.plots._generate_motor_region(
+                list_of_patches=motor_patches
+            )
+            # add outline first so it is behind the other patches
+            ax.add_patch(outline)
+            for patch in motor_patches:
+                ax.add_patch(patch)
 
         # Check if nozzle is beyond the last surface, if so draw a tube
         # to it, with the radius of the last surface


### PR DESCRIPTION
## Pull request type
<!-- Remove unchecked box items. -->

- [ ] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)(not needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
Try to call the Rocket.draw() method without adding a motor to the rocket. The EmptyMotor will be used as default, the plot will be created but an error will also be displayed 
![image](https://github.com/RocketPy-Team/RocketPy/assets/63590233/87a6b6ce-0fe9-4e30-824a-04f28875b3ba)

## New behavior
Changed the order of some operations and solved the problem.

## Breaking change

- [x] No

## Additional information
Bug reported from UPV-Faraday rocketry team (Valencia, Spain).