### PR TITLE
BUG: Allow multiple sets of stochastic fins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
+- BUG: Allow multiple sets of stochastic fins [#737](https://github.com/RocketPy-Team/RocketPy/pull/737)
 - BUG: forecast and reanalysis models - Update ECMWF dictionary values [#736](https://github.com/RocketPy-Team/RocketPy/pull/736)
 - BUG: forecast and reanalysis models - move wind_speed to correct position [#735](https://github.com/RocketPy-Team/RocketPy/pull/735)
 - BUG: Sideslip Angle and Damping Coefficient Calculation [#729](https://github.com/RocketPy-Team/RocketPy/pull/729)

--- a/rocketpy/stochastic/stochastic_rocket.py
+++ b/rocketpy/stochastic/stochastic_rocket.py
@@ -442,8 +442,7 @@ class StochasticRocket(StochasticModel):
                     for surface in surfaces:
                         if surface.component == validated_object.obj:
                             return surface.position
-                        else:
-                            raise AssertionError(error_msg)
+                    raise AssertionError(error_msg)
 
             return get_surface_position
 


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

Bugfix

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

If there is a rocket with 2 sets of fins and you try to make them stochastic, the function that is fixed in the code will throw because it only checks the first set of fins.  This makes it impossible to add 2 sets of fins.

Here is a sample program if you wish to confirm:
```py
from rocketpy import TrapezoidalFins, Rocket, StochasticTrapezoidalFins, StochasticRocket

# apply percent standard deviation to components
percentStdDeviation = 0.1

testRocket = Rocket( # All of the data is incorrect
    radius=0.1,
    mass=1,
    inertia=(6.321, 6.321, 0.034),
    power_off_drag= "powerOffDragCurve.csv",
    power_on_drag= "powerOnDragCurve.csv",
    center_of_mass_without_motor=0.5,
    coordinate_system_orientation="tail_to_nose",
)
fin_set_1 = testRocket.add_trapezoidal_fins(
    n=4,
    root_chord=0.203,
    tip_chord=0.0381,
    span=0.102,
    sweep_length=0.21,
    position=-0.015,
    cant_angle=0.5,
    airfoil=("airfoil_example.csv","radians"), # insert a .csv file for the side profile of the fin
)
fin_set_2 = testRocket.add_trapezoidal_fins(
    n = 4,
    root_chord=0.203,
    tip_chord=0.0381,
    span=0.102,
    sweep_length=0.21,
    position=-1.945,
    cant_angle=0.5,
    airfoil=("airfoil_example.csv","radians"), # insert a .csv file for the side profile of the fin
)
fin_set_3 = TrapezoidalFins(
    n = 4,
    root_chord=0.203,
    tip_chord=0.0381,
    span=0.102,
    sweep_length=0.21,
    cant_angle=0.5,
    rocket_radius=0.1,
    airfoil=("airfoil_example.csv","radians"), # insert a .csv file for the side profile of the fin
)

stochastic_fin_set_1_object = StochasticTrapezoidalFins(
    trapezoidal_fins=fin_set_1,
    root_chord=percentStdDeviation * fin_set_1.root_chord,
    tip_chord=percentStdDeviation * fin_set_1.tip_chord,
    span=percentStdDeviation * fin_set_1.span,
    sweep_length=percentStdDeviation * fin_set_1.sweep_length,
    cant_angle=0.01, # +- 0.01deg
)
stochastic_fin_set_2_object = StochasticTrapezoidalFins(
    trapezoidal_fins=fin_set_2,
    root_chord=percentStdDeviation * fin_set_2.root_chord,
    tip_chord=percentStdDeviation * fin_set_2.tip_chord,
    span=percentStdDeviation * fin_set_2.span,
    sweep_length=percentStdDeviation * fin_set_2.sweep_length,
    cant_angle=0.01, # +- 0.01deg
)

stochastic_testRocket = StochasticRocket(
    rocket=testRocket,
    radius=0.1 * testRocket.radius,
    mass=0.1 * testRocket.mass,
    center_of_mass_without_motor=0.1 * testRocket.center_of_mass_without_motor,
)

stochastic_fin_set_sustainer_Event1 = stochastic_testRocket.add_trapezoidal_fins(
   fins=stochastic_fin_set_1_object,
   position=0.01, # +-1cm
)

stochastic_fin_set_booster_Event1 = stochastic_testRocket.add_trapezoidal_fins(
    fins=stochastic_fin_set_2_object,
    position=0.01, # +-1cm
)

testRocket.draw()
```

I also tested adding a stochastic fin that actually wasn't a part of the rocket, and it still catches that error (replace one of the ``trapezoidal_fins=`` with ``fin_set_3`` to see this work)

## New behavior
<!-- Describe changes introduced by this PR. -->

Behaves as expected.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

I thought I figured out the git stuff but ig I didn't.  Oh well.  I am allowed to not know how to use git because I am fixing your bugs.
