### PR TITLE
DEV: remove windows py3.8 from ci

### DIFF
--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -18,10 +18,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: [3.8, 3.12]
         include:
           - os: macos-latest
+            python-version: 3.12
+          - os: windows-latest
             python-version: 3.12
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
## Pull request type

- [x] ReadMe, Docs and GitHub updates

## Current behavior
CI is breaking due to a problem with netcdf4 installation on windows with python 3.8.
This was caused due to the latest release of netcdf4, version 1.7.0

## New behavior
GitHub Actions will no longer run on windows with python 3.8, but the python 3.12 is kept for os compatibility check.
This is a temporary fix that will be rolled back after netcdf4 fix of: https://github.com/Unidata/netcdf4-python/issues/1329

## Breaking change
- [x] No

## Additional information

No further comments.
