### PR TITLE
ENH: implement powerseries NoseCones (#475)

### DIFF
--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -1024,7 +1024,14 @@ class Rocket:
         return tail
 
     def add_nose(
-        self, length, kind, position, bluffness=0, name="Nose Cone", base_radius=None
+        self,
+        length,
+        kind,
+        position,
+        bluffness=0,
+        power=None,
+        name="Nose Cone",
+        base_radius=None,
     ):
         """Creates a nose cone, storing its parameters as part of the
         aerodynamic_surfaces list. Its parameters are the axial position
@@ -1038,14 +1045,17 @@ class Rocket:
             Nose cone length or height in meters. Must be a positive
             value.
         kind : string
-            Nose cone type. Von Karman, conical, ogive, and lvhaack are
-            supported.
+            Nose cone type. Von Karman, conical, ogive, lvhaack and
+            powerseries are supported.
         position : int, float
             Nose cone tip coordinate relative to the rocket's coordinate system.
             See `Rocket.coordinate_system_orientation` for more information.
         bluffness : float, optional
             Ratio between the radius of the circle on the tip of the ogive and
             the radius of the base of the ogive.
+        power : float, optional
+            Factor that controls the bluntness of the nose cone shape when
+            using a 'powerseries' nose cone kind.
         name : string
             Nose cone name. Default is "Nose Cone".
         base_radius : int, float, optional
@@ -1067,6 +1077,7 @@ class Rocket:
             base_radius=base_radius or self.radius,
             rocket_radius=base_radius or self.radius,
             bluffness=bluffness,
+            power=power,
             name=name,
         )
         self.add_surfaces(nose, position)


### PR DESCRIPTION
## Pull request type
- [x] Code changes (bugfix, features)

## Checklist
- [ ] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
This PR implements [power series nosecones](https://en.wikipedia.org/wiki/Nose_cone_design#Power_series), as requested in #475 .

## New behavior
The implementation required adding an extra argument, 'power', to the initialization of the 'NoseCone' class and the 'add_nose' method on the Rocket class.

I tried to maintain the implementation style using setters and property decorators.

I calculated the _enigmatic_ 'self.k' attribute, used to compute the Center of Pressure, in the same way other methods calculate it:

$k = 1 - V/(2\pi R^2 L) $.

$V$ can be computed using basic calculus on the volume of 

$V = \int_{0}^{L} \pi (R\frac{x}{L}) ^ {2n} dx$.

Since this is a simple integral, the final result (if I computed things correctly):

$k = \frac{2n}{2n + 1}$

## Breaking change
- [x] No

## Additional information

I tested it on the example rocket in the Getting Started notebook. Here are some drawings with different values for the 'power' parameter:

$n = 0.2$
![powerseries_draw_0-2](https://github.com/RocketPy-Team/RocketPy/assets/57069366/524d323f-e499-4fe9-9b66-f032e490032a)

$n = 0.5$
![powerseries_draw_0-5](https://github.com/RocketPy-Team/RocketPy/assets/57069366/59350309-66a9-47cc-8034-a8acaeffeec2)

$n = 0.8$
![powerseries_draw_0-8](https://github.com/RocketPy-Team/RocketPy/assets/57069366/85ff9707-3943-4a27-a244-2282e602ed55)

