### PR TITLE
MNT: update Makefile

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 - [ ] Tests for the changes have been added (if needed)
 - [ ] Docs have been reviewed and added / updated
 - [ ] Lint (`black rocketpy/ tests/`) has passed locally 
-- [ ] All tests (`pytest --runslow`) have passed locally
+- [ ] All tests (`python3 -m pytest tests -m slow --runslow`) have passed locally
 - [ ] `CHANGELOG.md` has been updated (if relevant)
 
 ## Current behavior

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ MANIFEST
 pip-log.txt
 pip-delete-this-directory.txt
 
-# Unit test / coverage reports
+# Unit test / coverage reports / lints reports
 htmlcov/
 .tox/
 .nox/
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+.pylint-report.txt
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,32 @@
-test:
-	python -m pytest tests -vv
+pytest:
+	python3 -m pytest tests
 
-testfile:
-	python -m pytest tests/$(file) -vv
+pytest-slow:
+	python3 -m pytest tests -vv -m slow --runslow
 
-tests:
-	test
-
-coverage: 
-	python -m pytest --cov=rocketpy tests -vv
+coverage:
+	python3 -m pytest --cov=rocketpy tests
 
 coverage-report:
-	python -m pytest --cov=rocketpy tests -vv --cov-report html
+	python3 -m pytest --cov=rocketpy tests --cov-report html
 
-install: 
-	python -m pip install --upgrade pip
+install:
+	python3 -m pip install --upgrade pip
 	pip install -r requirements.txt
-	python setup.py install
+	pip install -r requirements-optional.txt
+	pip install -e .
 
-verify-lint:
-	flake8 --select BLK rocketpy
-	flake8 --select BLK test
+isort:
+	isort --profile black rocketpy/ tests/ docs/
 
-lint:
-	black rocketpy
-	black tests
+black:
+	black rocketpy/ tests/ docs/
+	
+pylint:
+	-pylint rocketpy tests --output=.pylint-report.txt
+
+biuld-docs:
+	cd docs
+	python3 -m pip install -r requirements.txt
+	make html
+	cd ..

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ black:
 pylint:
 	-pylint rocketpy tests --output=.pylint-report.txt
 
-biuld-docs:
+build-docs:
 	cd docs
 	python3 -m pip install -r requirements.txt
 	make html

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,5 @@ pylint:
 	-pylint rocketpy tests --output=.pylint-report.txt
 
 build-docs:
-	cd docs
-	python3 -m pip install -r requirements.txt
-	make html
+	cd docs && python3 -m pip install -r requirements.txt && make html
 	cd ..

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,24 @@
+# Set PYTHON variable according to OS
+ifeq ($(OS),Windows_NT)
+	PYTHON=python
+else
+	PYTHON=python3
+endif
+
 pytest:
-	python3 -m pytest tests
+	$(PYTHON) -m pytest tests
 
 pytest-slow:
-	python3 -m pytest tests -vv -m slow --runslow
+	$(PYTHON) -m pytest tests -vv -m slow --runslow
 
 coverage:
-	python3 -m pytest --cov=rocketpy tests
+	$(PYTHON) -m pytest --cov=rocketpy tests
 
 coverage-report:
-	python3 -m pytest --cov=rocketpy tests --cov-report html
+	$(PYTHON) -m pytest --cov=rocketpy tests --cov-report html
 
 install:
-	python3 -m pip install --upgrade pip
+	$(PYTHON) -m pip install --upgrade pip
 	pip install -r requirements.txt
 	pip install -r requirements-optional.txt
 	pip install -e .
@@ -26,5 +33,5 @@ pylint:
 	-pylint rocketpy tests --output=.pylint-report.txt
 
 build-docs:
-	cd docs && python3 -m pip install -r requirements.txt && make html
+	cd docs && $(PYTHON) -m pip install -r requirements.txt && make html
 	cd ..

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,7 +1,8 @@
 pytest==6.2.4
 pytest-coverage
-black
+black[jupyter]
 flake8-black
 pandas
 numericalunits==1.25
 pylint
+isort

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,4 +1,4 @@
-pytest==6.2.4
+pytest
 pytest-coverage
 black[jupyter]
 flake8-black


### PR DESCRIPTION
## Pull request type

- [x] ReadMe, Docs and GitHub updates

## Checklist

- [ ] Tests for the changes have been added (if needed) **[not relevant]**
- [ ] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant) **[not relevant]**

## Current behavior
The current Makefile is dated from more than 2 years ago, and I'm under the impression that almost none of our developers (including me) use it so often.

## New behavior
I updated (and hopefully improved) the Makefile, now adding new commands to help us during development phase.
You can now use the following commands:

- `make pytest`
- `make slow`
- `make coverage`
- `make coverage-report`
- `make install`
- `make isort`
- `make black`
- `make pylint`
- `make build-docs`

## Breaking change
- [x] No

## Additional information
- There's a strange error happening when running `make pylint`, but it is being ignored by the `-` sign and should not affect the performance, so don't worry about that.
- Please ensure the commands are running properly in your local machines! I'm curious to see the behaviour when running in Windows, @MateusStano .