### PR TITLE
BUG: Rollback Prandtl-Glauert corrections for Tail and Nose.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
-
+- BUG: Rollback Prandtl-Glauert corrections for Tail and Nose. [#685](https://github.com/RocketPy-Team/RocketPy/pull/685)
 
 ## [v1.4.2] - 2024-08-03
 

--- a/rocketpy/rocket/aero_surface/nose_cone.py
+++ b/rocketpy/rocket/aero_surface/nose_cone.py
@@ -451,7 +451,7 @@ class NoseCone(AeroSurface):
         # It must be set as a Function because it will be called and treated
         # as a function of mach in the simulation.
         self.clalpha = Function(
-            lambda mach: 2 / self._beta(mach) * self.radius_ratio**2,
+            lambda mach: 2 * self.radius_ratio**2,
             "Mach",
             f"Lift coefficient derivative for {self.name}",
         )

--- a/rocketpy/rocket/aero_surface/tail.py
+++ b/rocketpy/rocket/aero_surface/tail.py
@@ -169,7 +169,6 @@ class Tail(AeroSurface):
         # as a function of mach in the simulation.
         self.clalpha = Function(
             lambda mach: 2
-            / self._beta(mach)
             * (
                 (self.bottom_radius / self.rocket_radius) ** 2
                 - (self.top_radius / self.rocket_radius) ** 2

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -167,9 +167,9 @@ def test_out_of_rail_stability_margin(flight_calisto_custom_wind):
 @pytest.mark.parametrize(
     "flight_time, expected_values",
     [
-        ("t_initial", (0.17179073815516033, -0.431117, 0)),
-        ("out_of_rail_time", (0.543760, -1.364593, 0)),
-        ("apogee_time", (-0.5874848151271623, -0.7563596, 0)),
+        ("t_initial", (0.171780, -0.431091, 0)),
+        ("out_of_rail_time", (0.546945, -1.372586, 0)),
+        ("apogee_time", (-0.587317, -0.756234, 0)),
         ("t_final", (0, 0, 0)),
     ],
 )
@@ -206,10 +206,10 @@ def test_aerodynamic_moments(flight_calisto_custom_wind, flight_time, expected_v
 @pytest.mark.parametrize(
     "flight_time, expected_values",
     [
-        ("t_initial", (1.6542528, 0.65918, -0.067107)),
-        ("out_of_rail_time", (5.05334, 2.01364, -1.7541)),
-        ("apogee_time", (2.366258, -1.830744, -0.875342)),
-        ("t_final", (0, 0, 159.2212)),
+        ("t_initial", (1.654150, 0.659142, -0.067103)),
+        ("out_of_rail_time", (5.052628, 2.01336, -1.75370)),
+        ("apogee_time", (2.352518, -1.826998, -0.878729)),
+        ("t_final", (0, 0, 159.2210)),
     ],
 )
 def test_aerodynamic_forces(flight_calisto_custom_wind, flight_time, expected_values):
@@ -246,9 +246,12 @@ def test_aerodynamic_forces(flight_calisto_custom_wind, flight_time, expected_va
     "flight_time, expected_values",
     [
         ("t_initial", (0, 0, 0)),
-        ("out_of_rail_time", (0, 2.248727, 25.703072)),
-        ("apogee_time", (-13.204789, 15.990903, -0.000138)),
-        ("t_final", (5, 2, -5.65998)),
+        ("out_of_rail_time", (0, 2.248540, 25.700928)),
+        (
+            "apogee_time",
+            (-13.214438, 16.052063, -0.000421),
+        ),
+        ("t_final", (5, 2, -5.66015)),
     ],
 )
 def test_velocities(flight_calisto_custom_wind, flight_time, expected_values):
@@ -284,9 +287,9 @@ def test_velocities(flight_calisto_custom_wind, flight_time, expected_values):
     "flight_time, expected_values",
     [
         ("t_initial", (0, 0, 0)),
-        ("out_of_rail_time", (0, 7.8068, 89.2325)),
-        ("apogee_time", (0.07534, -0.058127, -9.614386)),
-        ("t_final", (0, 0, 0.0017346294117130806)),
+        ("out_of_rail_time", (0, 7.8067, 89.2315)),
+        ("apogee_time", (0.07532, -0.0581194, -9.614827)),
+        ("t_final", (0, 0, 0.0019548)),
     ],
 )
 def test_accelerations(flight_calisto_custom_wind, flight_time, expected_values):
@@ -334,10 +337,10 @@ def test_rail_buttons_forces(flight_calisto_custom_wind):
     """
     test = flight_calisto_custom_wind
     atol = 5e-3
-    assert pytest.approx(3.833613, abs=atol) == test.max_rail_button1_normal_force
-    assert pytest.approx(1.648938, abs=atol) == test.max_rail_button1_shear_force
-    assert pytest.approx(1.165307, abs=atol) == test.max_rail_button2_normal_force
-    assert pytest.approx(0.501229, abs=atol) == test.max_rail_button2_shear_force
+    assert pytest.approx(3.803078, abs=atol) == test.max_rail_button1_normal_force
+    assert pytest.approx(1.635804, abs=atol) == test.max_rail_button1_shear_force
+    assert pytest.approx(1.193331, abs=atol) == test.max_rail_button2_normal_force
+    assert pytest.approx(0.513283, abs=atol) == test.max_rail_button2_shear_force
 
 
 def test_max_values(flight_calisto_robust):


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest tests -m slow --runslow`) have passed locally
- [X] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Prandtl-Glauert corrections applied to Tail and Nose produced some unexpected behaviors.

## New behavior
<!-- Describe changes introduced by this PR. -->

This PR rollback the Tail and Nose aerodynamic to the earlier state.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No
