### PR TITLE
ENH: add structural to total mass ratio for motor and rocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Attention: The newest changes should be on top -->
 
 ### Added
 
-
+- ENH: add structural to total mass ratio for motor and rocket [#713](https://github.com/RocketPy-Team/RocketPy/pull/713)
 
 ### Changed
 

--- a/rocketpy/motors/hybrid_motor.py
+++ b/rocketpy/motors/hybrid_motor.py
@@ -72,6 +72,8 @@ class HybridMotor(Motor):
     HybridMotor.propellant_mass : Function
         Total propellant mass in kg as a function of time, this includes the
         mass of fluids in each tank and the mass of the solid grains.
+    Motor.structural_mass_ratio: float
+        Initial ratio between the dry mass and the total mass.
     HybridMotor.total_mass_flow_rate : Function
         Time derivative of propellant total mass in kg/s as a function
         of time as obtained by the thrust source.

--- a/rocketpy/motors/hybrid_motor.py
+++ b/rocketpy/motors/hybrid_motor.py
@@ -72,7 +72,7 @@ class HybridMotor(Motor):
     HybridMotor.propellant_mass : Function
         Total propellant mass in kg as a function of time, this includes the
         mass of fluids in each tank and the mass of the solid grains.
-    Motor.structural_mass_ratio: float
+    HybridMotor.structural_mass_ratio: float
         Initial ratio between the dry mass and the total mass.
     HybridMotor.total_mass_flow_rate : Function
         Time derivative of propellant total mass in kg/s as a function

--- a/rocketpy/motors/liquid_motor.py
+++ b/rocketpy/motors/liquid_motor.py
@@ -47,6 +47,8 @@ class LiquidMotor(Motor):
     LiquidMotor.propellant_mass : Function
         Total propellant mass in kg as a function of time, includes fuel
         and oxidizer.
+    Motor.structural_mass_ratio: float
+        Initial ratio between the dry mass and the total mass.
     LiquidMotor.total_mass_flow_rate : Function
         Time derivative of propellant total mass in kg/s as a function
         of time as obtained by the tanks mass flow.

--- a/rocketpy/motors/liquid_motor.py
+++ b/rocketpy/motors/liquid_motor.py
@@ -47,7 +47,7 @@ class LiquidMotor(Motor):
     LiquidMotor.propellant_mass : Function
         Total propellant mass in kg as a function of time, includes fuel
         and oxidizer.
-    Motor.structural_mass_ratio: float
+    LiquidMotor.structural_mass_ratio: float
         Initial ratio between the dry mass and the total mass.
     LiquidMotor.total_mass_flow_rate : Function
         Time derivative of propellant total mass in kg/s as a function

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -49,6 +49,8 @@ class Motor(ABC):
     Motor.propellant_mass : Function
         Total propellant mass in kg as a function of time, including solid,
         liquid and gas phases.
+    Motor.structural_mass_ratio: float
+        Initial ratio between the dry mass and the total mass.
     Motor.total_mass_flow_rate : Function
         Time derivative of propellant total mass in kg/s as a function
         of time as obtained by the thrust source.
@@ -496,6 +498,19 @@ class Motor(ABC):
         float
             Propellant initial mass in kg.
         """
+
+    @property
+    def structural_mass_ratio(self):
+        """Calculates the structural mass ratio. The ratio is defined as
+        the dry mass divided by the initial total mass.
+
+        Returns
+        -------
+        float
+            Initial structural mass ratio.
+        """
+        initial_total_mass = self.dry_mass + self.propellant_initial_mass
+        return self.dry_mass / initial_total_mass
 
     @funcify_method("Time (s)", "Motor center of mass (m)")
     def center_of_mass(self):

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -510,9 +510,10 @@ class Motor(ABC):
             Initial structural mass ratio.
         """
         initial_total_mass = self.dry_mass + self.propellant_initial_mass
-        if initial_total_mass == 0:
-            raise ValueError("Motor total mass is zero!")
-        return self.dry_mass / initial_total_mass
+        try:
+            return self.dry_mass / initial_total_mass
+        except ZeroDivisionError as e:
+            raise ValueError("Total motor mass (dry + propellant) cannot be zero") from e
 
     @funcify_method("Time (s)", "Motor center of mass (m)")
     def center_of_mass(self):

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -510,6 +510,8 @@ class Motor(ABC):
             Initial structural mass ratio.
         """
         initial_total_mass = self.dry_mass + self.propellant_initial_mass
+        if initial_total_mass == 0:
+            raise ValueError("Motor total mass is zero!")
         return self.dry_mass / initial_total_mass
 
     @funcify_method("Time (s)", "Motor center of mass (m)")
@@ -1517,6 +1519,7 @@ class EmptyMotor:
         self.nozzle_radius = 0
         self.thrust = Function(0, "Time (s)", "Thrust (N)")
         self.propellant_mass = Function(0, "Time (s)", "Propellant Mass (kg)")
+        self.propellant_initial_mass = 0
         self.total_mass = Function(0, "Time (s)", "Total Mass (kg)")
         self.total_mass_flow_rate = Function(
             0, "Time (s)", "Mass Depletion Rate (kg/s)"

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -513,7 +513,9 @@ class Motor(ABC):
         try:
             return self.dry_mass / initial_total_mass
         except ZeroDivisionError as e:
-            raise ValueError("Total motor mass (dry + propellant) cannot be zero") from e
+            raise ValueError(
+                "Total motor mass (dry + propellant) cannot be zero"
+            ) from e
 
     @funcify_method("Time (s)", "Motor center of mass (m)")
     def center_of_mass(self):

--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -70,6 +70,8 @@ class SolidMotor(Motor):
         of propellant and dry mass.
     SolidMotor.propellant_mass : Function
         Total propellant mass in kg as a function of time.
+    Motor.structural_mass_ratio: float
+        Initial ratio between the dry mass and the total mass.
     SolidMotor.total_mass_flow_rate : Function
         Time derivative of propellant total mass in kg/s as a function
         of time as obtained by the thrust source.

--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -70,7 +70,7 @@ class SolidMotor(Motor):
         of propellant and dry mass.
     SolidMotor.propellant_mass : Function
         Total propellant mass in kg as a function of time.
-    Motor.structural_mass_ratio: float
+    SolidMotor.structural_mass_ratio: float
         Initial ratio between the dry mass and the total mass.
     SolidMotor.total_mass_flow_rate : Function
         Time derivative of propellant total mass in kg/s as a function

--- a/rocketpy/prints/hybrid_motor_prints.py
+++ b/rocketpy/prints/hybrid_motor_prints.py
@@ -77,7 +77,7 @@ class _HybridMotorPrints:
         print(
             f"Total Propellant Mass: {self.hybrid_motor.propellant_initial_mass:.3f} kg"
         )
-        print(f"Structural to total mass ratio: {self.hybrid_motor.structural_mass_ratio:.3f}")
+        print(f"Structural Mass Ratio: {self.hybrid_motor.structural_mass_ratio:.3f}")
         avg = self.hybrid_motor.exhaust_velocity.average(*self.hybrid_motor.burn_time)
         print(f"Average Propellant Exhaust Velocity: {avg:.3f} m/s")
         print(f"Average Thrust: {self.hybrid_motor.average_thrust:.3f} N")

--- a/rocketpy/prints/hybrid_motor_prints.py
+++ b/rocketpy/prints/hybrid_motor_prints.py
@@ -77,6 +77,7 @@ class _HybridMotorPrints:
         print(
             f"Total Propellant Mass: {self.hybrid_motor.propellant_initial_mass:.3f} kg"
         )
+        print(f"Structural to total mass ratio: {self.hybrid_motor.structural_mass_ratio:.3f}")
         avg = self.hybrid_motor.exhaust_velocity.average(*self.hybrid_motor.burn_time)
         print(f"Average Propellant Exhaust Velocity: {avg:.3f} m/s")
         print(f"Average Thrust: {self.hybrid_motor.average_thrust:.3f} N")

--- a/rocketpy/prints/liquid_motor_prints.py
+++ b/rocketpy/prints/liquid_motor_prints.py
@@ -47,6 +47,7 @@ class _LiquidMotorPrints:
         print(
             f"Total Propellant Mass: {self.liquid_motor.propellant_initial_mass:.3f} kg"
         )
+        print(f"Structural to total mass ratio: {self.liquid_motor.structural_mass_ratio:.3f}")
         avg = self.liquid_motor.exhaust_velocity.average(*self.liquid_motor.burn_time)
         print(f"Average Propellant Exhaust Velocity: {avg:.3f} m/s")
         print(f"Average Thrust: {self.liquid_motor.average_thrust:.3f} N")

--- a/rocketpy/prints/liquid_motor_prints.py
+++ b/rocketpy/prints/liquid_motor_prints.py
@@ -47,7 +47,7 @@ class _LiquidMotorPrints:
         print(
             f"Total Propellant Mass: {self.liquid_motor.propellant_initial_mass:.3f} kg"
         )
-        print(f"Structural to total mass ratio: {self.liquid_motor.structural_mass_ratio:.3f}")
+        print(f"Structural Mass Ratio: {self.liquid_motor.structural_mass_ratio:.3f}")
         avg = self.liquid_motor.exhaust_velocity.average(*self.liquid_motor.burn_time)
         print(f"Average Propellant Exhaust Velocity: {avg:.3f} m/s")
         print(f"Average Thrust: {self.liquid_motor.average_thrust:.3f} N")

--- a/rocketpy/prints/motor_prints.py
+++ b/rocketpy/prints/motor_prints.py
@@ -35,7 +35,7 @@ class _MotorPrints:
         print("Motor Details")
         print("Total Burning Time: " + str(self.motor.burn_out_time) + " s")
         print(f"Total Propellant Mass: {self.motor.propellant_initial_mass:.3f} kg")
-        print(f"Structural to total mass ratio: {self.motor.structural_mass_ratio:.3f}")
+        print(f"Structural Mass Ratio: {self.motor.structural_mass_ratio:.3f}")
         print(
             "Average Propellant Exhaust Velocity: "
             f"{self.motor.exhaust_velocity.average(*self.motor.burn_time):.3f} m/s"

--- a/rocketpy/prints/motor_prints.py
+++ b/rocketpy/prints/motor_prints.py
@@ -35,6 +35,7 @@ class _MotorPrints:
         print("Motor Details")
         print("Total Burning Time: " + str(self.motor.burn_out_time) + " s")
         print(f"Total Propellant Mass: {self.motor.propellant_initial_mass:.3f} kg")
+        print(f"Structural to total mass ratio: {self.motor.structural_mass_ratio:.3f}")
         print(
             "Average Propellant Exhaust Velocity: "
             f"{self.motor.exhaust_velocity.average(*self.motor.burn_time):.3f} m/s"

--- a/rocketpy/prints/rocket_prints.py
+++ b/rocketpy/prints/rocket_prints.py
@@ -36,6 +36,8 @@ class _RocketPrints:
         print(f"Rocket Mass: {self.rocket.mass:.3f} kg (without motor)")
         print(f"Rocket Dry Mass: {self.rocket.dry_mass:.3f} kg (with unloaded motor)")
         print(f"Rocket Loaded Mass: {self.rocket.total_mass(0):.3f} kg")
+        mass_ratio = self.rocket.dry_mass / self.rocket.total_mass(0)
+        print(f"Rocket Structural to total mass ratio: {mass_ratio:.3f}")
         print(
             f"Rocket Inertia (with unloaded motor) 11: {self.rocket.dry_I_11:.3f} kg*m2"
         )

--- a/rocketpy/prints/rocket_prints.py
+++ b/rocketpy/prints/rocket_prints.py
@@ -36,8 +36,7 @@ class _RocketPrints:
         print(f"Rocket Mass: {self.rocket.mass:.3f} kg (without motor)")
         print(f"Rocket Dry Mass: {self.rocket.dry_mass:.3f} kg (with unloaded motor)")
         print(f"Rocket Loaded Mass: {self.rocket.total_mass(0):.3f} kg")
-        mass_ratio = self.rocket.dry_mass / self.rocket.total_mass(0)
-        print(f"Rocket Structural to total mass ratio: {mass_ratio:.3f}")
+        print(f"Rocket Structural Mass Ratio: {self.rocket.structural_mass_ratio:.3f}")
         print(
             f"Rocket Inertia (with unloaded motor) 11: {self.rocket.dry_I_11:.3f} kg*m2"
         )

--- a/rocketpy/prints/solid_motor_prints.py
+++ b/rocketpy/prints/solid_motor_prints.py
@@ -65,8 +65,7 @@ class _SolidMotorPrints:
         print(
             f"Total Propellant Mass: {self.solid_motor.propellant_initial_mass:.3f} kg"
         )
-        mass_ratio = self.solid_motor.dry_mass / self.solid_motor.total_mass(0)
-        print(f"Structural to total mass ratio: {mass_ratio:.3f}")
+        print(f"Structural to total mass ratio: {self.solid_motor.structural_mass_ratio:.3f}")
         average = self.solid_motor.exhaust_velocity.average(*self.solid_motor.burn_time)
         print(f"Average Propellant Exhaust Velocity: {average:.3f} m/s")
         print(f"Average Thrust: {self.solid_motor.average_thrust:.3f} N")

--- a/rocketpy/prints/solid_motor_prints.py
+++ b/rocketpy/prints/solid_motor_prints.py
@@ -65,6 +65,8 @@ class _SolidMotorPrints:
         print(
             f"Total Propellant Mass: {self.solid_motor.propellant_initial_mass:.3f} kg"
         )
+        mass_ratio = self.solid_motor.dry_mass / self.solid_motor.total_mass(0)
+        print(f"Structural to total mass ratio: {mass_ratio:.3f}")
         average = self.solid_motor.exhaust_velocity.average(*self.solid_motor.burn_time)
         print(f"Average Propellant Exhaust Velocity: {average:.3f} m/s")
         print(f"Average Thrust: {self.solid_motor.average_thrust:.3f} N")

--- a/rocketpy/prints/solid_motor_prints.py
+++ b/rocketpy/prints/solid_motor_prints.py
@@ -65,7 +65,7 @@ class _SolidMotorPrints:
         print(
             f"Total Propellant Mass: {self.solid_motor.propellant_initial_mass:.3f} kg"
         )
-        print(f"Structural to total mass ratio: {self.solid_motor.structural_mass_ratio:.3f}")
+        print(f"Structural Mass Ratio: {self.solid_motor.structural_mass_ratio:.3f}")
         average = self.solid_motor.exhaust_velocity.average(*self.solid_motor.burn_time)
         print(f"Average Propellant Exhaust Velocity: {average:.3f} m/s")
         print(f"Average Thrust: {self.solid_motor.average_thrust:.3f} N")

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -453,7 +453,9 @@ class Rocket:
                 self.dry_mass + self.motor.propellant_initial_mass
             )
         except ZeroDivisionError as e:
-            raise ValueError("Total rocket mass (dry + propellant) cannot be zero") from e
+            raise ValueError(
+                "Total rocket mass (dry + propellant) cannot be zero"
+            ) from e
         return self.structural_mass_ratio
 
     def evaluate_center_of_mass(self):

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -361,6 +361,7 @@ class Rocket:
 
         # calculate dynamic inertial quantities
         self.evaluate_dry_mass()
+        self.evaluate_structural_mass_ratio()
         self.evaluate_total_mass()
         self.evaluate_center_of_dry_mass()
         self.evaluate_center_of_mass()
@@ -432,6 +433,26 @@ class Rocket:
         self.dry_mass = self.mass + self.motor.dry_mass
 
         return self.dry_mass
+
+    def evaluate_structural_mass_ratio(self):
+        """Calculates and returns the rocket's structural mass ratio.
+        It is defined as the ratio between of the dry mass
+        (Motor + Rocket) and the initial total mass
+        (Motor + Propellant + Rocket).
+
+        Returns
+        -------
+        self.structural_mass_ratio: float
+            Initial structural mass ratio dry mass (Rocket + Motor) (kg)
+            divided by total mass (Rocket + Motor + Propellant) (kg).
+        """
+        # Make sure there is a motor associated with the rocket
+
+        self.structural_mass_ratio = self.dry_mass / (
+            self.dry_mass + self.motor.propellant_initial_mass
+        )
+
+        return self.structural_mass_ratio
 
     def evaluate_center_of_mass(self):
         """Evaluates rocket center of mass position relative to user defined
@@ -951,6 +972,7 @@ class Rocket:
         self.nozzle_position = self.motor.nozzle_position * _ + self.motor_position
         self.total_mass_flow_rate = self.motor.total_mass_flow_rate
         self.evaluate_dry_mass()
+        self.evaluate_structural_mass_ratio()
         self.evaluate_total_mass()
         self.evaluate_center_of_dry_mass()
         self.evaluate_nozzle_to_cdm()

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -89,6 +89,8 @@ class Rocket:
         Function of time expressing the total mass of the rocket,
         defined as the sum of the propellant mass and the rocket
         mass without propellant.
+    Rocket.structural_mass_ratio: float
+        Initial ratio between the dry mass and the total mass.
     Rocket.total_mass_flow_rate : Function
         Time derivative of rocket's total mass in kg/s as a function
         of time as obtained by the thrust source of the added motor.

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -448,11 +448,12 @@ class Rocket:
             Initial structural mass ratio dry mass (Rocket + Motor) (kg)
             divided by total mass (Rocket + Motor + Propellant) (kg).
         """
-
-        self.structural_mass_ratio = self.dry_mass / (
-            self.dry_mass + self.motor.propellant_initial_mass
-        )
-
+        try:
+            self.structural_mass_ratio = self.dry_mass / (
+                self.dry_mass + self.motor.propellant_initial_mass
+            )
+        except ZeroDivisionError as e:
+            raise ValueError("Total rocket mass (dry + propellant) cannot be zero") from e
         return self.structural_mass_ratio
 
     def evaluate_center_of_mass(self):

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -448,7 +448,6 @@ class Rocket:
             Initial structural mass ratio dry mass (Rocket + Motor) (kg)
             divided by total mass (Rocket + Motor + Propellant) (kg).
         """
-        # Make sure there is a motor associated with the rocket
 
         self.structural_mass_ratio = self.dry_mass / (
             self.dry_mass + self.motor.propellant_initial_mass


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally

## New behavior
Solves issue #671 .



## Breaking change

- [x] No

## Additional information
From what I understood from the issue, the information required to be printed was the the ratio of the dry mass by the total mass. I saw some [sources](https://www1.grc.nasa.gov/beginners-guide-to-aeronautics/mass-ratios/) computing the propellant mass ratio, which I believe is the opposite (inverse of the specified ratio).