### PR TITLE
ENH: adding rocket radius to RailButtons class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@ Attention: The newest changes should be on top -->
 - 
 
 ### Changed
-
-- 
+ 
+- ENH: Adding rocket radius to RailButtons class [#643](https://github.com/RocketPy-Team/RocketPy/pull/643)
 
 ### Fixed
 
@@ -50,10 +50,10 @@ You can install this version by running `pip install rocketpy==1.4.1`
 
 - Bumps rocketpy version to 1.4.1 [#646](https://github.com/RocketPy-Team/RocketPy/pull/646)
 - ENH: Insert apogee state into solution list during flight simulation [#638](https://github.com/RocketPy-Team/RocketPy/pull/638)
+- MNT: Refactor AeroSurfaces [#634](https://github.com/RocketPy-Team/RocketPy/pull/634)
 - ENH: Environment class major refactor may 2024 [#605](https://github.com/RocketPy-Team/RocketPy/pull/605)
 - MNT: Refactors the code to adopt flake8 [#631](https://github.com/RocketPy-Team/RocketPy/pull/631)
 - MNT: Refactors the code to adopt pylint [#621](https://github.com/RocketPy-Team/RocketPy/pull/621)
-- MNT: Refactor AeroSurfaces [#634](https://github.com/RocketPy-Team/RocketPy/pull/634)
 
 ## [1.4.0] - 2024-07-06
 

--- a/rocketpy/rocket/aero_surface/rail_buttons.py
+++ b/rocketpy/rocket/aero_surface/rail_buttons.py
@@ -36,6 +36,10 @@ class RailButtons(AeroSurface):
             relative to one of the other principal axis.
         name : string, optional
             Name of the rail buttons. Default is "Rail Buttons".
+        rocket_radius : int, float, optional
+            Radius of the rocket at the location of the rail buttons in meters.
+            If not provided, it will be calculated when the RailButtons object
+            is added to a Rocket object.
 
         Returns
         -------

--- a/rocketpy/rocket/aero_surface/rail_buttons.py
+++ b/rocketpy/rocket/aero_surface/rail_buttons.py
@@ -17,7 +17,13 @@ class RailButtons(AeroSurface):
         relative to one of the other principal axis.
     """
 
-    def __init__(self, buttons_distance, angular_position=45, name="Rail Buttons"):
+    def __init__(
+        self,
+        buttons_distance,
+        angular_position=45,
+        name="Rail Buttons",
+        rocket_radius=None,
+    ):
         """Initializes RailButtons Class.
 
         Parameters
@@ -40,7 +46,7 @@ class RailButtons(AeroSurface):
         self.buttons_distance = buttons_distance
         self.angular_position = angular_position
         self.name = name
-
+        self.rocket_radius = rocket_radius
         self.evaluate_lift_coefficient()
         self.evaluate_center_of_pressure()
 

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -962,10 +962,11 @@ class Rocket:
             positions = [positions]
 
         for surface, position in zip(surfaces, positions):
-            self.aerodynamic_surfaces.add(surface, position)
             if isinstance(surface, RailButtons):
                 surface.rocket_radius = surface.rocket_radius or self.radius
                 self.rail_buttons.add(surface, position)
+            else:
+                self.aerodynamic_surfaces.add(surface, position)
 
         self.evaluate_center_of_pressure()
         self.evaluate_stability_margin()

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -964,10 +964,7 @@ class Rocket:
             for surface, position in zip(surfaces, positions):
                 self.aerodynamic_surfaces.add(surface, position)
                 if isinstance(surface, RailButtons):
-                    try:
-                        self.rail_buttons.add(surface, position)
-                    except TypeError:
-                        self.rail_buttons.add(surface, positions)
+                    self.rail_buttons.add(surface, position)
         except TypeError:
             self.aerodynamic_surfaces.add(surfaces, positions)
 

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -956,9 +956,18 @@ class Rocket:
         -------
         None
         """
+        if isinstance(surfaces, list) is False:
+            if isinstance(surfaces, RailButtons):
+                surfaces = [surfaces]
+                positions = [positions]
         try:
             for surface, position in zip(surfaces, positions):
                 self.aerodynamic_surfaces.add(surface, position)
+                if isinstance(surface, RailButtons):
+                    try:
+                        self.rail_buttons.add(surface, position)
+                    except TypeError:
+                        self.rail_buttons.add(surface, positions)
         except TypeError:
             self.aerodynamic_surfaces.add(surfaces, positions)
 

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -947,6 +947,7 @@ class Rocket:
             the root chord which is highest in the rocket coordinate system.
             For Tail type, position is relative to the point belonging to the
             tail which is highest in the rocket coordinate system.
+            For RailButtons type, position is relative to the lower rail button.
 
         See Also
         --------
@@ -956,17 +957,15 @@ class Rocket:
         -------
         None
         """
-        if isinstance(surfaces, list) is False:
-            if isinstance(surfaces, RailButtons):
-                surfaces = [surfaces]
-                positions = [positions]
-        try:
-            for surface, position in zip(surfaces, positions):
-                self.aerodynamic_surfaces.add(surface, position)
-                if isinstance(surface, RailButtons):
-                    self.rail_buttons.add(surface, position)
-        except TypeError:
-            self.aerodynamic_surfaces.add(surfaces, positions)
+        if not isinstance(surfaces, list):
+            surfaces = [surfaces]
+            positions = [positions]
+
+        for surface, position in zip(surfaces, positions):
+            self.aerodynamic_surfaces.add(surface, position)
+            if isinstance(surface, RailButtons):
+                surface.rocket_radius = surface.rocket_radius or self.radius
+                self.rail_buttons.add(surface, position)
 
         self.evaluate_center_of_pressure()
         self.evaluate_stability_margin()
@@ -1518,6 +1517,7 @@ class Rocket:
         rail_buttons = RailButtons(
             buttons_distance=buttons_distance, angular_position=angular_position
         )
+        rail_buttons.rocket_radius = rail_buttons.rocket_radius or self.radius
         self.rail_buttons.add(rail_buttons, lower_button_position)
         return rail_buttons
 

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -8,8 +8,6 @@ import numpy as np
 import simplekml
 from scipy import integrate
 
-from rocketpy.rocket.aero_surface import RailButtons
-
 from ..mathutils.function import Function, funcify_method
 from ..mathutils.vector_matrix import Matrix, Vector
 from ..plots.flight_plots import _FlightPlots
@@ -1725,8 +1723,6 @@ class Flight:  # pylint: disable=too-many-public-methods
         velocity_in_body_frame = Kt @ v
         # Calculate lift and moment for each component of the rocket
         for aero_surface, position in self.rocket.aerodynamic_surfaces:
-            if isinstance(aero_surface, RailButtons):
-                continue
             comp_cpz = (
                 position - self.rocket.center_of_dry_mass_position
             ) * self.rocket._csys - aero_surface.cpz

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -8,6 +8,8 @@ import numpy as np
 import simplekml
 from scipy import integrate
 
+from rocketpy.rocket.aero_surface import RailButtons
+
 from ..mathutils.function import Function, funcify_method
 from ..mathutils.vector_matrix import Matrix, Vector
 from ..plots.flight_plots import _FlightPlots
@@ -1723,6 +1725,8 @@ class Flight:  # pylint: disable=too-many-public-methods
         velocity_in_body_frame = Kt @ v
         # Calculate lift and moment for each component of the rocket
         for aero_surface, position in self.rocket.aerodynamic_surfaces:
+            if isinstance(aero_surface, RailButtons):
+                continue
             comp_cpz = (
                 position - self.rocket.center_of_dry_mass_position
             ) * self.rocket._csys - aero_surface.cpz

--- a/tests/unit/test_rocket.py
+++ b/tests/unit/test_rocket.py
@@ -395,9 +395,10 @@ def test_set_rail_button(calisto):
 def test_add_rail_button(calisto, calisto_rail_buttons):
     calisto.add_surfaces(calisto_rail_buttons, -0.5)
     assert calisto.rail_buttons[0].position == -0.5
-    assert calisto.rail_buttons[0].component.buttons_distance + calisto.rail_buttons[
-        0
-    ].position == pytest.approx(0.7, 1e-12)
+    upper_position = (
+        calisto_rail_buttons.buttons_distance + calisto.rail_buttons[0].position
+    )
+    assert upper_position == pytest.approx(0.2, 1e-12)
 
 
 def test_evaluate_total_mass(calisto_motorless):

--- a/tests/unit/test_rocket.py
+++ b/tests/unit/test_rocket.py
@@ -392,6 +392,14 @@ def test_set_rail_button(calisto):
     ].position == pytest.approx(0.2, 1e-12)
 
 
+def test_add_rail_button(calisto, calisto_rail_buttons):
+    calisto.add_surfaces(calisto_rail_buttons, -0.5)
+    assert calisto.rail_buttons[0].position == -0.5
+    assert calisto.rail_buttons[0].component.buttons_distance + calisto.rail_buttons[
+        0
+    ].position == pytest.approx(0.7, 1e-12)
+
+
 def test_evaluate_total_mass(calisto_motorless):
     """Tests the evaluate_total_mass method of the Rocket class.
     Both with respect to return instances and expected behaviour.


### PR DESCRIPTION
## Pull request type

- [X] Code changes (bugfix, features)

## Checklist
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest tests -m slow --runslow`) have passed locally

## Current behavior
A small change (addition of the rocket_radius attribute) was made to the RailButtons class to resolve issue #606. For the change to work in practical simulations, small changes were made to the rocket.py (add_surfaces method) and flight.py (u_dot_generalized method) files.

## New behavior
It is now possible to use the RailButtons class in the way the user tried, without major changes to the code and with everything apparently working.

## Breaking change
- [X] No