### PR TITLE
MNT: Encapsulate quaternion conversions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -436,6 +436,7 @@ disable=raw-checker-failed,
         no-else-return,
         inconsistent-return-statements,
         unspecified-encoding,
+        no-member, # because we use funcify_method decorator
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ straightforward as possible.
 - MNT: Add repr method to Parachute class [#490](https://github.com/RocketPy-Team/RocketPy/pull/490)
 - ENH: Function Reverse Arithmetic Priority [#488](https://github.com/RocketPy-Team/RocketPy/pull/488)
 - DOC: Update Header Related Docs
+- MNT: Encapsulate quaternion conversions [#537](https://github.com/RocketPy-Team/RocketPy/pull/537)
 
 ### Fixed
 

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -13,9 +13,9 @@ from ..plots.flight_plots import _FlightPlots
 from ..prints.flight_prints import _FlightPrints
 from ..tools import (
     find_closest,
-    quaternions_to_phi,
+    quaternions_to_spin,
     quaternions_to_precession,
-    quaternions_to_theta,
+    quaternions_to_nutation,
 )
 
 
@@ -2308,7 +2308,7 @@ class Flight:
     @funcify_method("Time (s)", "Spin Angle - φ (°)", "spline", "constant")
     def phi(self):
         """Spin angle as a Function of time."""
-        phi = quaternions_to_phi(
+        phi = quaternions_to_spin(
             self.e0.y_array, self.e1.y_array, self.e2.y_array, self.e3.y_array
         )
         return np.column_stack([self.time, phi])
@@ -2316,7 +2316,7 @@ class Flight:
     @funcify_method("Time (s)", "Nutation Angle - θ (°)", "spline", "constant")
     def theta(self):
         """Nutation angle as a Function of time."""
-        theta = quaternions_to_theta(self.e1.y_array, self.e2.y_array)
+        theta = quaternions_to_nutation(self.e1.y_array, self.e2.y_array)
         return np.column_stack([self.time, theta])
 
     # Fluid Mechanics variables

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -11,7 +11,12 @@ from ..mathutils.function import Function, funcify_method
 from ..mathutils.vector_matrix import Matrix, Vector
 from ..plots.flight_plots import _FlightPlots
 from ..prints.flight_prints import _FlightPrints
-from ..tools import find_closest
+from ..tools import (
+    find_closest,
+    quaternions_to_phi,
+    quaternions_to_precession,
+    quaternions_to_theta,
+)
 
 
 class Flight:
@@ -2295,33 +2300,24 @@ class Flight:
     @funcify_method("Time (s)", "Precession Angle - ψ (°)", "spline", "constant")
     def psi(self):
         """Precession angle as a Function of time."""
-        psi = (180 / np.pi) * (
-            np.arctan2(self.e3[:, 1], self.e0[:, 1])
-            + np.arctan2(-self.e2[:, 1], -self.e1[:, 1])
-        )  # Precession angle
-        psi = np.column_stack([self.time, psi])  # Precession angle
-        return psi
+        psi = quaternions_to_precession(
+            self.e0.y_array, self.e1.y_array, self.e2.y_array, self.e3.y_array
+        )
+        return np.column_stack([self.time, psi])
 
     @funcify_method("Time (s)", "Spin Angle - φ (°)", "spline", "constant")
     def phi(self):
         """Spin angle as a Function of time."""
-        phi = (180 / np.pi) * (
-            np.arctan2(self.e3[:, 1], self.e0[:, 1])
-            - np.arctan2(-self.e2[:, 1], -self.e1[:, 1])
-        )  # Spin angle
-        phi = np.column_stack([self.time, phi])  # Spin angle
-        return phi
+        phi = quaternions_to_phi(
+            self.e0.y_array, self.e1.y_array, self.e2.y_array, self.e3.y_array
+        )
+        return np.column_stack([self.time, phi])
 
     @funcify_method("Time (s)", "Nutation Angle - θ (°)", "spline", "constant")
     def theta(self):
         """Nutation angle as a Function of time."""
-        theta = (
-            (180 / np.pi)
-            * 2
-            * np.arcsin(-((self.e1[:, 1] ** 2 + self.e2[:, 1] ** 2) ** 0.5))
-        )  # Nutation angle
-        theta = np.column_stack([self.time, theta])  # Nutation angle
-        return theta
+        theta = quaternions_to_theta(self.e1.y_array, self.e2.y_array)
+        return np.column_stack([self.time, theta])
 
     # Fluid Mechanics variables
     # Freestream Velocity

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -3,6 +3,7 @@ import importlib.metadata
 import re
 from bisect import bisect_left
 
+import numpy as np
 import pytz
 from cftime import num2pydate
 from packaging import version as packaging_version
@@ -379,6 +380,69 @@ def check_requirement_version(module_name, version):
             + f"version by running 'pip install {module_name}{version}'"
         )
     return True
+
+
+# Flight
+
+
+def quaternions_to_precession(e0, e1, e2, e3):
+    """Calculates the Precession angle
+
+    Parameters
+    ----------
+    e0 : float
+        Euler parameter 0, must be between -1 and 1
+    e1 : float
+        Euler parameter 1, must be between -1 and 1
+    e2 : float
+        Euler parameter 2, must be between -1 and 1
+    e3 : float
+        Euler parameter 3, must be between -1 and 1
+    Returns
+    -------
+    float
+        Euler Precession angle in degrees
+    """
+    return (180 / np.pi) * (np.arctan2(e3, e0) + np.arctan2(-e2, -e1))
+
+
+def quaternions_to_phi(e0, e1, e2, e3):
+    """Calculates the Spin angle from quaternions.
+
+    Parameters
+    ----------
+    e0 : float
+        Euler parameter 0, must be between -1 and 1
+    e1 : float
+        Euler parameter 1, must be between -1 and 1
+    e2 : float
+        Euler parameter 2, must be between -1 and 1
+    e3 : float
+        Euler parameter 3, must be between -1 and 1
+
+    Returns
+    -------
+    float
+        Euler Spin angle in degrees
+    """
+    return (180 / np.pi) * (np.arctan2(e3, e0) - np.arctan2(-e2, -e1))
+
+
+def quaternions_to_theta(e1, e2):
+    """Calculates the Nutation angle from quaternions.
+
+    Parameters
+    ----------
+    e1 : float
+        Euler parameter 1, must be between -1 and 1
+    e2 : float
+        Euler parameter 2, must be between -1 and 1
+    Returns
+    -------
+    float
+        Euler Nutation angle in degrees
+    """
+    return (180 / np.pi) * 2 * np.arcsin(-((e1**2 + e2**2) ** 0.5))
 
 
 if __name__ == "__main__":

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -406,7 +406,7 @@ def quaternions_to_precession(e0, e1, e2, e3):
     return (180 / np.pi) * (np.arctan2(e3, e0) + np.arctan2(-e2, -e1))
 
 
-def quaternions_to_phi(e0, e1, e2, e3):
+def quaternions_to_spin(e0, e1, e2, e3):
     """Calculates the Spin angle from quaternions.
 
     Parameters
@@ -428,7 +428,7 @@ def quaternions_to_phi(e0, e1, e2, e3):
     return (180 / np.pi) * (np.arctan2(e3, e0) - np.arctan2(-e2, -e1))
 
 
-def quaternions_to_theta(e1, e2):
+def quaternions_to_nutation(e1, e2):
     """Calculates the Nutation angle from quaternions.
 
     Parameters


### PR DESCRIPTION
## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)

## Checklist

- [ ] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
We take quaternions (euler parameters) and calculate euler angles inside the flight class, but this code cannot be reused in other applications.

## New behavior
- The quaternions -> angles conversions were moved to the tools.py module, thus allowing for other classes to access these functions.
- The Flight class was adjusted to use the new functions.

## Breaking change

- [x] No (I'm not sure if we should create a new .py file just to put these functions or not.) 

## Additional information
This is going to be quite useful for the `rocketpy.simulation.FlightDataImporter` class.