### PR TITLE
DOC: fixed documentation about spherical caps

### DIFF
--- a/docs/user/motors/tanks.rst
+++ b/docs/user/motors/tanks.rst
@@ -93,8 +93,9 @@ The predefined ``CylindricalTank`` class is easy to use and is defined as such:
 
 .. note::
   The ``spherical_caps`` parameter is optional and defaults to ``False``. If set
-  to ``True``, the tank will be defined as a cylinder with flat caps.
-  If True, the tank will have spherical caps.
+  to ``True``, the tank will have spherical caps at the top and bottom with the
+  same radius as the cylindrical part. If set to ``False``, the tank will
+  be defined as a cylinder with flat caps.
 
 The predefined ``SphericalTank`` is defined with:
 


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [ ] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [x] ReadMe, Docs and GitHub updates
- [ ] Other

## Current behavior
<!-- Describe current behavior or link to an issue. -->

The existing documentation for the ``spherical_caps`` parameter currently states:
> The ``spherical_caps`` parameter is optional and defaults to ``False``. If set
> to ``True``, the tank will be defined as a cylinder with flat caps.
> If True, the tank will have spherical caps.

## New behavior
<!-- Describe changes introduced by this PR. -->

This should be updated to:
> The ``spherical_caps`` parameter is optional and defaults to ``False``. If set
> to ``True``, the tank will have spherical caps at the top and bottom with the
> same radius as the cylindrical part. If set to ``False``, the tank will
> be defined as a cylinder with flat caps.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No
