### PR TITLE
FIX: Optional Dependencies Naming in pyproject.toml.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- BUG: Optional Dependencies Naming in pyproject.toml. [#592](https://github.com/RocketPy-Team/RocketPy/pull/592)
 - BUG: Swap rocket.total_mass.differentiate for motor.total_mass_flow rate [#585](https://github.com/RocketPy-Team/RocketPy/pull/585)
 - BUG: export_eng 'Motor' method would not work for liquid motors. [#559](https://github.com/RocketPy-Team/RocketPy/pull/559) 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,15 @@ tests = [
     "isort"
 ]
 
-env_analysis = [ 
+env-analysis = [ 
     "windrose>=1.6.8", 
     "timezonefinder", 
     "jsonpickle", 
     "ipython", 
     "ipywidgets>=7.6.3" 
 ]
+
+all = ["rocketpy[env-analysis]"]
 
 [tool.black]
 line-length = 88 


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

The installation of optional dependencies `env-analysis` and `àll` is not working as expected, yielding the following results:

<details>
<summary>env-analysis install results</summary>
<br>
<img width="764" alt="pyproject_env" src="https://github.com/RocketPy-Team/RocketPy/assets/87212571/7882f823-5c1f-4b40-9df6-5e97ba2b39ff">
<br>
<p>The same happens with `env_analysis`.</p>
</details>

<details>
<summary>"all" install result</summary>
<br>
<img width="757" alt="pyproject_all" src="https://github.com/RocketPy-Team/RocketPy/assets/87212571/40ad43b1-d9cd-4773-b4d6-015f7a736ba0">
</details>

## New behavior
<!-- Describe changes introduced by this PR. -->

Changing the naming of `env_anaysis` to the [python package normalized](https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization) `env-analysis` fixes the first installation issue.

The second was the addition of the `all` to the optional dependencies.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

The recursive syntax to generate the `all` in the `pyproject.toml` file is only supported from [`pip>=21.2`](https://pip.pypa.io/en/stable/news/#v21-2) (from 2021). The `+` symbol from `setup.py` is not valid in `pyproject.toml`.

If this is understood as a too strict version compromise, listing all the dependencies is the alternative.
