### PR TITLE
BUG: Vector encoding breaks MonteCarlo export.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
-- 
+- BUG: Vector encoding breaks MonteCarlo export. [#704](https://github.com/RocketPy-Team/RocketPy/pull/704)
 
 ## [v1.6.0] - 2024-09-29
 

--- a/rocketpy/mathutils/vector_matrix.py
+++ b/rocketpy/mathutils/vector_matrix.py
@@ -418,6 +418,10 @@ class Vector:
         """Returns the k vector, [0, 0, 1]."""
         return Vector([0, 0, 1])
 
+    def to_dict(self):
+        """Returns the vector as a JSON compatible element."""
+        return list(self.components)
+
 
 class Matrix:
     """Pure Python 3x3 Matrix class for simple matrix-matrix and matrix-vector

--- a/rocketpy/mathutils/vector_matrix.py
+++ b/rocketpy/mathutils/vector_matrix.py
@@ -1002,6 +1002,10 @@ class Matrix:
             + f"       [{self.zx}, {self.zy}, {self.zz}])"
         )
 
+    def to_dict(self):
+        """Returns the matrix as a JSON compatible element."""
+        return [list(row) for row in self.components]
+
     @staticmethod
     def identity():
         """Returns the 3x3 identity matrix."""


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [X] Lint (`black rocketpy/ tests/`) has passed locally 
- [X] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

The `Vector` class now being used for `Component` position does not have proper encoding. This breaks MonteCarlo inputs export.

## New behavior
<!-- Describe changes introduced by this PR. -->

This PR is a hotfix that implements the necessary changes to encode the `Vectors`. Full encoding support should be bought by #695 .

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No
