### PR TITLE
BUG: Fixes nose cone bluffness issue #610

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- BUG: Fixes nose cone bluffness issue #610 [#611](https://github.com/RocketPy-Team/RocketPy/pull/611)
 - BUG: plot drag curves when function source is callable [#599](https://github.com/RocketPy-Team/RocketPy/pull/599)
 - BUG: Fix minor type hinting problems [#598](https://github.com/RocketPy-Team/RocketPy/pull/598)
 - BUG: Optional Dependencies Naming in pyproject.toml. [#592](https://github.com/RocketPy-Team/RocketPy/pull/592)

--- a/rocketpy/rocket/aero_surface.py
+++ b/rocketpy/rocket/aero_surface.py
@@ -413,11 +413,11 @@ class NoseCone(AeroSurface):
                     r_circle, circle_center, x_init = 0, 0, 0
                 else:
                     # Find the intersection point between circle and nosecone curve
-                    x_init = fsolve(lambda x: find_radius(x) - r_circle, r_circle)[0]
+                    x_init = fsolve(lambda x: find_radius(x[0]) - r_circle, r_circle)[0]
                     circle_center = find_x_intercept(x_init)
             else:
                 # Find the intersection point between circle and nosecone curve
-                x_init = fsolve(lambda x: find_radius(x) - r_circle, r_circle)[0]
+                x_init = fsolve(lambda x: find_radius(x[0]) - r_circle, r_circle)[0]
                 circle_center = find_x_intercept(x_init)
 
         # Calculate a function to create the circle at the correct position


### PR DESCRIPTION
## Pull request type

Bug fix issue #610 .

- [x] Code changes (bugfix, features)

## Checklist

- [x] Lint (`black rocketpy/ tests/`) has passed locally 

## Current behavior
The `find_radius` method inside the `NoseCone` class computes the square of its argument `x`. The lambda function, however, passes a list to it, causing a `TypeError`.

## New behavior
Just pass the value instead of the list.

## Breaking change

- [x] No
