### PR TITLE
Bug: do not allow drawing rockets with no aerodynamic surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
--
+- BUG: do not allow drawing rockets with no aerodynamic surface [#774](https://github.com/RocketPy-Team/RocketPy/pull/774)
 
 ## [v1.8.0] - 2025-01-20
 

--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -681,9 +681,10 @@ class _RocketPlots:
         """
 
         # Rocket draw
-        print("\nRocket Draw")
-        print("-" * 40)
-        self.draw()
+        if len(self.rocket.aerodynamic_surfaces) > 0:
+            print("\nRocket Draw")
+            print("-" * 40)
+            self.draw()
 
         # Mass Plots
         print("\nMass Plots")

--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -212,6 +212,9 @@ class _RocketPlots:
             eps, jpg, jpeg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff
             and webp (these are the formats supported by matplotlib).
         """
+
+        self.__validate_aerodynamic_surfaces()
+
         if vis_args is None:
             vis_args = {
                 "background": "#EEEEEE",
@@ -247,6 +250,12 @@ class _RocketPlots:
         plt.legend(bbox_to_anchor=(1.05, 1), loc="upper left")
         plt.tight_layout()
         show_or_save_plot(filename)
+
+    def __validate_aerodynamic_surfaces(self):
+        if not self.rocket.aerodynamic_surfaces:
+            raise ValueError(
+                "The rocket must have at least one aerodynamic surface to be drawn."
+            )
 
     def _draw_aerodynamic_surfaces(self, ax, vis_args, plane):
         """Draws the aerodynamic surfaces and saves the position of the points
@@ -399,6 +408,8 @@ class _RocketPlots:
 
     def _draw_tubes(self, ax, drawn_surfaces, vis_args):
         """Draws the tubes between the aerodynamic surfaces."""
+        radius = 0
+        last_x = 0
         for i, d_surface in enumerate(drawn_surfaces):
             # Draw the tubes, from the end of the first surface to the beginning
             # of the next surface, with the radius of the rocket at that point


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist

- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior

See https://github.com/RocketPy-Team/RocketPy/issues/766,
When calling rocket.all_info() on a "surfaceless rocket", it throw an error.

## New behavior

Now you will see no more errors when trying to print out information from a rocket without aero surfaces.

## Breaking change
- [x] No

## Additional information
I tested with the getting started notebook. Everything is looking fine.

Essentially: if you do not define any aerodynamic surface, why in the world would you want to draw the rocket? Sorry but we can't.