### PR TITLE
BUG: LSODA solver not being detected correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Attention: The newest changes should be on top -->
 
 
 ### Fixed
-
+- BUG: Non-overshootable simulations error on time parsing. [#807](https://github.com/RocketPy-Team/RocketPy/pull/807)
 
 ## v1.9.0 - 2025-03-24
 

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1277,8 +1277,8 @@ class Flight:
                     f"Invalid ``ode_solver`` input: {solver}. "
                     f"Available options are: {', '.join(ODE_SOLVER_MAP.keys())}"
                 ) from e
-
-        self.__is_lsoda = hasattr(self._solver, "_lsoda_solver")
+            
+        self.__is_lsoda = issubclass(self._solver, LSODA)
 
     @cached_property
     def effective_1rl(self):


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
Note: Non-related `MonteCarlo` tests have failed. I am investigating it.
- [X] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

A bug introduced by yours truly on PR #748 causes the simulation solver not detect correctly when using `LSODA` solver. This is crucial when performing non-overshootable simulations.

## New behavior
<!-- Describe changes introduced by this PR. -->

This PR fixes the issue by correctly detecting the usage of `LSODA`.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

This could have been detected earlier had the `--runslow` tests been executed more often.
