### PR TITLE
TST: temporary changing git actions

### DIFF
--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        python-version: [3.8, 3.12]
+        os: [macos-latest]
+        python-version: [3.9, 3.12]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: [3.8, 3.12]
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -16,8 +16,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest]
-        python-version: [3.9, 3.12]
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.8, 3.12]
+        include:
+          - os: macos-latest
+            python-version: 3.12
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}


### PR DESCRIPTION
I am removing macOS + python 3.8 from the tests matrix. 

This will avoid a hdf5 error that is preventing us to install rocketpy on macOS using python 3.8

For future reference: https://github.com/h5py/h5py/issues/2408