### PR TITLE
BUG: fixes get_instance_attributes for Flight objects containing a Rocket object without rail buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Attention: The newest changes should be on top -->
 
 - BUG: do not allow drawing rockets with no aerodynamic surface [#774](https://github.com/RocketPy-Team/RocketPy/pull/774)
 - BUG: update flight simulation logic to include burn start time [#778](https://github.com/RocketPy-Team/RocketPy/pull/778)
+- BUG: fixes get_instance_attributes for Flight objects containing a Rocket object without rail buttons [#786](https://github.com/RocketPy-Team/RocketPy/pull/786)
 
 ## [v1.8.0] - 2025-01-20
 

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -3492,7 +3492,7 @@ def funcify_method(*args, **kwargs):  # pylint: disable=too-many-statements
     >>> example.f
     'Function from R1 to R1 : (x) → (f(x))'
 
-    In order to reset the cache, just delete de attribute from the instance:
+    In order to reset the cache, just delete the attribute from the instance:
 
     >>> del example.f
 

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -2954,7 +2954,7 @@ class Flight:
             Rail Button 2 force in the 2 direction
         """
         # First check for no rail phase or rail buttons
-        null_force = []
+        null_force = Function(0)
         if self.out_of_rail_time_index == 0:  # No rail phase, no rail button forces
             warnings.warn(
                 "Trying to calculate rail button forces without a rail phase defined."

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -165,13 +165,26 @@ def test_flutter_plots(mock_show, flight_calisto_custom_wind):  # pylint: disabl
     ), "An error occurred while running the utilities._flutter_plots function."
 
 
-def test_get_instance_attributes(flight_calisto_robust):
+def test_get_instance_attributes_with_robust_flight(flight_calisto_robust):
     """Tests if get_instance_attributes returns the expected results for a
     robust flight object."""
 
     attributes = utilities.get_instance_attributes(flight_calisto_robust)
     for key, value in attributes.items():
         attr = getattr(flight_calisto_robust, key)
+        if isinstance(attr, np.ndarray):
+            assert np.allclose(attr, value)
+        else:
+            assert attr == value
+
+
+def test_get_instance_attributes_with_flight_without_rail_buttons(flight_calisto):
+    """Tests if get_instance_attributes returns the expected results for a
+    flight object that contains a rocket object without rail buttons."""
+
+    attributes = utilities.get_instance_attributes(flight_calisto)
+    for key, value in attributes.items():
+        attr = getattr(flight_calisto, key)
         if isinstance(attr, np.ndarray):
             assert np.allclose(attr, value)
         else:


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code changes (bugfix, features)
- [x] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

When calling the function `get_instance_attributes()` and passing a Flight object that contains a Rocket object without rail buttons as the argument, it crashes. More specifically, it crashes when trying to calculate the rail button forces (`__calculate_rail_button_forces`).

Stack trace:
```self = <rocketpy.mathutils.function.funcify_method.<locals>.funcify_method_decorator object at 0x1112cf4d0>
instance = <Flight(rocket= <rocketpy.rocket.rocket.Rocket object at 0x11370c410>, environment= <rocketpy.environment.environment.Environment object at 0x110e2b680>, rail_length= 5.2, inclination= 85, heading = 0,name= Flight)>
owner = <class 'rocketpy.simulation.flight.Flight'>

    def __get__(self, instance, owner=None):
        if instance is None:
            return self
        cache = instance.__dict__
        try:
            # If cache is ready, return it
>           val = cache[self.attrname]
E           KeyError: 'rail_button1_normal_force'

rocketpy/mathutils/function.py:3531: KeyError

During handling of the above exception, another exception occurred:

self = <rocketpy.mathutils.function.funcify_method.<locals>.funcify_method_decorator object at 0x1112cf4d0>
instance = <Flight(rocket= <rocketpy.rocket.rocket.Rocket object at 0x11370c410>, environment= <rocketpy.environment.environment.Environment object at 0x110e2b680>, rail_length= 5.2, inclination= 85, heading = 0,name= Flight)>
owner = <class 'rocketpy.simulation.flight.Flight'>

    def __get__(self, instance, owner=None):
        if instance is None:
            return self
        cache = instance.__dict__
        try:
            # If cache is ready, return it
            val = cache[self.attrname]
        except KeyError:
            # If cache is not ready, create it
            try:
                # Handle methods which return Function instances
>               val = self.func(instance).reset(*args, **kwargs)
E               AttributeError: 'list' object has no attribute 'reset'

rocketpy/mathutils/function.py:3536: AttributeError

During handling of the above exception, another exception occurred:

flight_calisto = <Flight(rocket= <rocketpy.rocket.rocket.Rocket object at 0x11370c410>, environment= <rocketpy.environment.environment.Environment object at 0x110e2b680>, rail_length= 5.2, inclination= 85, heading = 0,name= Flight)>

    def test_get_instance_attributes_with_flight_without_rail_buttons(flight_calisto):
        """Tests if get_instance_attributes returns the expected results for a
        flight object that contains a rocket object without rail buttons."""
    
>       attributes = utilities.get_instance_attributes(flight_calisto)

tests/unit/test_utilities.py:185: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
rocketpy/utilities.py:682: in get_instance_attributes
    members = inspect.getmembers(instance)
/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py:607: in getmembers
    return _getmembers(object, predicate, getattr)
/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/inspect.py:585: in _getmembers
    value = getter(object, key)
rocketpy/simulation/flight.py:2850: in max_rail_button1_normal_force
    return np.abs(self.rail_button1_normal_force.y_array).max()
rocketpy/mathutils/function.py:3540: in __get__
    val = Function(source, *args, **kwargs)
rocketpy/mathutils/function.py:147: in __init__
    self.set_source(self.source)
rocketpy/mathutils/function.py:225: in set_source
    source = self.__validate_source(source)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <[AttributeError("'Function' object has no attribute '__dom_dim__'") raised in repr()] Function object at 0x113aee3c0>
source = array([], dtype=float64)

    def __validate_source(self, source):  # pylint: disable=too-many-statements
        """Used to validate the source parameter for creating a Function object.
    
        Parameters
        ----------
        source : np.ndarray, callable, str, Path, Function, list
            The source data of the Function object. This can be a numpy array,
            a callable function, a string or Path object to a csv or txt file,
            a Function object, or a list of numbers.
    
        Returns
        -------
        np.ndarray, callable
            The validated source parameter.
    
        Raises
        ------
        ValueError
            If the source is not a valid type or if the source is not a 2D array
            or a callable function.
        """
        if isinstance(source, Function):
            return source.get_source()
    
        if isinstance(source, (str, Path)):
            # Read csv or txt files and create a numpy array
            try:
                source = np.loadtxt(source, delimiter=",", dtype=np.float64)
            except ValueError:
                with open(source, "r") as file:
                    header, *data = file.read().splitlines()
    
                header = [label.strip("'").strip('"') for label in header.split(",")]
                source = np.loadtxt(data, delimiter=",", dtype=np.float64)
    
                if len(source[0]) == len(header):
                    if self.__inputs__ is None:
                        self.__inputs__ = header[:-1]
                    if self.__outputs__ is None:
                        self.__outputs__ = [header[-1]]
            except Exception as e:  # pragma: no cover
                raise ValueError(
                    "Could not read the csv or txt file to create Function source."
                ) from e
    
        if isinstance(source, (list, np.ndarray)):
            # Triggers an error if source is not a list of numbers
            source = np.array(source, dtype=np.float64)
    
            # Checks if 2D array
            if len(source.shape) != 2:
>               raise ValueError(
                    "Source must be a 2D array in the form [[x1, x2 ..., xn, y], ...]."
                )
E               ValueError: Source must be a 2D array in the form [[x1, x2 ..., xn, y], ...].

rocketpy/mathutils/function.py:3243: ValueError
```
## New behavior
<!-- Describe changes introduced by this PR. -->

The function `get_instance_attributes()` doesn't crash when passing a Flight object that contains a Rocket object without rail buttons. More specifically, the method __calculate_rail_button_forces() correctly returns a constant Function object mapping to 0.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

The test `tests/integration/test_flight.py::test_time_overshoot` fails locally.
