### PR TITLE
ENH: improve Function.low_pass_filter and adds docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ straightforward as possible.
 - MNT: Add repr method to Parachute class [#490](https://github.com/RocketPy-Team/RocketPy/pull/490)
 - ENH: Function Reverse Arithmetic Priority [#488](https://github.com/RocketPy-Team/RocketPy/pull/488)
 - DOC: Update Header Related Docs
+- MNT: improve the low pass filter and document an example [#538](https://github.com/RocketPy-Team/RocketPy/pull/538)
 
 ### Fixed
 

--- a/docs/user/function.rst
+++ b/docs/user/function.rst
@@ -438,6 +438,30 @@ Let's export the gaussian function to a CSV file:
     import os
     os.remove("gaussian.csv")
 
+f. Filter data
+~~~~~~~~~~~~~~
+
+Since rocketpy version 1.2.0, the ``Function`` class supports filtering the
+source data. This is accomplished by the method :meth:`rocketpy.Function.low_pass_filter`
+and allows for easy data filtering for further analysis.
+
+Let's filter an example function:
+
+.. jupyter-execute::
+
+    x = np.linspace(-4, 4, 1000)
+    y = np.sin(x) + np.random.normal(0, 0.1, 1000)
+
+    f = Function(list(zip(x, y)), inputs="x", outputs="f(x)")
+
+    # Filter the function
+    f_filtered = f.low_pass_filter(0.5)
+
+    # Compare the function with the filtered function
+    Function.compare_plots(
+        [(f, "Original"), (f_filtered, "Filtered")], lower=-4, upper=4
+    )
+
 ........
 
 This guide shows some of the capabilities of the ``Function`` class, but there are many other functionalities to enhance your analysis. Do not hesitate in tanking a look at the documentation :class:`rocketpy.Function`.

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -1118,7 +1118,10 @@ class Function:
         )
 
     def low_pass_filter(self, alpha, file_path=None):
-        """Implements a low pass filter with a moving average filter
+        """Implements a low pass filter with a moving average filter. This does
+        not mutate the original Function object, but returns a new one with the
+        filtered source. The filtered source is also saved to a CSV file if a
+        file path is given.
 
         Parameters
         ----------
@@ -1128,7 +1131,7 @@ class Function:
             filtered function returned will match the function the smaller
             alpha is, the smoother the filtered function returned will be
             (but with a phase shift)
-        file_path : string
+        file_path : string, optional
             File path or file name of the CSV to save. Don't save any CSV if
             if no argument is passed. Initiated to None.
 
@@ -1146,14 +1149,16 @@ class Function:
                 alpha * self.source[i] + (1 - alpha) * filtered_signal[i - 1]
             )
 
-        # Save the new csv file with filtered data
         if isinstance(file_path, str):
-            np.savetxt(file_path, filtered_signal, delimiter=",")
+            self.savetxt(file_path)
 
         return Function(
             source=filtered_signal,
+            inputs=self.__inputs__,
+            outputs=self.__outputs__,
             interpolation=self.__interpolation__,
             extrapolation=self.__extrapolation__,
+            title=self.title,
         )
 
     # Define all presentation methods


### PR DESCRIPTION
## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)
- [x] ReadMe, Docs and GitHub updates

## Checklist
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
While using the new low_pass_filter method, I noticed some minor adjustments could be done, let's see:

## New behavior

- Persist the inputs, outputs and title of the original Function
- Improve the method docstring
- Add an example to the .rst file


## Breaking change
- [x] No
