### PR TITLE
BUG: Motor method 'export_eng' for liquid motors bug fix. (solves #473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ You can install this version by running `pip install rocketpy==1.2.0`
 
 ### Fixed
 
+- BUG: export_eng 'Motor' method would not work for liquid motors. [#559](https://github.com/RocketPy-Team/RocketPy/pull/559)
 - BUG: Update flight trajectory plot axes limits [#552](https://github.com/RocketPy-Team/RocketPy/pull/552)
 - BUG: fix `get_controller_observed_variables` in the air brakes examples [#551](https://github.com/RocketPy-Team/RocketPy/pull/551)
 - MNT: small fixes before v1.2 [#550](https://github.com/RocketPy-Team/RocketPy/pull/550)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- These are the changes that were not release yet, please add them correctly.
   Attention: The newest changes should be on top -->
 
+- BUG: export_eng 'Motor' method would not work for liquid motors. [#559](https://github.com/RocketPy-Team/RocketPy/pull/559)
+
 ### Added
 
 
@@ -71,7 +73,6 @@ You can install this version by running `pip install rocketpy==1.2.0`
 
 ### Fixed
 
-- BUG: export_eng 'Motor' method would not work for liquid motors. [#559](https://github.com/RocketPy-Team/RocketPy/pull/559)
 - BUG: Update flight trajectory plot axes limits [#552](https://github.com/RocketPy-Team/RocketPy/pull/552)
 - BUG: fix `get_controller_observed_variables` in the air brakes examples [#551](https://github.com/RocketPy-Team/RocketPy/pull/551)
 - MNT: small fixes before v1.2 [#550](https://github.com/RocketPy-Team/RocketPy/pull/550)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- These are the changes that were not release yet, please add them correctly.
   Attention: The newest changes should be on top -->
 
-- BUG: export_eng 'Motor' method would not work for liquid motors. [#559](https://github.com/RocketPy-Team/RocketPy/pull/559)
-
 ### Added
 
 
@@ -39,7 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ### Fixed
-
+- BUG: export_eng 'Motor' method would not work for liquid motors. [#559](https://github.com/RocketPy-Team/RocketPy/pull/559) 
 
 ## [v1.2.0] - 2024-02-dd
 

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -1014,18 +1014,41 @@ class Motor(ABC):
         # Open file
         file = open(file_name, "w")
 
-        # Write first line
-        file.write(
-            motor_name
-            + " {:3.1f} {:3.1f} 0 {:2.3} {:2.3} RocketPy\n".format(
-                2000 * self.grain_outer_radius,
-                1000
-                * self.grain_number
-                * (self.grain_initial_height + self.grain_separation),
-                self.propellant_initial_mass,
-                self.propellant_initial_mass,
+        if (
+            hasattr(self, "grain_outer_radius")
+            and hasattr(self, "grain_number")
+            and hasattr(self, "grain_initial_height")
+            and hasattr(self, "grain_separation")
+        ):
+            # Write first line for motors with grains
+            file.write(
+                motor_name
+                + " {:3.1f} {:3.1f} 0 {:2.3} {:2.3} RocketPy\n".format(
+                    2000 * self.grain_outer_radius,
+                    1000
+                    * self.grain_number
+                    * (self.grain_initial_height + self.grain_separation),
+                    self.propellant_initial_mass,
+                    self.propellant_initial_mass,
+                )
             )
-        )
+
+        else:
+            # Warn the user that the motor doesn't have at least one grain attribute
+            warnings.warn(
+                "The motor object doesn't have some grain-related attributes. Using zeros to write to file."
+            )
+
+            # Write first line for motors without grain attributes
+            # The zeros are here because the first two placeholders
+            # are grain-related attributes.
+            file.write(
+                motor_name
+                + " 0 0 0 {:2.3} {:2.3} RocketPy\n".format(
+                    self.propellant_initial_mass,
+                    self.propellant_initial_mass,
+                )
+            )
 
         # Write thrust curve data points
         for time, thrust in self.thrust.source[1:-1, :]:


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)
- [X] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)
- [X] Docs have been reviewed and added / updated
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest tests -m slow --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

As described in #473, 'export_eng' method does not work for liquid motors since it does not have grain related attributes.

## New behavior
<!-- Describe changes introduced by this PR. -->

The Motor method 'export_eng' now works for liquid motors and the .eng file is created. For liquid motors, the first two parameters written to the file are now zeros, since those are grain related attributes.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

Below is the '.eng' file generated for the liquid motor defined in the SEB_liquid_motor.ipynb notebook.

![image](https://github.com/RocketPy-Team/RocketPy/assets/69172945/139ce577-28a1-4e08-9055-a6553e0df1d4)
