### PR TITLE
BUG: Fix the handling of reference pressure for older rpy files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Attention: The newest changes should be on top -->
 
 
 ### Fixed
+- BUG: Fix the handling of reference pressure for older rpy files. [#808](https://github.com/RocketPy-Team/RocketPy/pull/808)
 
 
 ## v1.9.0 - 2025-03-24

--- a/rocketpy/_encoders.py
+++ b/rocketpy/_encoders.py
@@ -7,8 +7,8 @@ from importlib import import_module
 import numpy as np
 
 from rocketpy.mathutils.function import Function
-from rocketpy.prints.flight_prints import _FlightPrints
 from rocketpy.plots.flight_plots import _FlightPlots
+from rocketpy.prints.flight_prints import _FlightPrints
 
 
 class RocketPyEncoder(json.JSONEncoder):
@@ -91,50 +91,7 @@ class RocketPyDecoder(json.JSONDecoder):
                     new_flight = class_.__new__(class_)
                     new_flight.prints = _FlightPrints(new_flight)
                     new_flight.plots = _FlightPlots(new_flight)
-                    attributes = (
-                        "rocket",
-                        "env",
-                        "rail_length",
-                        "inclination",
-                        "heading",
-                        "initial_solution",
-                        "terminate_on_apogee",
-                        "max_time",
-                        "max_time_step",
-                        "min_time_step",
-                        "rtol",
-                        "atol",
-                        "time_overshoot",
-                        "name",
-                        "solution",
-                        "out_of_rail_time",
-                        "apogee_time",
-                        "apogee",
-                        "parachute_events",
-                        "impact_state",
-                        "impact_velocity",
-                        "x_impact",
-                        "y_impact",
-                        "t_final",
-                        "flight_phases",
-                        "ax",
-                        "ay",
-                        "az",
-                        "out_of_rail_time_index",
-                        "function_evaluations",
-                        "alpha1",
-                        "alpha2",
-                        "alpha3",
-                        "R1",
-                        "R2",
-                        "R3",
-                        "M1",
-                        "M2",
-                        "M3",
-                    )
-                    for attribute in attributes:
-                        setattr(new_flight, attribute, obj[attribute])
-                    new_flight.t_initial = new_flight.initial_solution[0]
+                    set_minimal_flight_attributes(new_flight, obj)
                     return new_flight
                 elif hasattr(class_, "from_dict"):
                     return class_.from_dict(obj)
@@ -151,6 +108,63 @@ class RocketPyDecoder(json.JSONDecoder):
                 return obj
         else:
             return obj
+
+
+def set_minimal_flight_attributes(flight, obj):
+    attributes = (
+        "rocket",
+        "env",
+        "rail_length",
+        "inclination",
+        "heading",
+        "initial_solution",
+        "terminate_on_apogee",
+        "max_time",
+        "max_time_step",
+        "min_time_step",
+        "rtol",
+        "atol",
+        "time_overshoot",
+        "name",
+        "solution",
+        "out_of_rail_time",
+        "apogee_time",
+        "apogee",
+        "parachute_events",
+        "impact_state",
+        "impact_velocity",
+        "x_impact",
+        "y_impact",
+        "t_final",
+        "flight_phases",
+        "ax",
+        "ay",
+        "az",
+        "out_of_rail_time_index",
+        "function_evaluations",
+        "speed",
+        "alpha1",
+        "alpha2",
+        "alpha3",
+        "R1",
+        "R2",
+        "R3",
+        "M1",
+        "M2",
+        "M3",
+        "net_thrust",
+    )
+
+    for attribute in attributes:
+        try:
+            setattr(flight, attribute, obj[attribute])
+        except KeyError:
+            # Manual resolution of new attributes
+            if attribute == "net_thrust":
+                flight.net_thrust = obj["rocket"].motor.thrust
+                flight.net_thrust.set_discrete_based_on_model(flight.speed)
+
+    flight.t_initial = flight.initial_solution[0]
 
 
 def get_class_signature(obj):

--- a/rocketpy/motors/hybrid_motor.py
+++ b/rocketpy/motors/hybrid_motor.py
@@ -699,7 +699,7 @@ class HybridMotor(Motor):
             grains_center_of_mass_position=data["grains_center_of_mass_position"],
             nozzle_position=data["nozzle_position"],
             throat_radius=data["throat_radius"],
-            reference_pressure=data["reference_pressure"],
+            reference_pressure=data.get("reference_pressure"),
         )
 
         for tank in data["positioned_tanks"]:

