### PR TITLE
BUG: Time Node Merge Not Including Controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
-- 
+- BUG: Time Node Merge Not Including Controllers [#647](https://github.com/RocketPy-Team/RocketPy/pull/647)
 
 ## [v1.4.1] - 2024-07-20
 

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -3498,6 +3498,7 @@ class Flight:  # pylint: disable=too-many-public-methods
                 try:
                     # Try to access the node and merge if it exists
                     tmp_dict[time].parachutes += node.parachutes
+                    tmp_dict[time]._controllers += node._controllers
                     tmp_dict[time].callbacks += node.callbacks
                 except KeyError:
                     # If the node does not exist, add it to the dictionary


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] `CHANGELOG.md` has been updated (if relevant)

## Description

Found by team RED on Discord.

Controller time nodes were being ignored and discarded  in the merging of the time nodes, now they are correctly considered
