### PR TITLE
DEV: fix tests with numpy2

### DIFF
--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -53,7 +53,9 @@ jobs:
         run: pytest tests/unit --cov=rocketpy
 
       - name: Run Documentation Tests
-        run: pytest rocketpy --doctest-modules --cov=rocketpy --cov-append
+        run: |
+          pip install numpy --upgrade
+          pytest rocketpy --doctest-modules --cov=rocketpy --cov-append
 
       - name: Run Integration Tests
         run: pytest tests/integration --cov=rocketpy --cov-append

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -20,6 +20,7 @@ from scipy import integrate, linalg, optimize
 # Numpy 1.x compatibility,
 # TODO: remove these lines when all dependencies support numpy>=2.0.0
 if np.lib.NumpyVersion(np.__version__) >= "2.0.0b1":
+    # pylint: disable=no-name-in-module
     from numpy import trapezoid  # pragma: no cover
 else:
     from numpy import trapz as trapezoid  # pragma: no cover


### PR DESCRIPTION
for some weird reason the CI is installing numpy 1.26 instead of 2.0 since last week.