### PR TITLE
MNT: EmptyMotor class inherits from Motor(ABC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,11 @@ Attention: The newest changes should be on top -->
 
 ### Added
 
-- DOC: ASTRA Flight Example [#770](https://github.com/RocketPy-Team/RocketPy/pull/770))
+- DOC: ASTRA Flight Example [#770](https://github.com/RocketPy-Team/RocketPy/pull/770)
 
 ### Changed
 
--
+- MNT: EmptyMotor class inherits from Motor(ABC) [#779](https://github.com/RocketPy-Team/RocketPy/pull/779)
 
 ### Fixed
 

--- a/rocketpy/motors/__init__.py
+++ b/rocketpy/motors/__init__.py
@@ -1,7 +1,8 @@
+from .empty_motor import EmptyMotor
 from .fluid import Fluid
 from .hybrid_motor import HybridMotor
 from .liquid_motor import LiquidMotor
-from .motor import EmptyMotor, GenericMotor, Motor
+from .motor import GenericMotor, Motor
 from .solid_motor import SolidMotor
 from .tank import (
     LevelBasedTank,

--- a/rocketpy/motors/empty_motor.py
+++ b/rocketpy/motors/empty_motor.py
@@ -1,4 +1,4 @@
-from rocketpy.mathutils import Function
+from rocketpy.mathutils import Function, funcify_method
 from rocketpy.motors.motor import Motor
 
 
@@ -37,41 +37,41 @@ class EmptyMotor(Motor):
         self.I_13 = Function(0)
         self.I_23 = Function(0)
 
-    @property
+    @funcify_method("Time (s)", "Center of Propellant Mass (kg)", "linear", "zero")
     def center_of_propellant_mass(self):
-        return Function(0, "Time (s)", "Center of Propellant Mass (kg)")
+        return 0
 
-    @property
+    @funcify_method("Time (s)", "Exhaust Velocity (m/s)", "linear", "zero")
     def exhaust_velocity(self):
-        return Function(0, "Time (s)", "Exhaust Velocity (m/s)")
+        return 0
 
     @property
     def propellant_initial_mass(self):
         return 0
 
-    @property
+    @funcify_method("Time (s)", "Propellant I_11 (kg m²)", "linear", "zero")
     def propellant_I_11(self):
-        return Function(0, "Time (s)", "Propellant I_11 (kg m²)")
+        return 0
 
-    @property
+    @funcify_method("Time (s)", "Propellant I_12 (kg m²)", "linear", "zero")
     def propellant_I_12(self):
-        return Function(0, "Time (s)", "Propellant I_12 (kg m²)")
+        return 0
 
-    @property
+    @funcify_method("Time (s)", "Propellant I_13 (kg m²)", "linear", "zero")
     def propellant_I_13(self):
-        return Function(0, "Time (s)", "Propellant I_13 (kg m²)")
+        return 0
 
-    @property
+    @funcify_method("Time (s)", "Propellant I_22 (kg m²)", "linear", "zero")
     def propellant_I_22(self):
-        return Function(0, "Time (s)", "Propellant I_22 (kg m²)")
+        return 0
 
-    @property
+    @funcify_method("Time (s)", "Propellant I_23 (kg m²)", "linear", "zero")
     def propellant_I_23(self):
-        return Function(0, "Time (s)", "Propellant I_23 (kg m²)")
+        return 0
 
-    @property
+    @funcify_method("Time (s)", "Propellant I_33 (kg m²)", "linear", "zero")
     def propellant_I_33(self):
-        return Function(0, "Time (s)", "Propellant I_33 (kg m²)")
+        return 0
 
     @property
     def structural_mass_ratio(self):

--- a/rocketpy/motors/empty_motor.py
+++ b/rocketpy/motors/empty_motor.py
@@ -72,3 +72,7 @@ class EmptyMotor(Motor):
     @property
     def propellant_I_33(self):
         return Function(0, "Time (s)", "Propellant I_33 (kg m²)")
+
+    @property
+    def structural_mass_ratio(self):
+        return 0

--- a/rocketpy/motors/empty_motor.py
+++ b/rocketpy/motors/empty_motor.py
@@ -1,0 +1,74 @@
+from rocketpy.mathutils import Function
+from rocketpy.motors.motor import Motor
+
+
+class EmptyMotor(Motor):
+    """Class that represents an empty motor with no mass and no thrust."""
+
+    def __init__(self):
+        """Initializes an empty motor with no mass and no thrust."""
+
+        super().__init__(
+            thrust_source=0,
+            dry_inertia=(0, 0, 0),
+            nozzle_radius=0,
+            center_of_dry_mass_position=0,
+            dry_mass=0,
+            nozzle_position=0,
+            burn_time=1,
+            reshape_thrust_curve=False,
+            interpolation_method="linear",
+            coordinate_system_orientation="nozzle_to_combustion_chamber",
+        )
+
+        # Mass properties
+        self.propellant_mass = Function(0, "Time (s)", "Propellant Mass (kg)")
+        self.total_mass = Function(0, "Time (s)", "Total Mass (kg)")
+        self.total_mass_flow_rate = Function(
+            0, "Time (s)", "Mass Depletion Rate (kg/s)"
+        )
+        self.center_of_mass = Function(0, "Time (s)", "Center of Mass (kg)")
+
+        # Inertia properties
+        self.I_11 = Function(0)
+        self.I_22 = Function(0)
+        self.I_33 = Function(0)
+        self.I_12 = Function(0)
+        self.I_13 = Function(0)
+        self.I_23 = Function(0)
+
+    @property
+    def center_of_propellant_mass(self):
+        return Function(0, "Time (s)", "Center of Propellant Mass (kg)")
+
+    @property
+    def exhaust_velocity(self):
+        return Function(0, "Time (s)", "Exhaust Velocity (m/s)")
+
+    @property
+    def propellant_initial_mass(self):
+        return 0
+
+    @property
+    def propellant_I_11(self):
+        return Function(0, "Time (s)", "Propellant I_11 (kg m²)")
+
+    @property
+    def propellant_I_12(self):
+        return Function(0, "Time (s)", "Propellant I_12 (kg m²)")
+
+    @property
+    def propellant_I_13(self):
+        return Function(0, "Time (s)", "Propellant I_13 (kg m²)")
+
+    @property
+    def propellant_I_22(self):
+        return Function(0, "Time (s)", "Propellant I_22 (kg m²)")
+
+    @property
+    def propellant_I_23(self):
+        return Function(0, "Time (s)", "Propellant I_23 (kg m²)")
+
+    @property
+    def propellant_I_33(self):
+        return Function(0, "Time (s)", "Propellant I_33 (kg m²)")

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -1162,6 +1162,7 @@ class Motor(ABC):
         self.prints.all()
         self.plots.all()
 
+
 # TODO: move this class to a separate file, needs a breaking change warning
 class GenericMotor(Motor):
     """Class that represents a simple motor defined mainly by its thrust curve.

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -1162,7 +1162,7 @@ class Motor(ABC):
         self.prints.all()
         self.plots.all()
 
-
+# TODO: move this class to a separate file, needs a breaking change warning
 class GenericMotor(Motor):
     """Class that represents a simple motor defined mainly by its thrust curve.
     There is no distinction between the propellant types (e.g. Solid, Liquid).
@@ -1601,56 +1601,3 @@ class GenericMotor(Motor):
             nozzle_position=data["nozzle_position"],
             interpolation_method=data["interpolate"],
         )
-
-
-class EmptyMotor:
-    """Class that represents an empty motor with no mass and no thrust."""
-
-    # TODO: This is a temporary solution. It should be replaced by a class that
-    # inherits from the abstract Motor class. Currently cannot be done easily.
-    # pylint: disable=too-many-statements
-    def __init__(self):
-        """Initializes an empty motor with no mass and no thrust.
-
-        Notes
-        -----
-        This class is a temporary solution to the problem of having a motor
-        with no mass and no thrust. It should be replaced by a class that
-        inherits from the abstract Motor class. Currently cannot be done easily.
-        """
-        self._csys = 1
-        self.dry_mass = 0
-        self.nozzle_radius = 0
-        self.thrust = Function(0, "Time (s)", "Thrust (N)")
-        self.propellant_mass = Function(0, "Time (s)", "Propellant Mass (kg)")
-        self.propellant_initial_mass = 0
-        self.total_mass = Function(0, "Time (s)", "Total Mass (kg)")
-        self.total_mass_flow_rate = Function(
-            0, "Time (s)", "Mass Depletion Rate (kg/s)"
-        )
-        self.burn_out_time = 1
-        self.nozzle_position = 0
-        self.nozzle_radius = 0
-        self.center_of_dry_mass_position = 0
-        self.center_of_propellant_mass = Function(
-            0, "Time (s)", "Center of Propellant Mass (kg)"
-        )
-        self.center_of_mass = Function(0, "Time (s)", "Center of Mass (kg)")
-        self.dry_I_11 = 0
-        self.dry_I_22 = 0
-        self.dry_I_33 = 0
-        self.dry_I_12 = 0
-        self.dry_I_13 = 0
-        self.dry_I_23 = 0
-        self.propellant_I_11 = Function(0, "Time (s)", "Propellant I_11 (kg m²)")
-        self.propellant_I_22 = Function(0, "Time (s)", "Propellant I_22 (kg m²)")
-        self.propellant_I_33 = Function(0, "Time (s)", "Propellant I_33 (kg m²)")
-        self.propellant_I_12 = Function(0, "Time (s)", "Propellant I_12 (kg m²)")
-        self.propellant_I_13 = Function(0, "Time (s)", "Propellant I_13 (kg m²)")
-        self.propellant_I_23 = Function(0, "Time (s)", "Propellant I_23 (kg m²)")
-        self.I_11 = Function(0)
-        self.I_22 = Function(0)
-        self.I_33 = Function(0)
-        self.I_12 = Function(0)
-        self.I_13 = Function(0)
-        self.I_23 = Function(0)

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -6,7 +6,7 @@ import numpy as np
 from rocketpy.control.controller import _Controller
 from rocketpy.mathutils.function import Function
 from rocketpy.mathutils.vector_matrix import Matrix, Vector
-from rocketpy.motors.motor import EmptyMotor
+from rocketpy.motors.empty_motor import EmptyMotor
 from rocketpy.plots.rocket_plots import _RocketPlots
 from rocketpy.prints.rocket_prints import _RocketPrints
 from rocketpy.rocket.aero_surface import (

--- a/rocketpy/stochastic/stochastic_rocket.py
+++ b/rocketpy/stochastic/stochastic_rocket.py
@@ -4,7 +4,8 @@ import warnings
 from random import choice
 
 from rocketpy.mathutils.vector_matrix import Vector
-from rocketpy.motors.motor import EmptyMotor, GenericMotor, Motor
+from rocketpy.motors.empty_motor import EmptyMotor
+from rocketpy.motors.motor import GenericMotor, Motor
 from rocketpy.motors.solid_motor import SolidMotor
 from rocketpy.rocket.aero_surface import (
     EllipticalFins,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ pytest_plugins = [
     "tests.fixtures.motor.liquid_fixtures",
     "tests.fixtures.motor.hybrid_fixtures",
     "tests.fixtures.motor.solid_motor_fixtures",
+    "tests.fixtures.motor.empty_motor_fixtures",
     "tests.fixtures.motor.tanks_fixtures",
     "tests.fixtures.motor.tank_geometry_fixtures",
     "tests.fixtures.motor.generic_motor_fixtures",

--- a/tests/fixtures/motor/empty_motor_fixtures.py
+++ b/tests/fixtures/motor/empty_motor_fixtures.py
@@ -1,0 +1,14 @@
+import pytest
+
+from rocketpy.motors.empty_motor import EmptyMotor
+
+
+@pytest.fixture
+def empty_motor():
+    """An example of an empty motor with zero thrust and mass.
+
+    Returns
+    -------
+    rocketpy.EmptyMotor
+    """
+    return EmptyMotor()

--- a/tests/fixtures/motor/solid_motor_fixtures.py
+++ b/tests/fixtures/motor/solid_motor_fixtures.py
@@ -122,7 +122,7 @@ def dimensionless_cesaroni_m1670(kg, m):  # old name: dimensionless_motor
 @pytest.fixture
 def dummy_empty_motor():
     # Create a motor with ZERO thrust and ZERO mass to keep the rocket's speed constant
-    # TODO: why don t we use these same values to create EmptyMotor class?
+    # TODO: Maybe we should simple use the new `EmptyMotor` class?
     return SolidMotor(
         thrust_source=1e-300,
         burn_time=1e-10,

--- a/tests/integration/test_empty_motor.py
+++ b/tests/integration/test_empty_motor.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+
+@patch("matplotlib.pyplot.show")
+def test_empty_motor_info(mock_show, empty_motor):  # pylint: disable=unused-argument
+    """Tests the LiquidMotor.all_info() method.
+
+    Parameters
+    ----------
+    mock_show : mock
+        Mock of the matplotlib.pyplot.show function.
+    empty_motor : rocketpy.EmptyMotor
+        The EmptyMotor object to be used in the tests.
+    """
+    assert empty_motor.info() is None
+    assert empty_motor.all_info() is None

--- a/tests/unit/test_rocket.py
+++ b/tests/unit/test_rocket.py
@@ -5,7 +5,8 @@ import pytest
 
 from rocketpy import Function, NoseCone, Rocket, SolidMotor
 from rocketpy.mathutils.vector_matrix import Vector
-from rocketpy.motors.motor import EmptyMotor, Motor
+from rocketpy.motors.empty_motor import EmptyMotor
+from rocketpy.motors.motor import Motor
 
 
 @patch("matplotlib.pyplot.show")


### PR DESCRIPTION
## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
The EmptyMotor is a huge workaround

## New behavior

The EmptyMotor ihnerits from the abstract Motor class

## Breaking change

- [x] Yes, but small. Should we care about it at all? 

## Additional information

#778 needs this first