### PR TITLE
BUG: Pressure ISA Extrapolation as "linear"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
+- BUG: Pressure ISA Extrapolation as "linear" [#675](https://github.com/RocketPy-Team/RocketPy/pull/675)
 - BUG: fix the Frequency Response plot of Flight class [#653](https://github.com/RocketPy-Team/RocketPy/pull/653)
 
 ## [v1.4.2] - 2024-08-03

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -2382,7 +2382,7 @@ class Environment:
             DeprecationWarning,
         )
 
-    @funcify_method("Height Above Sea Level (m)", "Pressure (Pa)", "spline", "linear")
+    @funcify_method("Height Above Sea Level (m)", "Pressure (Pa)", "spline", "natural")
     def pressure_ISA(self):
         """Pressure, in Pa, as a function of height above sea level as defined
         by the `International Standard Atmosphere ISO 2533`."""


### PR DESCRIPTION
## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)


## Info

Extrapolation was being incorrectly set on `pressure_ISA` which was causing it to raise an undesired warning