### PR TITLE
MNT: Refactor flight prints module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- MNT: Refactor flight prints module [#758](https://github.com/RocketPy-Team/RocketPy/pull/578)
 - DOC: Convert CompareFlights example notebooks to .rst files [#576](https://github.com/RocketPy-Team/RocketPy/pull/576)
 - ENH: Optional argument to show the plot in Function.compare_plots [#563](https://github.com/RocketPy-Team/RocketPy/pull/563)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- MNT: Refactor flight prints module [#758](https://github.com/RocketPy-Team/RocketPy/pull/578)
+- MNT: Refactor flight prints module [#579](https://github.com/RocketPy-Team/RocketPy/pull/579)
 - DOC: Convert CompareFlights example notebooks to .rst files [#576](https://github.com/RocketPy-Team/RocketPy/pull/576)
 - ENH: Optional argument to show the plot in Function.compare_plots [#563](https://github.com/RocketPy-Team/RocketPy/pull/563)
 

--- a/rocketpy/prints/flight_prints.py
+++ b/rocketpy/prints/flight_prints.py
@@ -1,3 +1,17 @@
+"""rocketpy/prints/flight_prints.py
+
+This module contains the _FlightPrints class, which is responsible for printing
+flight information in a user-friendly manner.
+
+Notes
+-----
+- This module does not have any external dependencies (avoid importing libraries).
+- We assume that all flight information is valid, no validation checks is run.
+- Avoid calculating values here, only print the values from the Flight class.
+- The _FlightPrints is a private class, it is subjected to change without notice.
+"""
+
+
 class _FlightPrints:
     """Class that holds prints methods for Flight class.
 
@@ -5,7 +19,6 @@ class _FlightPrints:
     ----------
     _FlightPrints.flight : Flight
         Flight object that will be used for the prints.
-
     """
 
     def __init__(
@@ -24,10 +37,11 @@ class _FlightPrints:
         None
         """
         self.flight = flight
-        return None
 
     def initial_conditions(self):
-        """Prints all initial conditions data available about the Flight.
+        """Prints initial conditions data available about the flight, including
+        position, velocity, attitude, euler angles, angular velocity, and
+        stability margin.
 
         Returns
         -------
@@ -67,186 +81,145 @@ class _FlightPrints:
         print(f"Initial Stability Margin: {self.flight.initial_stability_margin:.3f} c")
 
     def numerical_integration_settings(self):
-        """Prints out the Numerical Integration settings available about the
-        flight.
+        """Prints out the numerical integration settings available about the
+        flight, this includes the maximum allowed flight time, maximum allowed
+        time step, and other settings.
 
         Returns
         -------
         None
         """
-
         print("\nNumerical Integration Settings\n")
-        print("Maximum Allowed Flight Time: {:f} s".format(self.flight.max_time))
-        print("Maximum Allowed Time Step: {:f} s".format(self.flight.max_time_step))
-        print("Minimum Allowed Time Step: {:e} s".format(self.flight.min_time_step))
-        print("Relative Error Tolerance: ", self.flight.rtol)
-        print("Absolute Error Tolerance: ", self.flight.atol)
-        print("Allow Event Overshoot: ", self.flight.time_overshoot)
-        print("Terminate Simulation on Apogee: ", self.flight.terminate_on_apogee)
-        print("Number of Time Steps Used: ", len(self.flight.time_steps))
+        print(f"Maximum Allowed Flight Time: {self.flight.max_time:.2f} s")
+        print(f"Maximum Allowed Time Step: {self.flight.max_time_step:.2f} s")
+        print(f"Minimum Allowed Time Step: {self.flight.min_time_step:.2e} s")
+        print(f"Relative Error Tolerance: {self.flight.rtol}")
+        print(f"Absolute Error Tolerance: {self.flight.atol}")
+        print(f"Allow Event Overshoot: {self.flight.time_overshoot}")
+        print(f"Terminate Simulation on Apogee: {self.flight.terminate_on_apogee}")
+        print(f"Number of Time Steps Used: {len(self.flight.time_steps)}")
         print(
-            "Number of Derivative Functions Evaluation: ",
-            sum(self.flight.function_evaluations_per_time_step),
+            "Number of Derivative Functions Evaluation: "
+            f"{sum(self.flight.function_evaluations_per_time_step)}"
         )
+        avg_func_evals_per_step = sum(
+            self.flight.function_evaluations_per_time_step
+        ) / len(self.flight.time_steps)
         print(
-            "Average Function Evaluations per Time Step: {:3f}".format(
-                sum(self.flight.function_evaluations_per_time_step)
-                / len(self.flight.time_steps)
-            )
+            f"Average Function Evaluations per Time Step: {avg_func_evals_per_step:.3f}"
         )
-
-        return None
 
     def surface_wind_conditions(self):
-        """Prints out the Surface Wind Conditions available about the flight.
+        """Prints out the Surface Wind Conditions for the flight.
 
         Returns
         -------
         None
         """
-        if self.flight.post_processed is False:
-            self.flight.post_process()
         print("\nSurface Wind Conditions\n")
-        print(
-            "Frontal Surface Wind Speed: {:.2f} m/s".format(
-                self.flight.frontal_surface_wind
-            )
-        )
-        print(
-            "Lateral Surface Wind Speed: {:.2f} m/s".format(
-                self.flight.lateral_surface_wind
-            )
-        )
-
-        return None
+        print(f"Frontal Surface Wind Speed: {self.flight.frontal_surface_wind:.2f} m/s")
+        print(f"Lateral Surface Wind Speed: {self.flight.lateral_surface_wind:.2f} m/s")
 
     def launch_rail_conditions(self):
-        """Prints out the Launch Rail Conditions available about the flight.
+        """Prints out the Launch Rail Conditions available about the flight,
+        including the length, inclination, and heading of the launch rail.
 
         Returns
         -------
         None
         """
-
         print("\nLaunch Rail\n")
-        print("Launch Rail Length:", self.flight.rail_length, " m")
-        print("Launch Rail Inclination: {:.2f}°".format(self.flight.inclination))
-        print("Launch Rail Heading: {:.2f}°".format(self.flight.heading))
-        return None
+        print(f"Launch Rail Length: {self.flight.rail_length} m")
+        print(f"Launch Rail Inclination: {self.flight.inclination:.2f}°")
+        print(f"Launch Rail Heading: {self.flight.heading:.2f}°")
 
     def out_of_rail_conditions(self):
-        """Prints out the Out of Rail Conditions available about the flight.
+        """Prints out the Out of Rail Conditions available about the flight,
+        including the time, velocity, stability margin, angle of attack, thrust
+        to weight ratio, and Reynolds number.
 
         Returns
         -------
         None
         """
-        if self.flight.post_processed is False:
-            self.flight.post_process()
         print("\nRail Departure State\n")
-        print("Rail Departure Time: {:.3f} s".format(self.flight.out_of_rail_time))
+        print(f"Rail Departure Time: {self.flight.out_of_rail_time:.3f} s")
+        print(f"Rail Departure Velocity: {self.flight.out_of_rail_velocity:.3f} m/s")
         print(
             "Rail Departure Stability Margin: "
             f"{self.flight.out_of_rail_stability_margin:.3f} c"
         )
         print(
-            "Rail Departure Stability Margin: {:.3f} c".format(
-                self.flight.stability_margin(self.flight.out_of_rail_time)
-            )
+            "Rail Departure Angle of Attack: "
+            f"{self.flight.angle_of_attack(self.flight.out_of_rail_time):.3f}°"
         )
         print(
-            "Rail Departure Angle of Attack: {:.3f}°".format(
-                self.flight.angle_of_attack(self.flight.out_of_rail_time)
-            )
+            "Rail Departure Thrust-Weight Ratio: "
+            f"{self.flight.rocket.thrust_to_weight(self.flight.out_of_rail_time):.3f}"
         )
         print(
-            "Rail Departure Thrust-Weight Ratio: {:.3f}".format(
-                self.flight.rocket.thrust_to_weight(self.flight.out_of_rail_time)
-            )
+            "Rail Departure Reynolds Number: "
+            f"{self.flight.reynolds_number(self.flight.out_of_rail_time):.3e}"
         )
-        print(
-            "Rail Departure Reynolds Number: {:.3e}".format(
-                self.flight.reynolds_number(self.flight.out_of_rail_time)
-            )
-        )
-
-        return None
 
     def burn_out_conditions(self):
-        """Prints out the Burn Out Conditions available about the flight.
+        """Prints out the Burn Out Conditions available about the flight,
+        including the burn out time, altitude, speed, freestream speed, Mach
+        number, and kinetic energy.
 
         Returns
         -------
         None
         """
         print("\nBurn out State\n")
-        print("Burn out time: {:.3f} s".format(self.flight.rocket.motor.burn_out_time))
+        print(f"Burn out time: {self.flight.rocket.motor.burn_out_time:.3f} s")
         print(
-            "Altitude at burn out: {:.3f} m (AGL)".format(
-                self.flight.z(self.flight.rocket.motor.burn_out_time)
-                - self.flight.env.elevation
-            )
+            "Altitude at burn out: "
+            f"{self.flight.altitude(self.flight.rocket.motor.burn_out_time):.3f} "
+            "m (AGL)"
         )
         print(
-            "Rocket velocity at burn out: {:.3f} m/s".format(
-                self.flight.speed(self.flight.rocket.motor.burn_out_time)
-            )
-        )
-        print(
-            "Freestream velocity at burn out: {:.3f} m/s".format(
-                (
-                    self.flight.stream_velocity_x(
-                        self.flight.rocket.motor.burn_out_time
-                    )
-                    ** 2
-                    + self.flight.stream_velocity_y(
-                        self.flight.rocket.motor.burn_out_time
-                    )
-                    ** 2
-                    + self.flight.stream_velocity_z(
-                        self.flight.rocket.motor.burn_out_time
-                    )
-                    ** 2
-                )
-                ** 0.5
-            )
-        )
-        print(
-            "Mach Number at burn out: {:.3f}".format(
-                self.flight.mach_number(self.flight.rocket.motor.burn_out_time)
-            )
-        )
-        print(
-            "Kinetic energy at burn out: {:.3e} J".format(
-                self.flight.kinetic_energy(self.flight.rocket.motor.burn_out_time)
-            )
+            "Rocket speed at burn out: "
+            f"{self.flight.speed(self.flight.rocket.motor.burn_out_time):.3f} m/s"
         )
 
-        return None
+        stream_velocity = self.flight.free_stream_speed(
+            self.flight.rocket.motor.burn_out_time
+        )
+        print(f"Freestream velocity at burn out: {stream_velocity:.3f} m/s")
+
+        print(
+            "Mach Number at burn out: "
+            f"{self.flight.mach_number(self.flight.rocket.motor.burn_out_time):.3f}"
+        )
+        print(
+            "Kinetic energy at burn out: "
+            f"{self.flight.kinetic_energy(self.flight.rocket.motor.burn_out_time):.3e} "
+            "J"
+        )
 
     def apogee_conditions(self):
-        """Prints out the Apogee Conditions available about the flight.
+        """Prints out the Apogee Conditions available about the flight,
+        including the apogee time, altitude, freestream speed, latitude, and
+        longitude.
 
         Returns
         -------
         None
         """
-        if self.flight.post_processed is False:
-            self.flight.post_process()
         print("\nApogee State\n")
+        print(f"Apogee Time: {self.flight.apogee_time:.3f} s")
         print(
-            "Apogee Altitude: {:.3f} m (ASL) | {:.3f} m (AGL)".format(
-                self.flight.apogee, self.flight.apogee - self.flight.env.elevation
-            )
+            f"Apogee Altitude: {self.flight.apogee:.3f} m (ASL) | "
+            f"{self.flight.altitude(self.flight.apogee_time):.3f} m (AGL)"
         )
-        print("Apogee Time: {:.3f} s".format(self.flight.apogee_time))
+        print(f"Apogee Freestream Speed: {self.flight.apogee_freestream_speed:.3f} m/s")
+        print(f"Apogee X position: {self.flight.x(self.flight.apogee_time):.3f} m")
+        print(f"Apogee Y position: {self.flight.y(self.flight.apogee_time):.3f} m")
+        print(f"Apogee latitude: {self.flight.latitude(self.flight.apogee_time):.7f}°")
         print(
-            "Apogee Freestream Speed: {:.3f} m/s".format(
-                self.flight.apogee_freestream_speed
-            )
+            f"Apogee longitude: {self.flight.longitude(self.flight.apogee_time):.7f}°"
         )
-
-        return None
 
     def events_registered(self):
         """Prints out the Events Registered available about the flight.
@@ -255,8 +228,6 @@ class _FlightPrints:
         -------
         None
         """
-        if self.flight.post_processed is False:
-            self.flight.post_process()
         print("\nParachute Events\n")
         if len(self.flight.parachute_events) == 0:
             print("No Parachute Events Were Triggered.")
@@ -264,24 +235,17 @@ class _FlightPrints:
             trigger_time = event[0]
             parachute = event[1]
             open_time = trigger_time + parachute.lag
-            velocity = self.flight.free_stream_speed(open_time)
+            speed = self.flight.free_stream_speed(open_time)
             altitude = self.flight.z(open_time)
             name = parachute.name.title()
-            print(name + " Ejection Triggered at: {:.3f} s".format(trigger_time))
-            print(name + " Parachute Inflated at: {:.3f} s".format(open_time))
+            print(f"Parachute: {name}")
+            print(f"\tEjection time: {trigger_time:.3f} s")
+            print(f"\tInflation time: {open_time:.3f} s")
+            print(f"\tFreestream speed at inflation: {speed:.3f} m/s")
             print(
-                name
-                + " Parachute Inflated with Freestream Speed of: {:.3f} m/s".format(
-                    velocity
-                )
+                f"\tAltitude at inflation: {altitude:.3f} m (ASL) | "
+                f"{self.flight.altitude(trigger_time):.3f} m (AGL)"
             )
-            print(
-                name
-                + " Parachute Inflated at Height of: {:.3f} m (AGL)".format(
-                    altitude - self.flight.env.elevation
-                )
-            )
-        return None
 
     def impact_conditions(self):
         """Prints out the Impact Conditions available about the flight.
@@ -290,27 +254,36 @@ class _FlightPrints:
         -------
         None
         """
-        if self.flight.post_processed is False:
-            self.flight.post_process()
         if len(self.flight.impact_state) != 0:
             print("\nImpact Conditions\n")
-            print("X Impact: {:.3f} m".format(self.flight.x_impact))
-            print("Y Impact: {:.3f} m".format(self.flight.y_impact))
-            print("Latitude: {:.7f}°".format(self.flight.latitude(self.flight.t_final)))
+            print(f"Time of impact: {self.flight.t_final:.3f} s")
+            print(f"X impact: {self.flight.x_impact:.3f} m")
+            print(f"Y impact: {self.flight.y_impact:.3f} m")
             print(
-                "Longitude: {:.7f}°".format(self.flight.longitude(self.flight.t_final))
+                f"Altitude impact: {self.flight.z(self.flight.t_final):.3f} m (ASL) | "
+                f"{self.flight.altitude(self.flight.t_final):.3f} m (AGL) "
             )
-            print("Time of Impact: {:.3f} s".format(self.flight.t_final))
-            print("Velocity at Impact: {:.3f} m/s".format(self.flight.impact_velocity))
+            print(f"Latitude: {self.flight.latitude(self.flight.t_final):.7f}°")
+            print(f"Longitude: {self.flight.longitude(self.flight.t_final):.7f}°")
+            print(f"Vertical velocity at impact: {self.flight.impact_velocity:.3f} m/s")
+            num_parachute_events = sum(
+                1
+                for event in self.flight.parachute_events
+                if event[0] < self.flight.t_final
+            )
+            print(
+                f"Number of parachutes triggered until impact: {num_parachute_events}"
+            )
         elif self.flight.terminate_on_apogee is False:
             print("End of Simulation")
-            t_final = self.flight.solution[-1][0]
-            print("Time: {:.3f} s".format(t_final))
-            print("Altitude: {:.3f} m".format(self.flight.solution[-1][3]))
-            print("Latitude: {:.3f}°".format(self.flight.latitude(t_final)))
-            print("Longitude: {:.3f}°".format(self.flight.longitude(t_final)))
-
-        return None
+            t_final = self.flight.time[-1]
+            print(f"Time: {t_final:.3f} s")
+            print(
+                f"Altitude: {self.flight.z(t_final)} m (ASL) | "
+                f"{self.flight.altitude(t_final):.3f} m (AGL)"
+            )
+            print(f"Latitude: {self.flight.latitude(t_final):.7f}°")
+            print(f"Longitude: {self.flight.longitude(t_final):.7f}°")
 
     def maximum_values(self):
         """Prints out the Maximum Values available about the flight.
@@ -321,53 +294,44 @@ class _FlightPrints:
         """
         print("\nMaximum Values\n")
         print(
-            "Maximum Speed: {:.3f} m/s at {:.2f} s".format(
-                self.flight.max_speed, self.flight.max_speed_time
-            )
+            f"Maximum Speed: {self.flight.max_speed:.3f} m/s "
+            f"at {self.flight.max_speed_time:.2f} s"
         )
         print(
-            "Maximum Mach Number: {:.3f} Mach at {:.2f} s".format(
-                self.flight.max_mach_number, self.flight.max_mach_number_time
-            )
+            f"Maximum Mach Number: {self.flight.max_mach_number:.3f} Mach "
+            f"at {self.flight.max_mach_number_time:.2f} s"
         )
         print(
-            "Maximum Reynolds Number: {:.3e} at {:.2f} s".format(
-                self.flight.max_reynolds_number, self.flight.max_reynolds_number_time
-            )
+            f"Maximum Reynolds Number: {self.flight.max_reynolds_number:.3e} "
+            f"at {self.flight.max_reynolds_number_time:.2f} s"
         )
         print(
-            "Maximum Dynamic Pressure: {:.3e} Pa at {:.2f} s".format(
-                self.flight.max_dynamic_pressure, self.flight.max_dynamic_pressure_time
-            )
+            f"Maximum Dynamic Pressure: {self.flight.max_dynamic_pressure:.3e} Pa "
+            f"at {self.flight.max_dynamic_pressure_time:.2f} s"
         )
         print(
-            "Maximum Acceleration During Motor Burn: {:.3f} m/s² at {:.2f} s".format(
-                self.flight.max_acceleration_power_on,
-                self.flight.max_acceleration_power_on_time,
-            )
+            "Maximum Acceleration During Motor Burn: "
+            f"{self.flight.max_acceleration_power_on:.3f} m/s² "
+            f"at {self.flight.max_acceleration_power_on_time:.2f} s"
         )
         print(
-            "Maximum Gs During Motor Burn: {:.3f} g at {:.2f} s".format(
-                self.flight.max_acceleration_power_on / self.flight.env.standard_g,
-                self.flight.max_acceleration_power_on_time,
-            )
+            "Maximum Gs During Motor Burn: "
+            f"{self.flight.max_acceleration_power_on / self.flight.env.standard_g:.3f} "
+            f"g at {self.flight.max_acceleration_power_on_time:.2f} s"
         )
         print(
-            "Maximum Acceleration After Motor Burn: {:.3f} m/s² at {:.2f} s".format(
-                self.flight.max_acceleration_power_off,
-                self.flight.max_acceleration_power_off_time,
-            )
+            "Maximum Acceleration After Motor Burn: "
+            f"{self.flight.max_acceleration_power_off:.3f} m/s² "
+            f"at {self.flight.max_acceleration_power_off_time:.2f} s"
         )
         print(
-            "Maximum Gs After Motor Burn: {:.3f} g at {:.2f} s".format(
-                self.flight.max_acceleration_power_off / self.flight.env.standard_g,
-                self.flight.max_acceleration_power_off_time,
-            )
+            "Maximum Gs After Motor Burn: "
+            f"{self.flight.max_acceleration_power_off / self.flight.env.standard_g:.3f}"
+            f" Gs at {self.flight.max_acceleration_power_off_time:.2f} s"
         )
         print(
-            "Maximum Stability Margin: {:.3f} c at {:.2f} s".format(
-                self.flight.max_stability_margin, self.flight.max_stability_margin_time
-            )
+            f"Maximum Stability Margin: {self.flight.max_stability_margin:.3f} c "
+            f"at {self.flight.max_stability_margin_time:.2f} s"
         )
 
         if (
@@ -377,30 +341,35 @@ class _FlightPrints:
             pass
         else:
             print(
-                "Maximum Upper Rail Button Normal Force: {:.3f} N".format(
-                    self.flight.max_rail_button1_normal_force
-                )
+                "Maximum Upper Rail Button Normal Force: "
+                f"{self.flight.max_rail_button1_normal_force:.3f} N"
             )
             print(
-                "Maximum Upper Rail Button Shear Force: {:.3f} N".format(
-                    self.flight.max_rail_button1_shear_force
-                )
+                "Maximum Upper Rail Button Shear Force: "
+                f"{self.flight.max_rail_button1_shear_force:.3f} N"
             )
             print(
-                "Maximum Lower Rail Button Normal Force: {:.3f} N".format(
-                    self.flight.max_rail_button2_normal_force
-                )
+                "Maximum Lower Rail Button Normal Force: "
+                f"{self.flight.max_rail_button2_normal_force:.3f} N"
             )
             print(
-                "Maximum Lower Rail Button Shear Force: {:.3f} N".format(
-                    self.flight.max_rail_button2_shear_force
-                )
+                "Maximum Lower Rail Button Shear Force: "
+                f"{self.flight.max_rail_button2_shear_force:.3f} N"
             )
-        return None
 
     def stability_margin(self):
-        """Prints out the maximum and minimum stability margin available
-        about the flight."""
+        """Prints out the stability margins of the flight at different times.
+
+        This method prints the following: Initial Stability Margin, Out of Rail
+        Stability Margin, Maximum Stability Margin, and Minimum Stability Margin
+
+        Each stability margin is printed along with the time it occurred.
+
+        Notes
+        -----
+        The stability margin is typically measured in calibers (c), where 1
+        caliber is the diameter of the rocket.
+        """
         print("\nStability Margin\n")
         print(
             f"Initial Stability Margin: {self.flight.initial_stability_margin:.3f} c "
@@ -412,62 +381,52 @@ class _FlightPrints:
             f"at {self.flight.out_of_rail_time:.2f} s"
         )
         print(
-            "Minimum Stability Margin: {:.3f} c at {:.2f} s".format(
-                self.flight.min_stability_margin, self.flight.min_stability_margin_time
-            )
+            f"Maximum Stability Margin: {self.flight.max_stability_margin:.3f} c "
+            f"at {self.flight.max_stability_margin_time:.2f} s"
         )
-        return None
+        print(
+            f"Minimum Stability Margin: {self.flight.min_stability_margin:.3f} c "
+            f"at {self.flight.min_stability_margin_time:.2f} s"
+        )
 
     def all(self):
-        """Prints out all data available about the Flight.
+        """Prints out all data available about the Flight. This method invokes
+        all other print methods in the class.
 
         Returns
         -------
         None
         """
 
-        # Print initial conditions
         self.initial_conditions()
         print()
 
-        # Print surface wind conditions
         self.surface_wind_conditions()
         print()
 
-        # Print launch rail orientation
         self.launch_rail_conditions()
         print()
 
-        # Print out of rail conditions
         self.out_of_rail_conditions()
         print()
 
-        # Print burn out conditions
         self.burn_out_conditions()
         print()
 
-        # Print apogee conditions
         self.apogee_conditions()
         print()
 
-        # Print events registered
         self.events_registered()
         print()
 
-        # Print impact conditions
         self.impact_conditions()
         print()
 
-        # Print stability margin
         self.stability_margin()
         print()
 
-        # Print maximum values
         self.maximum_values()
         print()
 
-        # Print Numerical Integration Information
         self.numerical_integration_settings()
         print()
-
-        return None

--- a/rocketpy/prints/flight_prints.py
+++ b/rocketpy/prints/flight_prints.py
@@ -175,6 +175,7 @@ class _FlightPrints:
         print(f"Burn out time: {self.flight.rocket.motor.burn_out_time:.3f} s")
         print(
             "Altitude at burn out: "
+            f"{self.flight.z(self.flight.rocket.motor.burn_out_time):.3f} m (ASL) | "
             f"{self.flight.altitude(self.flight.rocket.motor.burn_out_time):.3f} "
             "m (AGL)"
         )


### PR DESCRIPTION
## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)

## Checklist

- [ ] Tests for the changes have been added (not needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
The code used within the `_FlightPrints` class is becoming quite outdated.
It is basically the same code since rocketpy was created.
There are some quick improvements that we can do, while not changing the behavior of the class.

## New behavior

The class still gives the same results, but with some refactoring like:

- F-strings as faster in python, let's use them!
- Added a docstring to the module, this may helps both users and devs. Now the `help(rocketpy.prints.flight_prints)` command will work.
- useless comments were removed (don't state the obvious with comments, that's annoying and does help anyone)
- docstrings were updated
- no code line is longer than 88 columns (pylint and flake8 restriction)
- improve parachute printing

## Breaking change
- [x] No

## Additional information

- Reviewers, please let me know if you have any suggestion regarding these prints.
- Here I provide a example of using the Flight.prints.all() after the refactor:

```text
Initial Conditions

Initial time: 0.000 s
Position - x: 0.00 m | y: 0.00 m | z: 1471.47 m
Velocity - Vx: 0.00 m/s | Vy: 0.00 m/s | Vz: 0.00 m/s
Attitude (quaternions) - e0: 0.999 | e1: -0.044 | e2: -0.000 | e3: 0.000
Euler Angles - Spin φ : 0.00° | Nutation θ: -5.00° | Precession ψ: 0.00°
Angular Velocity - ω1: 0.00 rad/s | ω2: 0.00 rad/s | ω3: 0.00 rad/s
Initial Stability Margin: 2.590 c


Surface Wind Conditions

Frontal Surface Wind Speed: 3.61 m/s
Lateral Surface Wind Speed: 1.51 m/s
Wind Direction: 157.33°
Wind heading: 337.33°


Launch Rail

Launch Rail Length: 5.2 m
Launch Rail Inclination: 85.00°
Launch Rail Heading: 0.00°


Rail Departure State

Rail Departure Time: 0.414 s
Rail Departure Velocity: 22.713 m/s
Rail Departure Stability Margin: 2.664 c
Rail Departure Angle of Attack: 9.875°
Rail Departure Thrust-Weight Ratio: 7.952
Rail Departure Reynolds Number: 1.664e+05


Burn out State

Burn out time: 3.900 s
Altitude at burn out: 495.223 m (AGL)
Rocket speed at burn out: 212.057 m/s
Freestream velocity at burn out: 211.868 m/s
Mach Number at burn out: 0.625
Kinetic energy at burn out: 4.905e+05 J


Apogee State

Apogee Time: 22.902 s
Apogee Altitude: 3845.312 m (ASL) | 2373.846 m (AGL)
Apogee Freestream Speed: 4.577 m/s


Parachute Events

Parachute: Drogue
	Ejection time: 22.905 s
	Inflation time: 24.405 s
	Freestream speed at inflation: 15.011 m/s
	Altitude at inflation: 3834.365 m (ASL) | 2373.846 m (AGL)
Parachute: Main
	Ejection time: 99.181 s
	Inflation time: 100.681 s
	Freestream speed at inflation: 20.326 m/s
	Altitude at inflation: 2241.511 m (ASL) | 800.551 m (AGL)


Impact Conditions

Time of impact: 222.191 s
X impact: 479.991 m
Y impact: 1528.874 m
Altitude impact: 1471.466 m (ASL) | -0.000 m (AGL) 
Latitude: 33.0040016°
Longitude: -106.9698514°
Vertical velocity at impact: -6.169 m/s
Number of parachutes triggered until impact: 2


Stability Margin

Initial Stability Margin: 2.590 c at 0.00 s
Out of Rail Stability Margin: 2.664 c at 0.41 s
Maximum Stability Margin: 3.657 c at 3.65 s
Minimum Stability Margin: 2.590 c at 0.00 s


Maximum Values

Maximum Speed: 215.533 m/s at 3.44 s
Maximum Mach Number: 0.635 Mach at 3.44 s
Maximum Reynolds Number: 1.518e+06 at 3.36 s
Maximum Dynamic Pressure: 2.292e+04 Pa at 3.38 s
Maximum Acceleration During Motor Burn: 78.654 m/s² at 0.15 s
Maximum Gs During Motor Burn: 8.020 g at 0.15 s
Maximum Acceleration After Motor Burn: 10.368 m/s² at 15.03 s
Maximum Gs After Motor Burn: 1.057 Gs at 15.03 s
Maximum Stability Margin: 3.657 c at 3.65 s
Maximum Upper Rail Button Normal Force: 0.969 N
Maximum Upper Rail Button Shear Force: 2.366 N
Maximum Lower Rail Button Normal Force: 0.621 N
Maximum Lower Rail Button Shear Force: 1.518 N


Numerical Integration Settings

Maximum Allowed Flight Time: 600.00 s
Maximum Allowed Time Step: inf s
Minimum Allowed Time Step: 0.00e+00 s
Relative Error Tolerance: 1e-06
Absolute Error Tolerance: [0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 1e-06, 1e-06, 1e-06, 1e-06, 0.001, 0.001, 0.001]
Allow Event Overshoot: True
Terminate Simulation on Apogee: False
Number of Time Steps Used: 1043
Number of Derivative Functions Evaluation: 2169
Average Function Evaluations per Time Step: 2.080
```
