### PR TITLE
DEP: delete deprecated rocketpy.tools.cached_property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- DEP: delete deprecated rocketpy.tools.cached_property [#587](https://github.com/RocketPy-Team/RocketPy/pull/587) 
 - DOC: Improvements of Environment docstring phrasing [#565](https://github.com/RocketPy-Team/RocketPy/pull/565)
 - MNT: Refactor flight prints module [#579](https://github.com/RocketPy-Team/RocketPy/pull/579)
 - DOC: Convert CompareFlights example notebooks to .rst files [#576](https://github.com/RocketPy-Team/RocketPy/pull/576)

--- a/rocketpy/environment/environment_analysis.py
+++ b/rocketpy/environment/environment_analysis.py
@@ -3,15 +3,11 @@ import copy
 import datetime
 import json
 from collections import defaultdict
+from functools import cached_property
 
 import netCDF4
 import numpy as np
 import pytz
-
-try:
-    from functools import cached_property
-except ImportError:
-    from ..tools import cached_property
 
 from ..mathutils.function import Function
 from ..plots.environment_analysis_plots import _EnvironmentAnalysisPlots

--- a/rocketpy/environment/environment_analysis.py
+++ b/rocketpy/environment/environment_analysis.py
@@ -8,6 +8,11 @@ import netCDF4
 import numpy as np
 import pytz
 
+try:
+    from functools import cached_property
+except ImportError:
+    from ..tools import cached_property
+
 from ..mathutils.function import Function
 from ..plots.environment_analysis_plots import _EnvironmentAnalysisPlots
 from ..prints.environment_analysis_prints import _EnvironmentAnalysisPrints
@@ -21,11 +26,6 @@ from ..tools import (
 )
 from ..units import convert_units
 from .environment import Environment
-
-try:
-    from functools import cached_property
-except ImportError:
-    from ..tools import cached_property
 
 # TODO: the average_wind_speed_profile_by_hour and similar methods could be more abstract than currently are
 

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -7,17 +7,13 @@ carefully as it may impact all the rest of the project.
 import warnings
 from collections.abc import Iterable
 from copy import deepcopy
+from functools import cached_property
 from inspect import signature
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import integrate, linalg, optimize
-
-try:
-    from functools import cached_property
-except ImportError:
-    from ..tools import cached_property
 
 NUMERICAL_TYPES = (float, int, complex, np.ndarray, np.integer, np.floating)
 

--- a/rocketpy/mathutils/vector_matrix.py
+++ b/rocketpy/mathutils/vector_matrix.py
@@ -1,7 +1,6 @@
 from cmath import isclose
+from functools import cached_property
 from itertools import product
-
-from rocketpy.tools import cached_property
 
 
 class Vector:

--- a/rocketpy/motors/hybrid_motor.py
+++ b/rocketpy/motors/hybrid_motor.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 from rocketpy.tools import parallel_axis_theorem_from_com
 
 from ..mathutils.function import Function, funcify_method, reset_funcified_methods
@@ -6,11 +8,6 @@ from ..prints.hybrid_motor_prints import _HybridMotorPrints
 from .liquid_motor import LiquidMotor
 from .motor import Motor
 from .solid_motor import SolidMotor
-
-try:
-    from functools import cached_property
-except ImportError:
-    from ..tools import cached_property
 
 
 class HybridMotor(Motor):

--- a/rocketpy/motors/liquid_motor.py
+++ b/rocketpy/motors/liquid_motor.py
@@ -1,4 +1,4 @@
-import warnings
+from functools import cached_property
 
 import numpy as np
 
@@ -12,11 +12,6 @@ from rocketpy.tools import parallel_axis_theorem_from_com
 from ..plots.liquid_motor_plots import _LiquidMotorPlots
 from ..prints.liquid_motor_prints import _LiquidMotorPrints
 from .motor import Motor
-
-try:
-    from functools import cached_property
-except ImportError:
-    from ..tools import cached_property
 
 
 class LiquidMotor(Motor):

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -1,6 +1,7 @@
 import re
 import warnings
 from abc import ABC, abstractmethod
+from functools import cached_property
 
 import numpy as np
 
@@ -8,11 +9,6 @@ from ..mathutils.function import Function, funcify_method
 from ..plots.motor_plots import _MotorPlots
 from ..prints.motor_prints import _MotorPrints
 from ..tools import parallel_axis_theorem_from_com, tuple_handler
-
-try:
-    from functools import cached_property
-except ImportError:
-    from ..tools import cached_property
 
 
 class Motor(ABC):

--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 import numpy as np
 from scipy import integrate
 
@@ -5,11 +7,6 @@ from ..mathutils.function import Function, funcify_method, reset_funcified_metho
 from ..plots.solid_motor_plots import _SolidMotorPlots
 from ..prints.solid_motor_prints import _SolidMotorPrints
 from .motor import Motor
-
-try:
-    from functools import cached_property
-except ImportError:
-    from ..tools import cached_property
 
 
 class SolidMotor(Motor):

--- a/rocketpy/motors/tank_geometry.py
+++ b/rocketpy/motors/tank_geometry.py
@@ -11,10 +11,7 @@ except ImportError:
 
     cache = lru_cache(maxsize=None)
 
-try:
-    from functools import cached_property
-except ImportError:
-    from ..tools import cached_property
+from functools import cached_property
 
 
 class TankGeometry:

--- a/rocketpy/plots/flight_plots.py
+++ b/rocketpy/plots/flight_plots.py
@@ -1,10 +1,7 @@
+from functools import cached_property
+
 import matplotlib.pyplot as plt
 import numpy as np
-
-try:
-    from functools import cached_property
-except ImportError:
-    from ..tools import cached_property
 
 
 class _FlightPlots:

--- a/rocketpy/rocket/aero_surface.py
+++ b/rocketpy/rocket/aero_surface.py
@@ -1,6 +1,5 @@
 import warnings
 from abc import ABC, abstractmethod
-from functools import cached_property
 
 import numpy as np
 from scipy.optimize import fsolve

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -7,35 +7,12 @@ import numpy as np
 import pytz
 from cftime import num2pydate
 from packaging import version as packaging_version
+from functools import cached_property
 
 _NOT_FOUND = object()
 
 # Mapping of module name and the name of the package that should be installed
 INSTALL_MAPPING = {"IPython": "ipython"}
-
-
-class cached_property:
-    def __init__(self, func):
-        self.func = func
-        self.attrname = None
-        self.__doc__ = func.__doc__
-
-    def __set_name__(self, owner, name):
-        self.attrname = name
-
-    def __get__(self, instance, owner=None):
-        if instance is None:
-            return self
-        if self.attrname is None:
-            raise TypeError(
-                "Cannot use cached_property instance without calling __set_name__ on it."
-            )
-        cache = instance.__dict__
-        val = cache.get(self.attrname, _NOT_FOUND)
-        if val is _NOT_FOUND:
-            val = self.func(instance)
-            cache[self.attrname] = val
-        return val
 
 
 def tuple_handler(value):

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -7,9 +7,6 @@ import numpy as np
 import pytz
 from cftime import num2pydate
 from packaging import version as packaging_version
-from functools import cached_property
-
-_NOT_FOUND = object()
 
 # Mapping of module name and the name of the package that should be installed
 INSTALL_MAPPING = {"IPython": "ipython"}


### PR DESCRIPTION
## Pull request type

- [x] Other (please describe):

## Checklist

- [ ] Tests for the changes have been added (if needed) (not necessary)
- [ ] Docs have been reviewed and added / updated (not necessary)
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
This PR completes the previous PR #541, which solves the issue #531 

## New behavior
Use the `cached_property` class from functools instead of rocketpy.tools.

## Breaking change

- [x] Yes (importing cached_property from rocketpy.tools won't be possible. Is it a big enough reason to be concerned? I don't think so.)

## Additional information
I used git cherry-pick to save Daniel's commit.