--- a/rocketpy/motors/liquid_motor.py
+++ b/rocketpy/motors/liquid_motor.py
@@ -528,7 +528,7 @@ class LiquidMotor(Motor):
             nozzle_position=data["nozzle_position"],
             interpolation_method=data["interpolate"],
             coordinate_system_orientation=data["coordinate_system_orientation"],
-            reference_pressure=data["reference_pressure"],
+            reference_pressure=data.get("reference_pressure"),
         )
 
         for tank in data["positioned_tanks"]:

--- a/rocketpy/motors/motor.py
+++ b/rocketpy/motors/motor.py
@@ -1896,5 +1896,5 @@ class GenericMotor(Motor):
             ),
             nozzle_position=data["nozzle_position"],
             interpolation_method=data["interpolate"],
-            reference_pressure=data["reference_pressure"],
+            reference_pressure=data.get("reference_pressure"),
         )

--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -821,5 +821,5 @@ class SolidMotor(Motor):
             throat_radius=data["throat_radius"],
             interpolation_method=data["interpolate"],
             coordinate_system_orientation=data["coordinate_system_orientation"],
-            reference_pressure=data["reference_pressure"],
+            reference_pressure=data.get("reference_pressure"),
         )

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -281,6 +281,7 @@ class MonteCarlo:
         try:
             while sim_monitor.keep_simulating():
                 sim_monitor.increment()
+                inputs_json, outputs_json = "", ""
 
                 flight = self.__run_single_simulation()
                 inputs_json = self.__evaluate_flight_inputs(sim_monitor.count)
@@ -406,6 +407,7 @@ class MonteCarlo:
 
             while sim_monitor.keep_simulating():
                 sim_idx = sim_monitor.increment() - 1
+                inputs_json, outputs_json = "", ""
 
                 flight = self.__run_single_simulation()
                 inputs_json = self.__evaluate_flight_inputs(sim_idx)
@@ -484,7 +486,9 @@ class MonteCarlo:
             for item in d.items()
         )
         inputs_dict["index"] = sim_idx
-        return json.dumps(inputs_dict, cls=RocketPyEncoder) + "\n"
+        return (
+            json.dumps(inputs_dict, cls=RocketPyEncoder, **self._export_config) + "\n"
+        )
 
     def __evaluate_flight_outputs(self, flight, sim_idx):
         """Evaluates the outputs of a single flight simulation.
@@ -518,7 +522,9 @@ class MonteCarlo:
                     ) from e
             outputs_dict = outputs_dict | additional_exports
 
-        return json.dumps(outputs_dict, cls=RocketPyEncoder) + "\n"
+        return (
+            json.dumps(outputs_dict, cls=RocketPyEncoder, **self._export_config) + "\n"
+        )
 
     def __terminate_simulation(self):
         """

--- a/rocketpy/utilities.py
+++ b/rocketpy/utilities.py
@@ -1,23 +1,23 @@
 import ast
 import inspect
-import traceback
-import warnings
 import json
 import os
-
-from pathlib import Path
-from importlib.metadata import version
+import traceback
+import warnings
 from datetime import date
+from importlib.metadata import version
+from pathlib import Path
+
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.integrate import solve_ivp
 
+from ._encoders import RocketPyDecoder, RocketPyEncoder
 from .environment.environment import Environment
 from .mathutils.function import Function
 from .plots.plot_helpers import show_or_save_plot
 from .rocket.aero_surface import TrapezoidalFins
 from .simulation.flight import Flight
-from ._encoders import RocketPyEncoder, RocketPyDecoder
 
 
 def compute_cd_s_from_drop_test(

--- a/tests/unit/test_utilities.py
+++ b/tests/unit/test_utilities.py
@@ -1,6 +1,6 @@
+import os
 from unittest.mock import patch
 
-import os
 import numpy as np
 import pytest
 


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [X] Lint (`make format`) has passed locally 
- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
    - Note: all the standard tests have passed locally, the `--runslow` needs #807 and #805 
- [X] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Currently, the introduction of `net_thrust` is the first addition of an attribute that impacts the behavior of the motor and flight classes. Therefore, the `.rpy` of version 1.8.0 does not have this parameters, which should be handled.

One notable point is that the tests are working as expected and caught this "file breaking change".

## New behavior
<!-- Describe changes introduced by this PR. -->

This PR adds custom handling for the new attributes. Unfortunately, I did not find other ways beside manual handling (i.e. pinpointing in code the necessary attribute).

I am open to suggestions on how to deal with those parameter changes between older file versions.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No
