### PR TITLE
BUG: `savetxt` Not Accepting lambda Functions

### DIFF
--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -3171,7 +3171,7 @@ class Function:  # pylint: disable=too-many-public-methods
                 )
             # Generate the data points using the callable
             x = np.linspace(lower, upper, samples)
-            data_points = np.column_stack((x, self.source(x)))
+            data_points = np.column_stack((x, self.get_value_opt(x)))
         else:
             # If the source is already an array, use it as is
             data_points = self.source


### PR DESCRIPTION
## Description

Currently, lambda defined `Function` are not correctly saved when using `savetxt`. The problem was that a np.array was being passed for the evaluation of the lambda.

The solution was to use `Function`'s  `get_value_opt` to call on the lambdas.