### PR TITLE
BUG: 3D trajectory plot not labeling axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ straightforward as possible.
 - ENH: Parachute trigger doesn't work if "Apogee" is used instead of "apogee" [#489](https://github.com/RocketPy-Team/RocketPy/pull/489)
 - BUG: fin_flutter_analysis doesn't find any fin set [#510](https://github.com/RocketPy-Team/RocketPy/pull/510)
 - FIX: EmptyMotor is breaking the Rocket.draw() method [#516](https://github.com/RocketPy-Team/RocketPy/pull/516)
+- BUG: 3D trajectory plot not labeling axes [#533](https://github.com/RocketPy-Team/RocketPy/pull/533)
 
 ## [v1.1.4] - 2023-12-07
 

--- a/rocketpy/plots/flight_plots.py
+++ b/rocketpy/plots/flight_plots.py
@@ -63,9 +63,8 @@ class _FlightPlots:
         -------
         None
         """
-
-        # Get max and min x and y
         max_z = max(self.flight.z[:, 1] - self.flight.env.elevation)
+        min_z = min(self.flight.z[:, 1] - self.flight.env.elevation)
         max_x = max(self.flight.x[:, 1])
         min_x = min(self.flight.x[:, 1])
         max_y = max(self.flight.y[:, 1])
@@ -73,8 +72,7 @@ class _FlightPlots:
         max_xy = max(max_x, max_y)
         min_xy = min(min_x, min_y)
 
-        # Create figure
-        fig1 = plt.figure(figsize=(9, 9))
+        _ = plt.figure(figsize=(9, 9))
         ax1 = plt.subplot(111, projection="3d")
         ax1.plot(
             self.flight.x[:, 1], self.flight.y[:, 1], zs=0, zdir="z", linestyle="--"
@@ -99,18 +97,29 @@ class _FlightPlots:
             self.flight.z[:, 1] - self.flight.env.elevation,
             linewidth="2",
         )
-        ax1.scatter(0, 0, 0)
+        ax1.scatter(
+            self.flight.x(0),
+            self.flight.y(0),
+            self.flight.z(0) - self.flight.env.elevation,
+            color="black",
+        )
+        ax1.scatter(
+            self.flight.x(self.flight.t_final),
+            self.flight.y(self.flight.t_final),
+            self.flight.z(self.flight.t_final) - self.flight.env.elevation,
+            color="red",
+            marker="X",
+        )
         ax1.set_xlabel("X - East (m)")
         ax1.set_ylabel("Y - North (m)")
         ax1.set_zlabel("Z - Altitude Above Ground Level (m)")
         ax1.set_title("Flight Trajectory")
-        ax1.set_zlim3d([0, max_z])
+        ax1.set_zlim3d([min_z, max_z])
         ax1.set_ylim3d([min_xy, max_xy])
         ax1.set_xlim3d([min_xy, max_xy])
         ax1.view_init(15, 45)
+        ax1.set_box_aspect(None, zoom=0.95)  # 95% for label adjustment
         plt.show()
-
-        return None
 
     def linear_kinematics_data(self):
         """Prints out all Kinematics graphs available about the Flight


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [ ] Tests for the changes have been added (if needed) (*not needed*)
- [ ] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
It's getting into my nerves since 2021 or even more!
![image](https://github.com/RocketPy-Team/RocketPy/assets/63590233/3c6550f6-d8bd-4ee0-ad71-82534600e729)

## New behavior
![image](https://github.com/RocketPy-Team/RocketPy/assets/63590233/782626a5-89f1-47c2-a2f0-6aa70d383d4b)

## Breaking change

- [x] nooo

## Additional information

- This is the magic line: `ax1.set_box_aspect(None, zoom=0.95)`
- And this is the wizard that has shown me how to perform such skill: https://stackoverflow.com/a/77580433