### PR TITLE
BUG: Swap `rocket.total_mass.differentiate` for `motor.total_mass_flow rate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- BUG: Swap rocket.total_mass.differentiate for motor.total_mass_flow rate [#585](https://github.com/RocketPy-Team/RocketPy/pull/585)
 - BUG: export_eng 'Motor' method would not work for liquid motors. [#559](https://github.com/RocketPy-Team/RocketPy/pull/559) 
 
 ## [v1.2.2] - 2024-03-22

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -81,6 +81,9 @@ class Rocket:
         Function of time expressing the total mass of the rocket,
         defined as the sum of the propellant mass and the rocket
         mass without propellant.
+    Rocket.total_mass_flow_rate : Function
+        Time derivative of rocket's total mass in kg/s as a function
+        of time as obtained by the thrust source of the added motor.
     Rocket.thrust_to_weight : Function
         Function of time expressing the motor thrust force divided by rocket
         weight. The gravitational acceleration is assumed as 9.80665 m/s^2.
@@ -764,6 +767,7 @@ class Rocket:
             self.motor.center_of_dry_mass_position * _ + self.motor_position
         )
         self.nozzle_position = self.motor.nozzle_position * _ + self.motor_position
+        self.total_mass_flow_rate = self.motor.total_mass_flow_rate
         self.evaluate_dry_mass()
         self.evaluate_total_mass()
         self.evaluate_center_of_dry_mass()

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1645,8 +1645,8 @@ class Flight:
         # Retrieve necessary quantities
         rho = self.env.density.get_value_opt(z)
         total_mass = self.rocket.total_mass.get_value_opt(t)
-        total_mass_dot = self.rocket.total_mass.differentiate(t)
-        total_mass_ddot = self.rocket.total_mass.differentiate(t, order=2)
+        total_mass_dot = self.rocket.motor.total_mass_flow_rate(t)
+        total_mass_ddot = self.rocket.motor.total_mass_flow_rate.differentiate(t)
         ## CM position vector and time derivatives relative to CDM in body frame
         r_CM_z = (
             -1

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1645,8 +1645,8 @@ class Flight:
         # Retrieve necessary quantities
         rho = self.env.density.get_value_opt(z)
         total_mass = self.rocket.total_mass.get_value_opt(t)
-        total_mass_dot = self.rocket.motor.total_mass_flow_rate(t)
-        total_mass_ddot = self.rocket.motor.total_mass_flow_rate.differentiate(t)
+        total_mass_dot = self.rocket.total_mass_flow_rate.get_value_opt(t)
+        total_mass_ddot = self.rocket.total_mass_flow_rate.differentiate(t)
         ## CM position vector and time derivatives relative to CDM in body frame
         r_CM_z = (
             -1

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -604,12 +604,12 @@ def test_max_values(flight_calisto_robust):
     calculated by hand, it was just copied from the test results. This is
     because the expected values are not easy to calculate by hand, and the
     results are not expected to change. If the results change, the test will
-    fail, and the expected values must be updated. If if want to update the
-    values, always double check if the results are really correct. Acceptable
-    reasons for changes in the results are: 1) changes in the code that
-    improve the accuracy of the simulation, 2) a bug was found and fixed. Keep
-    in mind that other tests may be more accurate than this one, for example,
-    the acceptance tests, which are based on the results of real flights.
+    fail, and the expected values must be updated. If the values are updated,
+    always double check if the results are really correct. Acceptable reasons
+    for changes in the results are: 1) changes in the code that improve the
+    accuracy of the simulation, 2) a bug was found and fixed. Keep in mind that
+    other tests may be more accurate than this one, for example, the acceptance
+    tests, which are based on the results of real flights.
 
     Parameters
     ----------
@@ -622,7 +622,7 @@ def test_max_values(flight_calisto_robust):
     assert pytest.approx(105.2774, abs=atol) == test.max_acceleration_power_on
     assert pytest.approx(105.2774, abs=atol) == test.max_acceleration
     assert pytest.approx(0.85999, abs=atol) == test.max_mach_number
-    assert pytest.approx(285.90240, abs=atol) == test.max_speed
+    assert pytest.approx(285.94948, abs=atol) == test.max_speed
 
 
 def test_rail_buttons_forces(flight_calisto_custom_wind):


### PR DESCRIPTION
## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Description

If a simulation is using the new EOMs and has a time node at the motor burn-out time, an outlier acceleration value might be calculated:

![image](https://github.com/RocketPy-Team/RocketPy/assets/69485049/b5c015f8-ef34-431c-b433-8049a573d6d4)

This is due to the second-order differentiation of `rocket.total_mass` blowing up due to numerical errors. Swapping this to `motor.total_mass_flow_rate` gives the following:

![image](https://github.com/RocketPy-Team/RocketPy/assets/69485049/3672c7b1-ec42-4384-9d2c-a8490533577f)

This makes `u_dot_generalized` more similar to the old udot

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No
