### PR TITLE
MNT: Bump Minimum Python version to 3.9.

### DIFF
--- a/.github/workflows/lint_black.yaml
+++ b/.github/workflows/lint_black.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install Python dependencies
         run: pip install black[jupyter]

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -18,13 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: [3.8, 3.12]
-        include:
-          - os: macos-latest
-            python-version: 3.12
-          - os: windows-latest
-            python-version: 3.12
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.9, 3.12]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/.pylintrc
+++ b/.pylintrc
@@ -88,7 +88,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.8
+py-version=3.9
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - yyyy-mm-dd
 
-<!-- These are the changes that were not release yet, please add them correctly.
+<!-- These are the changes that were not released yet, please add them correctly.
 Attention: The newest changes should be on top -->
+
+### Added
+
+### Changed
+
+- MNT: bump minimum Python version to 3.9. [#624](https://github.com/RocketPy-Team/RocketPy/pull/624)
+
+### Fixed
+
 
 ## [1.3.0.post1] - 2024-06-02
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 version: '3.8'
 
 services:
-  python38-linux:
-    image: python:3.8
+  python39-linux:
+    image: python:3.9
     volumes:
       - .:/app
     working_dir: /app

--- a/docs/development/docker.rst
+++ b/docs/development/docker.rst
@@ -108,7 +108,7 @@ operational system.
 However, it is still useful to run the unit tests on different python versions.
 
 Currently, the `docker-compose.yml` file is configured to run the unit tests
-on python 3.8 and 3.12.
+on python 3.9 and 3.12.
 
 To run the unit tests on both python versions, run the following command
 **on your machine**:

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -85,9 +85,9 @@ Requirements
 Python Version
 ^^^^^^^^^^^^^^
 
-RocketPy supports Python 3.8 and above.
+RocketPy supports Python 3.9 and above.
 Sorry, there are currently no plans to support earlier versions.
-If you really need to run RocketPy on Python 3.7 or earlier, feel free to submit an issue and we will see what we can do!
+If you really need to run RocketPy on Python 3.8 or earlier, feel free to submit an issue and we will see what we can do!
 
 Required Packages
 ^^^^^^^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.3.0.post1"
 description="Advanced 6-DOF trajectory simulation for High-Power Rocketry."
 dynamic = ["dependencies"]
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
   {name = "Giovani Hidalgo Ceotto", email = "ghceotto@gmail.com"}
 ]


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code maintenance (refactoring, formatting, tests)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [X] Docs have been reviewed and added / updated
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest tests -m slow --runslow`) have passed locally
- [X] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

As Python 3.8 nears the end of its life in a few months and many of rocketpy dependencies having removed it from official support, it is time to drop rocketpy Python 3.8 support.

## New behavior
<!-- Describe changes introduced by this PR. -->

This PR raises the minimum Python requirements to 3.9.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

Short PR, but I advise to review it carefully. It is easy to mess up by accident the version numbers, or not catch a place that should be changed.
