### PR TITLE
Bug: Fix StochasticFlight time_overshoot None bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Attention: The newest changes should be on top -->
 
 ### Added
 
+- BUG: Fix StochasticFlight time_overshoot None bug [#805] (https://github.com/RocketPy-Team/RocketPy/pull/805)
 - ENH: Implement Multivariate Rejection Sampling (MRS) [#738] (https://github.com/RocketPy-Team/RocketPy/pull/738) 
 - ENH: Create a rocketpy file to store flight simulations [#800](https://github.com/RocketPy-Team/RocketPy/pull/800)
 - ENH: Support for the RSE file format has been added to the library [#798](https://github.com/RocketPy-Team/RocketPy/pull/798)

--- a/rocketpy/stochastic/stochastic_flight.py
+++ b/rocketpy/stochastic/stochastic_flight.py
@@ -87,7 +87,10 @@ class StochasticFlight(StochasticModel):
 
         self.initial_solution = initial_solution
         self.terminate_on_apogee = terminate_on_apogee
-        self.time_overshoot = time_overshoot
+        if time_overshoot is None:
+            self.time_overshoot = flight.time_overshoot
+        else:
+            self.time_overshoot = time_overshoot
 
     def _validate_initial_solution(self, initial_solution):
         if initial_solution is not None:


### PR DESCRIPTION
## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior

`time_overshoot=None` causes an error in `Flight._simulate`.


## New behavior

Fixes #804 by setting `time_overshoot` to the base flight value when it is `None`. 

## Breaking change

- [x] No

## Additional information

Still need to fix `time_overshoot=False` problem described in #802 