### PR TITLE
BUG: Parachute Pressures not being Set before All Info.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -435,6 +435,7 @@ disable=raw-checker-failed,
         use-implicit-booleaness-not-comparison-to-zero,
         no-else-return,
         inconsistent-return-statements,
+        unspecified-encoding,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ straightforward as possible.
 
 ### Fixed
 
+- BUG: Parachute Pressures not being Set before All Info. [#534](https://github.com/RocketPy-Team/RocketPy/pull/534)
 - BUG: Invalid Arguments on Two Dimensional Discretize. [#521](https://github.com/RocketPy-Team/RocketPy/pull/521)
 
 ## [v1.1.4] - 2023-12-07

--- a/rocketpy/plots/flight_plots.py
+++ b/rocketpy/plots/flight_plots.py
@@ -817,7 +817,6 @@ class _FlightPlots:
         if len(self.flight.parachute_events) > 0:
             for parachute in self.flight.rocket.parachutes:
                 print("\nParachute: ", parachute.name)
-                self.flight._calculate_pressure_signal()
                 parachute.noise_signal_function()
                 parachute.noisy_pressure_signal_function()
                 parachute.clean_pressure_signal_function()

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1065,6 +1065,7 @@ class Flight:
                                         )
 
         self.t_final = self.t
+        self._calculate_pressure_signal()
         if verbose:
             print("Simulation Completed at Time: {:3.4f} s".format(self.t))
 
@@ -3089,8 +3090,8 @@ class Flight:
             else:
                 for parachute in self.rocket.parachutes:
                     for t in time_points:
-                        p_cl = parachute.clean_pressure_signal(t)
-                        p_ns = parachute.noisy_pressure_signal(t)
+                        p_cl = parachute.clean_pressure_signal_function(t)
+                        p_ns = parachute.noisy_pressure_signal_function(t)
                         file.write(f"{t:f}, {p_cl:.5f}, {p_ns:.5f}\n")
                     # We need to save only 1 parachute data
                     break

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -949,3 +949,31 @@ def test_aerodynamic_moments(flight_calisto_custom_wind, flight_time, expected_v
         test.M2(t),
         test.M3(t),
     ), f"Assertion error for moment vector at {expected_attr}."
+
+
+def test_export_pressures(flight_calisto_robust):
+    """Tests if the method Flight.export_pressures is working as intended.
+
+    Parameters
+    ----------
+    flight_calisto_robust : Flight
+        Flight object to be tested. See the conftest.py file for more info
+        regarding this pytest fixture.
+    """
+    file_name = "pressures.csv"
+    time_step = 0.5
+    parachute = flight_calisto_robust.rocket.parachutes[0]
+
+    flight_calisto_robust.export_pressures(file_name, time_step)
+
+    with open(file_name, "r") as file:
+        contents = file.read()
+
+    expected_data = ""
+    for t in np.arange(0, flight_calisto_robust.t_final, time_step):
+        p_cl = parachute.clean_pressure_signal_function(t)
+        p_ns = parachute.noisy_pressure_signal_function(t)
+        expected_data += f"{t:f}, {p_cl:.5f}, {p_ns:.5f}\n"
+
+    assert contents == expected_data
+    os.remove(file_name)


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

The method `export_pressure` incorrectly calls the `lists`: `parachute.clean_pressure_signal` and `noisy_pressure_signal` as if they were functions. Furthermore, this data is not set before the call of the `all_info`, which could lead to invalid exports if it was working.

The issue when trying to export the pressure was: 

```py
   3091 for parachute in self.rocket.parachutes:
   3092     for t in time_points:
-> 3093         p_cl = parachute.clean_pressure_signal(t)
   3094         p_ns = parachute.noisy_pressure_signal(t)
   3095         file.write(f"{t:f}, {p_cl:.5f}, {p_ns:.5f}\n")

TypeError: 'list' object is not callable
```

## New behavior
<!-- Describe changes introduced by this PR. -->

The employed fix was to call the method that set these values not in the `all_info`, but after `Flight` computations. On top of that, the incorrect `list` calls were substituted by their `_function` counterparts.

Now the data is being exported correctly: 

```
0.000000, 85639.55296, 85652.28657
1.000000, 85228.90121, 85223.88463
...
```
## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [X] No

