### PR TITLE
MNT: Refactor inertia calculations using parallel axis theorem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - ENH: adds `Function.remove_outliers` method [#554](https://github.com/RocketPy-Team/RocketPy/pull/554)
 
 ### Changed
+- MNT: Refactor inertia calculations using parallel axis theorem [#573] (https://github.com/RocketPy-Team/RocketPy/pull/573)
 - ENH: Optional argument to show the plot in Function.compare_plots [#563](https://github.com/RocketPy-Team/RocketPy/pull/563)
 
 ### Fixed

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -7,7 +7,7 @@ import numpy as np
 from ..mathutils.function import Function, funcify_method
 from ..plots.motor_plots import _MotorPlots
 from ..prints.motor_prints import _MotorPrints
-from ..tools import tuple_handler
+from ..tools import parallel_axis_theorem, tuple_handler
 
 try:
     from functools import cached_property
@@ -513,25 +513,17 @@ class Motor(ABC):
         ----------
         .. [1] https://en.wikipedia.org/wiki/Moment_of_inertia#Inertia_tensor
         """
-        # Propellant inertia tensor 11 component wrt propellant center of mass
-        propellant_I_11 = self.propellant_I_11
 
-        # Dry inertia tensor 11 component wrt dry center of mass
+        prop_I_11 = self.propellant_I_11
         dry_I_11 = self.dry_I_11
 
-        # Steiner theorem the get inertia wrt motor center of mass
-        propellant_I_11 += (
-            self.propellant_mass
-            * (self.center_of_propellant_mass - self.center_of_mass) ** 2
-        )
+        prop_to_cm = self.center_of_propellant_mass - self.center_of_mass
+        dry_to_cm = self.center_of_dry_mass_position - self.center_of_mass
 
-        dry_I_11 += (
-            self.dry_mass
-            * (self.center_of_dry_mass_position - self.center_of_mass) ** 2
-        )
+        prop_I_11 = parallel_axis_theorem(prop_I_11, self.propellant_mass, prop_to_cm)
+        dry_I_11 = parallel_axis_theorem(dry_I_11, self.dry_mass, dry_to_cm)
 
-        # Sum of inertia components
-        return propellant_I_11 + dry_I_11
+        return prop_I_11 + dry_I_11
 
     @funcify_method("Time (s)", "Inertia I_22 (kg m²)")
     def I_22(self):

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -18,6 +18,7 @@ from rocketpy.rocket.aero_surface import (
 )
 from rocketpy.rocket.components import Components
 from rocketpy.rocket.parachute import Parachute
+from rocketpy.tools import parallel_axis_theorem
 
 
 class Rocket:
@@ -620,6 +621,10 @@ class Rocket:
         ----------
         .. [1] https://en.wikipedia.org/wiki/Moment_of_inertia#Inertia_tensor
         """
+        # Get masses
+        motor_dry_mass = self.motor.dry_mass
+        mass = self.mass
+
         # Compute axes distances
         noMCM_to_CDM = (
             self.center_of_mass_without_motor - self.center_of_dry_mass_position
@@ -629,18 +634,14 @@ class Rocket:
         )
 
         # Compute dry inertias
-        self.dry_I_11 = (
-            self.I_11_without_motor
-            + self.mass * noMCM_to_CDM**2
-            + self.motor.dry_I_11
-            + self.motor.dry_mass * motorCDM_to_CDM**2
-        )
-        self.dry_I_22 = (
-            self.I_22_without_motor
-            + self.mass * noMCM_to_CDM**2
-            + self.motor.dry_I_22
-            + self.motor.dry_mass * motorCDM_to_CDM**2
-        )
+        self.dry_I_11 = parallel_axis_theorem(
+            self.I_11_without_motor, mass, noMCM_to_CDM
+        ) + parallel_axis_theorem(self.motor.dry_I_11, motor_dry_mass, motorCDM_to_CDM)
+
+        self.dry_I_22 = parallel_axis_theorem(
+            self.I_22_without_motor, mass, noMCM_to_CDM
+        ) + parallel_axis_theorem(self.motor.dry_I_22, motor_dry_mass, motorCDM_to_CDM)
+
         self.dry_I_33 = self.I_33_without_motor + self.motor.dry_I_33
         self.dry_I_12 = self.I_12_without_motor + self.motor.dry_I_12
         self.dry_I_13 = self.I_13_without_motor + self.motor.dry_I_13
@@ -697,18 +698,14 @@ class Rocket:
         CM_to_CPM = self.center_of_mass - self.center_of_propellant_position
 
         # Compute inertias
-        self.I_11 = (
-            self.dry_I_11
-            + self.motor.I_11
-            + dry_mass * CM_to_CDM**2
-            + prop_mass * CM_to_CPM**2
-        )
-        self.I_22 = (
-            self.dry_I_22
-            + self.motor.I_22
-            + dry_mass * CM_to_CDM**2
-            + prop_mass * CM_to_CPM**2
-        )
+        self.I_11 = parallel_axis_theorem(
+            self.dry_I_11, dry_mass, CM_to_CDM
+        ) + parallel_axis_theorem(self.motor.I_11, prop_mass, CM_to_CPM)
+
+        self.I_22 = parallel_axis_theorem(
+            self.dry_I_22, dry_mass, CM_to_CDM
+        ) + parallel_axis_theorem(self.motor.I_22, prop_mass, CM_to_CPM)
+
         self.I_33 = self.dry_I_33 + self.motor.I_33
         self.I_12 = self.dry_I_12 + self.motor.I_12
         self.I_13 = self.dry_I_13 + self.motor.I_13

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -382,6 +382,27 @@ def check_requirement_version(module_name, version):
     return True
 
 
+def parallel_axis_theorem(initial_inertia_moment, mass, distance):
+    """Converts the moment of inertia from one axis to another using the
+    parallel axis theorem. The axes must be parallel to each other.
+
+    Parameters
+    ----------
+    initial_inertia_moment : float
+        Initial moment of inertia.
+    mass : float
+        Mass of the object.
+    distance : float
+        Distance between the two points.
+
+    Returns
+    -------
+    float
+        New moment of inertia.
+    """
+    return initial_inertia_moment + mass * distance**2
+
+
 # Flight
 
 


### PR DESCRIPTION
## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)

## Checklist

- [ ] Tests for the changes have been added (I don't think it's needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
We apply the [parallel axis theorem](https://en.wikipedia.org/wiki/Parallel_axis_theorem#:~:text=The%20parallel%20axis%20theorem%20states%20that%20if%20the,perpendicular%20distance%20between%20the%20axes%20z%20and%20z%E2%80%B2.) in many parts of the code today. 

## New behavior
I created a parallel axis theorem function in the tools.py module, so now all the calculations are centralized in a single place.
This makes the code more readable, as it quickly guides the reader when understanding the code.

Don't repeat yourself (DRY).

## Breaking change

- [x] No

## Additional information
- In the future we might wanna add acceptance/integration tests to verify if our inertia calculations (After summing different components) are aligned with expected physics phenomena.
