### PR TITLE
BUG: Correctly update atmospheric conditions after changing date and location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
+- BUG: Correctly update atmospheric conditions after changing date and location [#743](https://github.com/RocketPy-Team/RocketPy/pull/743)
+
 
 ## [v1.7.0] - 2024-11-30
 

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -688,7 +688,9 @@ class Environment:
             "Ensemble",
         ]:
             self.set_atmospheric_model(
-                type=self.atmospheric_model_type, file=self.atmospheric_model_file, dictionary=self.atmospheric_model_dict
+                type=self.atmospheric_model_type,
+                file=self.atmospheric_model_file,
+                dictionary=self.atmospheric_model_dict,
             )
 
     def set_location(self, latitude, longitude):
@@ -726,7 +728,9 @@ class Environment:
             "Ensemble",
         ]:
             self.set_atmospheric_model(
-                type=self.atmospheric_model_type, file=self.atmospheric_model_file, dictionary=self.atmospheric_model_dict
+                type=self.atmospheric_model_type,
+                file=self.atmospheric_model_file,
+                dictionary=self.atmospheric_model_dict,
             )
 
     def set_gravity_model(self, gravity=None):

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -688,7 +688,7 @@ class Environment:
             "Ensemble",
         ]:
             self.set_atmospheric_model(
-                self.atmospheric_model_type, self.atmospheric_model_file, self.atmospheric_model_dict
+                type=self.atmospheric_model_type, file=self.atmospheric_model_file, dictionary=self.atmospheric_model_dict
             )
 
     def set_location(self, latitude, longitude):
@@ -726,7 +726,7 @@ class Environment:
             "Ensemble",
         ]:
             self.set_atmospheric_model(
-                self.atmospheric_model_type, self.atmospheric_model_file, self.atmospheric_model_dict
+                type=self.atmospheric_model_type, file=self.atmospheric_model_file, dictionary=self.atmospheric_model_dict
             )
 
     def set_gravity_model(self, gravity=None):

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -688,7 +688,7 @@ class Environment:
             "Ensemble",
         ]:
             self.set_atmospheric_model(
-                self.atmospheric_model_file, self.atmospheric_model_dict
+                self.atmospheric_model_type, self.atmospheric_model_file, self.atmospheric_model_dict
             )
 
     def set_location(self, latitude, longitude):
@@ -726,7 +726,7 @@ class Environment:
             "Ensemble",
         ]:
             self.set_atmospheric_model(
-                self.atmospheric_model_file, self.atmospheric_model_dict
+                self.atmospheric_model_type, self.atmospheric_model_file, self.atmospheric_model_dict
             )
 
     def set_gravity_model(self, gravity=None):


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

Bugfix

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

If the environment date is updated after setting the atmospheric model, the function call to update the model to that date did not pass ``self.atmospheric_model_type`` when it is required by the function.  This led to the file being passed in as the type.

## New behavior
<!-- Describe changes introduced by this PR. -->

Behaves as expected

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

N/A
