### PR TITLE
DEV: add requirements-tests.txt on make install target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ Attention: The newest changes should be on top -->
 
 - DOCS: reshape docs (closes #659) [#781](https://github.com/RocketPy-Team/RocketPy/pull/781)
 - MNT: EmptyMotor class inherits from Motor(ABC) [#779](https://github.com/RocketPy-Team/RocketPy/pull/779)
-- DEV: add requirements-tests.txt on make install target [#791](https://github.com/RocketPy-Team/RocketPy/pull/791)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Attention: The newest changes should be on top -->
 
 - DOCS: reshape docs (closes #659) [#781](https://github.com/RocketPy-Team/RocketPy/pull/781)
 - MNT: EmptyMotor class inherits from Motor(ABC) [#779](https://github.com/RocketPy-Team/RocketPy/pull/779)
-- DEV: add requirements-tests.txt on make install target [#790](https://github.com/RocketPy-Team/RocketPy/issues/790)
+- DEV: add requirements-tests.txt on make install target [#791](https://github.com/RocketPy-Team/RocketPy/pull/791)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Attention: The newest changes should be on top -->
 
 - DOCS: reshape docs (closes #659) [#781](https://github.com/RocketPy-Team/RocketPy/pull/781)
 - MNT: EmptyMotor class inherits from Motor(ABC) [#779](https://github.com/RocketPy-Team/RocketPy/pull/779)
+- DEV: add requirements-tests.txt on make install target [#790](https://github.com/RocketPy-Team/RocketPy/issues/790)
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ install:
 	$(PYTHON) -m pip install --upgrade pip
 	pip install -r requirements.txt
 	pip install -r requirements-optional.txt
+	pip install -r requirements-tests.txt
 	pip install -e .
 
 format:


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [ ] Code changes (bugfix, features)
- [x] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Running `make install` didn't install all packages necessary to develop RocketPy locally, specifically to run the tests. In order to have **ruff** installed, for example, it was necessary to run `pip install -r requirements-tests.txt` separately.

## New behavior
<!-- Describe changes introduced by this PR. -->

Running `make install` installs all necessary packages to develop and test RocketPy locally.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

`make install` was executed in a new, blank virtual environment locally and it successfully installed **ruff**.
