### PR TITLE
BUG: wrong rocket mass in parachute u dot method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [v1.2.2] - 2024-03-dd
+
+You can install this version by running `pip install rocketpy==1.2.2`
+
+- BUG: wrong rocket mass in parachute u dot method [#569](https://github.com/RocketPy-Team/RocketPy/pull/569)
 
 ## [v1.2.1] - 2024-02-22
 

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -61,6 +61,9 @@ class Rocket:
         pointing from the rocket's nose cone to the rocket's tail.
     Rocket.mass : float
         Rocket's mass without motor and propellant, measured in kg.
+    Rocket.dry_mass : float
+        Rocket's mass without propellant, measured in kg. It does include the
+        motor mass.
     Rocket.center_of_mass : Function
         Position of the rocket's center of mass, including propellant, relative
         to the user defined rocket reference system.
@@ -394,22 +397,18 @@ class Rocket:
     def evaluate_dry_mass(self):
         """Calculates and returns the rocket's dry mass. The dry
         mass is defined as the sum of the motor's dry mass and the
-        rocket mass without motor. The function returns an object
-        of the Function class and is defined as a function of time.
+        rocket mass without motor.
 
         Returns
         -------
-        self.total_mass : Function
-            Function of time expressing the total mass of the rocket,
-            defined as the sum of the propellant mass and the rocket
-            mass without propellant.
+        self.dry_mass : float
+            Rocket's dry mass (Rocket + Motor) (kg)
         """
         # Make sure there is a motor associated with the rocket
         if self.motor is None:
             print("Please associate this rocket with a motor!")
             return False
 
-        # Calculate total dry mass: motor (without propellant) + rocket mass
         self.dry_mass = self.mass + self.motor.dry_mass
 
         return self.dry_mass

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1911,7 +1911,7 @@ class Flight:
         rho = self.env.density.get_value_opt(u[2])
         to = 1.2
         ma = ka * rho * (4 / 3) * np.pi * R**3
-        mp = self.rocket.mass
+        mp = self.rocket.dry_mass
         eta = 1
         Rdot = (6 * R * (1 - eta) / (1.2**6)) * (
             (1 - eta) * t**5 + eta * (to**3) * (t**2)

--- a/tests/acceptance/test_bella_lui_rocket.py
+++ b/tests/acceptance/test_bella_lui_rocket.py
@@ -242,3 +242,10 @@ def test_bella_lui_rocket_data_asserts_acceptance():
     assert (
         abs(apogee_time_measured - apogee_time_simulated) / apogee_time_simulated < 0.02
     )
+    # Guarantee the impact velocity is within 30% of the real data.
+    # Use the last 5 real points to avoid outliers
+    assert (
+        abs(test_flight.impact_velocity - np.mean(vert_vel_kalt[-5:]))
+        / abs(test_flight.impact_velocity)
+        < 0.30
+    )

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -691,7 +691,7 @@ def test_accelerations(flight_calisto_custom_wind, flight_time, expected_values)
         ("t_initial", (0, 0, 0)),
         ("out_of_rail_time", (0, 2.248727, 25.703072)),
         ("apogee_time", (-13.209436, 16.05115, -0.000257)),
-        ("t_final", (5, 2, -5.334289)),
+        ("t_final", (5, 2, -5.65998)),
     ],
 )
 def test_velocities(flight_calisto_custom_wind, flight_time, expected_values):
@@ -729,7 +729,7 @@ def test_velocities(flight_calisto_custom_wind, flight_time, expected_values):
         ("t_initial", (1.6542528, 0.65918, -0.067107)),
         ("out_of_rail_time", (5.05334, 2.01364, -1.7541)),
         ("apogee_time", (2.35291, -1.8275, -0.87851)),
-        ("t_final", (0, 0, 141.42421)),
+        ("t_final", (0, 0, 159.2212)),
     ],
 )
 def test_aerodynamic_forces(flight_calisto_custom_wind, flight_time, expected_values):

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -153,7 +153,7 @@ def test_fin_flutter_analysis(flight_calisto_custom_wind):
     assert np.isclose(flutter_mach(np.inf), 1.0048188594647927, atol=5e-3)
     assert np.isclose(safety_factor(0), 64.78797, atol=5e-3)
     assert np.isclose(safety_factor(10), 2.1948620401502072, atol=5e-3)
-    assert np.isclose(safety_factor(np.inf), 65.40588722032527, atol=5e-3)
+    assert np.isclose(safety_factor(np.inf), 61.64222220469224, atol=5e-3)
 
 
 def test_flutter_prints(flight_calisto_custom_wind):


### PR DESCRIPTION
## Pull request type
- [x] Code changes (bugfix, features)

## Checklist
- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
When calculating the parachute forces in the `Flight.u_dot_parachute` method, the code is using the rocket's mass without the motor's dry mass. It should be using the `Rocket.dry_mass` value instead.

## New behavior
Fixed the bug, updated docs and tests.

## Breaking change

- [x] No (but you should expect some slight change in impact velocity values since the v1.0 was out).

## Additional information
- Quick obs.: Acceptance tests should prevent bugs like this, @lucasfourier @GabrielBarberini !!
- This bug was captured today by the Faraday team, Spain. Many thanks to their contribution!
![image](https://github.com/RocketPy-Team/RocketPy/assets/63590233/cabb1358-d25f-44b3-b1c5-0b2b2fec1bf6)

