### PR TITLE
BUG: Zero Mass Flow Tank causing Empty Velocity Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
+- BUG: Zero Mass Flow Rate in Liquid Motors breaks Exhaust Velocity [#677](https://github.com/RocketPy-Team/RocketPy/pull/677)
 - DOC: Fix documentation dependencies [#651](https://github.com/RocketPy-Team/RocketPy/pull/651)
 - DOC: Fix documentation warnings [#645](https://github.com/RocketPy-Team/RocketPy/pull/645)
 - BUG: Rotational EOMs Not Relative To CDM [#674](https://github.com/RocketPy-Team/RocketPy/pull/674)

--- a/rocketpy/motors/liquid_motor.py
+++ b/rocketpy/motors/liquid_motor.py
@@ -266,16 +266,16 @@ class LiquidMotor(Motor):
         """
         times, thrusts = self.thrust.source[:, 0], self.thrust.source[:, 1]
         mass_flow_rates = self.mass_flow_rate(times)
+        exhaust_velocity = np.zeros_like(mass_flow_rates)
 
         # Compute exhaust velocity only for non-zero mass flow rates
         valid_indices = mass_flow_rates != 0
-        valid_times = times[valid_indices]
-        valid_thrusts = thrusts[valid_indices]
-        valid_mass_flow_rates = mass_flow_rates[valid_indices]
 
-        ext_vel = -valid_thrusts / valid_mass_flow_rates
+        exhaust_velocity[valid_indices] = (
+            -thrusts[valid_indices] / mass_flow_rates[valid_indices]
+        )
 
-        return np.column_stack([valid_times, ext_vel])
+        return np.column_stack([times, exhaust_velocity])
 
     @funcify_method("Time (s)", "Propellant Mass (kg)")
     def propellant_mass(self):

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -483,7 +483,8 @@ class Motor(ABC):
         rate should not be greater than `total_mass_flow_rate`, otherwise the
         grains mass flow rate will be negative, losing physical meaning.
         """
-        return -1 * self.thrust / self.exhaust_velocity
+        average_exhaust_velocity = self.total_impulse / self.propellant_initial_mass
+        return self.thrust / -average_exhaust_velocity
 
     @property
     @abstractmethod


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest tests -m slow --runslow`) have passed locally
- [X] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Adding a `Tank` with zero mass flow rate **at all times** causes an error on ``exhaust_velocity`` computation.

## New behavior
<!-- Describe changes introduced by this PR. -->

Zeros were added as defaults to the `exhaust_velocity` calculation and the `total_mass_flow_rate` formula as changed to an identical one that avoids possible zero divisions errors.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No
