### PR TITLE
BUG: Sideslip Angle and Damping Coefficient Calculation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ Attention: The newest changes should be on top -->
 
 ### Changed
 
--
+- BUG: Sideslip Angle and Damping Coefficient Calculation [#729](https://github.com/RocketPy-Team/RocketPy/pull/729)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,11 @@ Attention: The newest changes should be on top -->
 
 ### Changed
 
-- BUG: Sideslip Angle and Damping Coefficient Calculation [#729](https://github.com/RocketPy-Team/RocketPy/pull/729)
+-
 
 ### Fixed
 
--
+- BUG: Sideslip Angle and Damping Coefficient Calculation [#729](https://github.com/RocketPy-Team/RocketPy/pull/729)
 
 ## [v1.6.2] - 2024-11-08
 

--- a/rocketpy/rocket/aero_surface/generic_surface.py
+++ b/rocketpy/rocket/aero_surface/generic_surface.py
@@ -273,7 +273,7 @@ class GenericSurface:
 
         # Angles of attack and sideslip
         alpha = np.arctan2(stream_velocity[1], stream_velocity[2])
-        beta = np.arctan2(-stream_velocity[0], stream_velocity[2])
+        beta = np.arctan2(stream_velocity[0], stream_velocity[2])
 
         # Compute aerodynamic forces and moments
         lift, side, drag, pitch, yaw, roll = self._compute_from_coefficients(
@@ -283,9 +283,9 @@ class GenericSurface:
             beta,
             stream_mach,
             reynolds,
-            omega[0],
-            omega[1],
-            omega[2],
+            omega[0],  # q
+            omega[1],  # r
+            omega[2],  # p
         )
 
         # Conversion from aerodynamic frame to body frame

--- a/rocketpy/rocket/aero_surface/linear_generic_surface.py
+++ b/rocketpy/rocket/aero_surface/linear_generic_surface.py
@@ -62,22 +62,22 @@ class LinearGenericSurface(GenericSurface):
                 Coefficient of lift derivative with respect to yaw rate.
                 Default is 0.\n
             cQ_0: callable, str, optional
-                Coefficient of pitch moment at zero angle of attack.
+                Coefficient of side force at zero angle of attack.
                 Default is 0.\n
             cQ_alpha: callable, str, optional
-                Coefficient of pitch moment derivative with respect to angle of
+                Coefficient of side force derivative with respect to angle of
                 attack. Default is 0.\n
             cQ_beta: callable, str, optional
-                Coefficient of pitch moment derivative with respect to sideslip
+                Coefficient of side force derivative with respect to sideslip
                 angle. Default is 0.\n
             cQ_p: callable, str, optional
-                Coefficient of pitch moment derivative with respect to roll rate.
+                Coefficient of side force derivative with respect to roll rate.
                 Default is 0.\n
             cQ_q: callable, str, optional
-                Coefficient of pitch moment derivative with respect to pitch rate.
+                Coefficient of side force derivative with respect to pitch rate.
                 Default is 0.\n
             cQ_r: callable, str, optional
-                Coefficient of pitch moment derivative with respect to yaw rate.
+                Coefficient of side force derivative with respect to yaw rate.
                 Default is 0.\n
             cD_0: callable, str, optional
                 Coefficient of drag at zero angle of attack. Default is 0.\n
@@ -258,11 +258,11 @@ class LinearGenericSurface(GenericSurface):
         ):
             return (
                 c_p(alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate)
-                * pitch_rate
-                + c_q(alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate)
-                * yaw_rate
-                + c_r(alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate)
                 * roll_rate
+                + c_q(alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate)
+                * pitch_rate
+                + c_r(alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate)
+                * yaw_rate
             )
 
         return Function(
@@ -372,38 +372,38 @@ class LinearGenericSurface(GenericSurface):
         # Compute aerodynamic forces
         lift = dyn_pressure_area * self.cLf(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
-        ) - dyn_pressure_area_damping * self.cLd(
+        ) + dyn_pressure_area_damping * self.cLd(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
         )
 
         side = dyn_pressure_area * self.cQf(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
-        ) - dyn_pressure_area_damping * self.cQd(
+        ) + dyn_pressure_area_damping * self.cQd(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
         )
 
         drag = dyn_pressure_area * self.cDf(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
-        ) - dyn_pressure_area_damping * self.cDd(
+        ) + dyn_pressure_area_damping * self.cDd(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
         )
 
         # Compute aerodynamic moments
         pitch = dyn_pressure_area_length * self.cmf(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
-        ) - dyn_pressure_area_length_damping * self.cmd(
+        ) + dyn_pressure_area_length_damping * self.cmd(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
         )
 
         yaw = dyn_pressure_area_length * self.cnf(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
-        ) - dyn_pressure_area_length_damping * self.cnd(
+        ) + dyn_pressure_area_length_damping * self.cnd(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
         )
 
         roll = dyn_pressure_area_length * self.clf(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
-        ) - dyn_pressure_area_length_damping * self.cld(
+        ) + dyn_pressure_area_length_damping * self.cld(
             alpha, beta, mach, reynolds, pitch_rate, yaw_rate, roll_rate
         )
 

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -2699,7 +2699,7 @@ class Flight:  # pylint: disable=too-many-public-methods
         # Stream velocity in standard aerodynamic frame
         stream_velocity = -self.stream_velocity_body_frame
         beta = np.arctan2(
-            -stream_velocity[:, 0],
+            stream_velocity[:, 0],
             stream_velocity[:, 2],
         )  # x-z plane
         return np.column_stack([self.time, np.rad2deg(beta)])


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Description

Fixed the calculation of the angle of sideslip to be in accordance with the documentation.

Fixed the sign of the damping coefficient in the `LinearGenericSurface`
