### PR TITLE
BUG: plot drag curves when function source is callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- BUG: plot drag curves when function source is callable [#599](https://github.com/RocketPy-Team/RocketPy/pull/599)
 - BUG: Fix minor type hinting problems [#598](https://github.com/RocketPy-Team/RocketPy/pull/598)
 - BUG: Optional Dependencies Naming in pyproject.toml. [#592](https://github.com/RocketPy-Team/RocketPy/pull/592)
 - BUG: Swap rocket.total_mass.differentiate for motor.total_mass_flow rate [#585](https://github.com/RocketPy-Team/RocketPy/pull/585)

--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -134,10 +134,22 @@ class _RocketPlots:
         None
         """
 
-        x_power_drag_off = self.rocket.power_off_drag.x_array
-        y_power_drag_off = self.rocket.power_off_drag.y_array
-        x_power_drag_on = self.rocket.power_on_drag.x_array
-        y_power_drag_on = self.rocket.power_on_drag.y_array
+        try:
+            x_power_drag_on = self.rocket.power_on_drag.x_array
+            y_power_drag_on = self.rocket.power_on_drag.y_array
+        except AttributeError:
+            x_power_drag_on = np.linspace(0, 2, 50)
+            y_power_drag_on = np.array(
+                [self.rocket.power_on_drag.source(x) for x in x_power_drag_on]
+            )
+        try:
+            x_power_drag_off = self.rocket.power_off_drag.x_array
+            y_power_drag_off = self.rocket.power_off_drag.y_array
+        except AttributeError:
+            x_power_drag_off = np.linspace(0, 2, 50)
+            y_power_drag_off = np.array(
+                [self.rocket.power_off_drag.source(x) for x in x_power_drag_off]
+            )
 
         fig, ax = plt.subplots()
         ax.plot(x_power_drag_on, y_power_drag_on, label="Power on Drag")


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [ ] Tests for the changes have been added (if needed) (no idea on how to do that smartly)
- [ ] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
When you use a callable object as the source of your power_on or power_off curves in the Rocket class, the `all_info()` method will break because `self.rocket.power_on_drag.x_array` is inexistent

## New behavior
Solved the issue by  adding a try/except block that will prevent code from breaking in the situation 

## Breaking change
- [x] No

## Additional information
None