### PR TITLE
BUG: update flight simulation logic to include burn start time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
--
+- BUG: update flight simulation logic to include burn start time [#778](https://github.com/RocketPy-Team/RocketPy/pull/778)
 
 ## [v1.8.0] - 2025-01-20
 

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1451,7 +1451,7 @@ class Flight:
         # Determine lift force and moment
         R1, R2, M1, M2, M3 = 0, 0, 0, 0, 0
         # Determine current behavior
-        if t < self.rocket.motor.burn_out_time:
+        if self.rocket.motor.burn_start_time < t < self.rocket.motor.burn_out_time:
             # Motor burning
             # Retrieve important motor quantities
             # Inertias
@@ -1788,7 +1788,7 @@ class Flight:
         speed_of_sound = self.env.speed_of_sound.get_value_opt(z)
         free_stream_mach = free_stream_speed / speed_of_sound
 
-        if t < self.rocket.motor.burn_out_time:
+        if self.rocket.motor.burn_start_time < t < self.rocket.motor.burn_out_time:
             drag_coeff = self.rocket.power_on_drag.get_value_opt(free_stream_mach)
         else:
             drag_coeff = self.rocket.power_off_drag.get_value_opt(free_stream_mach)


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior

In the Flight class, during two-stage rocket simulations, the second-stage motor is temporarily turned off after separation (except in hot separation cases). However, the current condition for applying power-on drag (`t < self.rocket.motor.burn_out_time`) incorrectly keeps power-on drag active during this period.

## New behavior

The condition has been updated to `self.rocket.motor.burn_start_time < t < self.rocket.motor.burn_out_time` in `u_dot` and `u_dot_generalized` to ensure proper handling of drag forces for both single- and multi-stage rockets. This ensures that power-off drag is correctly applied when the second-stage motor is off.

## Breaking change

- [x] No

## Additional information

Firstly reported here: https://discord.com/channels/765037887016140840/1334492994631372810
