### PR TITLE
ENH: Initial solution from flights gets previous results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Attention: The newest changes should be on top -->
 ### Changed
 
 - 
+- ENH: Initial solution from flights gets previous results [#568](https://github.com/RocketPy-Team/RocketPy/pull/568)
 - DOC: New Environment class docs pages [#644](https://github.com/RocketPy-Team/RocketPy/pull/644)
 
 ### Fixed

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1101,6 +1101,7 @@ class Flight:  # pylint: disable=too-many-public-methods
         elif isinstance(self.initial_solution, Flight):
             # Initialize time and state variables based on last solution of
             # previous flight
+            self.solution = self.initial_solution.solution[:-1]
             self.initial_solution = self.initial_solution.solution[-1]
             # Set unused monitors
             self.out_of_rail_state = self.initial_solution[1:]


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [ ] Tests for the changes have been added (not needed)
- [ ] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
When you use a Flight object as the initial solution, only the final state of the flight is captured.
See orange plot:
![image](https://github.com/RocketPy-Team/RocketPy/assets/63590233/52a9bf15-2852-43a0-8d69-617ae56a9201)


## New behavior
Now the whole flight solution array is used in the new flight.
See orange plot now:

![image](https://github.com/RocketPy-Team/RocketPy/assets/63590233/3fd1a448-e3c6-4426-941b-315c50489b73)


## Breaking change

- [x] No (all the current script made on top of rocketpy will still run and work, just some plots might change (for better) when using deployables of multi-stage.

## Additional information
Another enhancement allowed by the euroc works that we have been doing.