### PR TITLE
ENH: Plotting both power on and off drag curves in a single plot.

### DIFF
--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -86,27 +86,31 @@ class _RocketPlots:
 
         return None
 
-    def power_on_drag(self):
-        """Plots power on drag of the rocket as a function of time.
+    def power_on_and_off_drag(self):
+        """Plots power off and on drag curve of the rocket as a function of time.
 
         Returns
         -------
         None
         """
+        x_power_drag_off = self.rocket.power_off_drag.x_array
+        y_power_drag_off = self.rocket.power_off_drag.y_array
+        x_power_drag_on = self.rocket.power_on_drag.x_array
+        y_power_drag_on = self.rocket.power_on_drag.y_array
 
-        self.rocket.power_on_drag()
+        fig, ax = plt.subplots()
+        ax.plot(x_power_drag_on, y_power_drag_on, label="Power on Drag")
+        ax.plot(
+            x_power_drag_off, y_power_drag_off, label="Power off Drag", linestyle="--"
+        )
 
-        return None
-
-    def power_off_drag(self):
-        """Plots power off drag of the rocket as a function of time.
-
-        Returns
-        -------
-        None
-        """
-
-        self.rocket.power_off_drag()
+        ax.set_title("Power on and off Drag")
+        ax.set_ylabel("Drag Coefficient")
+        ax.set_xlabel("Mach")
+        ax.axvspan(0.8, 1.2, alpha=0.3, color="gray", label="Transonic Region")
+        ax.legend(loc="best", shadow=True)
+        plt.grid(True)
+        plt.show()
 
         return None
 
@@ -524,8 +528,7 @@ class _RocketPlots:
         # Drag Plots
         print("Drag Plots")
         print("-" * 20)  # Separator for Drag Plots
-        self.power_on_drag()
-        self.power_off_drag()
+        self.power_on_and_off_drag()
 
         # Stability Plots
         print("\nStability Plots")


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)


## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Docs have been reviewed and added / updated
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Before the changes, the drag curves were plotted separated.

## New behavior
<!-- Describe changes introduced by this PR. -->

Now, with the changes made, there is only a plot with both curves.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

The methods power_on_drag and power_off_drag of the _RocketPlots class were removed. 
