### PR TITLE
ENH: support for ND arithmetical operations for Function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ Attention: The newest changes should be on top -->
 ### Added
 - ENH: Support for ND arithmetic in Function class. [#810] (https://github.com/RocketPy-Team/RocketPy/pull/810)
 - ENH: allow users to provide custom samplers [#803](https://github.com/RocketPy-Team/RocketPy/pull/803)
-- BUG: Fix StochasticFlight time_overshoot None bug [#805] (https://github.com/RocketPy-Team/RocketPy/pull/805)
 - ENH: Implement Multivariate Rejection Sampling (MRS) [#738] (https://github.com/RocketPy-Team/RocketPy/pull/738) 
 - ENH: Create a rocketpy file to store flight simulations [#800](https://github.com/RocketPy-Team/RocketPy/pull/800)
 - ENH: Support for the RSE file format has been added to the library [#798](https://github.com/RocketPy-Team/RocketPy/pull/798)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Attention: The newest changes should be on top -->
 
 ### Added
+- ENH: Support for ND arithmetic in Function class. [#810] (https://github.com/RocketPy-Team/RocketPy/pull/810)
 - ENH: allow users to provide custom samplers [#803](https://github.com/RocketPy-Team/RocketPy/pull/803)
+- BUG: Fix StochasticFlight time_overshoot None bug [#805] (https://github.com/RocketPy-Team/RocketPy/pull/805)
 - ENH: Implement Multivariate Rejection Sampling (MRS) [#738] (https://github.com/RocketPy-Team/RocketPy/pull/738) 
 - ENH: Create a rocketpy file to store flight simulations [#800](https://github.com/RocketPy-Team/RocketPy/pull/800)
 - ENH: Support for the RSE file format has been added to the library [#798](https://github.com/RocketPy-Team/RocketPy/pull/798)

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -1948,7 +1948,7 @@ class Function:  # pylint: disable=too-many-public-methods
                     self.__outputs__,
                 )
             else:
-                param_names = [f"x{i}" for i in range(len(self.__inputs__))]
+                param_names = [f"x{i}" for i in range(self.__dom_dim__)]
                 param_str = ", ".join(param_names)
                 func_str = f"lambda {param_str}: -func({param_str})"
                 return Function(
@@ -2131,7 +2131,9 @@ class Function:  # pylint: disable=too-many-public-methods
             A Function object which gives the result of self(x)+other(x).
         """
         other_is_func = isinstance(other, Function)
-        other_array = other._source_type is SourceType.ARRAY if other_is_func else False
+        other_is_array = (
+            other._source_type is SourceType.ARRAY if other_is_func else False
+        )
         inputs = self.__inputs__[:]
         interp = self.__interpolation__
         extrap = self.__extrapolation__
@@ -2139,7 +2141,7 @@ class Function:  # pylint: disable=too-many-public-methods
 
         if (
             self._source_type is SourceType.ARRAY
-            and other_array
+            and other_is_array
             and np.array_equal(self._domain, other._domain)
         ):
             source = np.column_stack((self._domain, self._image + other._image))
@@ -2162,7 +2164,7 @@ class Function:  # pylint: disable=too-many-public-methods
         elif callable(other):
             if other_is_func:
                 other_dim = other.__dom_dim__
-                other = other.get_value_opt if other_array else other.source
+                other = other.get_value_opt if other_is_array else other.source
             else:
                 other_dim = len(signature(other).parameters)
 
@@ -2216,7 +2218,9 @@ class Function:  # pylint: disable=too-many-public-methods
             A Function object which gives the result of self(x)-other(x).
         """
         other_is_func = isinstance(other, Function)
-        other_array = other._source_type is SourceType.ARRAY if other_is_func else False
+        other_is_array = (
+            other._source_type is SourceType.ARRAY if other_is_func else False
+        )
         inputs = self.__inputs__[:]
         interp = self.__interpolation__
         extrap = self.__extrapolation__
@@ -2224,7 +2228,7 @@ class Function:  # pylint: disable=too-many-public-methods
 
         if (
             self._source_type is SourceType.ARRAY
-            and other_array
+            and other_is_array
             and np.array_equal(self._domain, other._domain)
         ):
             source = np.column_stack((self._domain, self._image - other._image))
@@ -2249,7 +2253,7 @@ class Function:  # pylint: disable=too-many-public-methods
         elif callable(other):
             if other_is_func:
                 other_dim = other.__dom_dim__
-                other = other.get_value_opt if other_array else other.source
+                other = other.get_value_opt if other_is_array else other.source
             else:
                 other_dim = len(signature(other).parameters)
 
@@ -2304,7 +2308,9 @@ class Function:  # pylint: disable=too-many-public-methods
             A Function object which gives the result of self(x)*other(x).
         """
         other_is_func = isinstance(other, Function)
-        other_array = other._source_type is SourceType.ARRAY if other_is_func else False
+        other_is_array = (
+            other._source_type is SourceType.ARRAY if other_is_func else False
+        )
         inputs = self.__inputs__[:]
         interp = self.__interpolation__
         extrap = self.__extrapolation__
@@ -2312,7 +2318,7 @@ class Function:  # pylint: disable=too-many-public-methods
 
         if (
             self._source_type is SourceType.ARRAY
-            and other_array
+            and other_is_array
             and np.array_equal(self._domain, other._domain)
         ):
             source = np.column_stack((self._domain, self._image * other._image))
@@ -2337,7 +2343,7 @@ class Function:  # pylint: disable=too-many-public-methods
         elif callable(other):
             if other_is_func:
                 other_dim = other.__dom_dim__
-                other = other.get_value_opt if other_array else other.source
+                other = other.get_value_opt if other_is_array else other.source
             else:
                 other_dim = len(signature(other).parameters)
 
@@ -2391,7 +2397,9 @@ class Function:  # pylint: disable=too-many-public-methods
             A Function object which gives the result of self(x)/other(x).
         """
         other_is_func = isinstance(other, Function)
-        other_array = other._source_type is SourceType.ARRAY if other_is_func else False
+        other_is_array = (
+            other._source_type is SourceType.ARRAY if other_is_func else False
+        )
         inputs = self.__inputs__[:]
         interp = self.__interpolation__
         extrap = self.__extrapolation__
@@ -2399,7 +2407,7 @@ class Function:  # pylint: disable=too-many-public-methods
 
         if (
             self._source_type is SourceType.ARRAY
-            and other_array
+            and other_is_array
             and np.array_equal(self._domain, other._domain)
         ):
             with np.errstate(divide="ignore", invalid="ignore"):
@@ -2428,7 +2436,7 @@ class Function:  # pylint: disable=too-many-public-methods
         elif callable(other):
             if other_is_func:
                 other_dim = other.__dom_dim__
-                other = other.get_value_opt if other_array else other.source
+                other = other.get_value_opt if other_is_array else other.source
             else:
                 other_dim = len(signature(other).parameters)
 
@@ -2526,7 +2534,9 @@ class Function:  # pylint: disable=too-many-public-methods
             A Function object which gives the result of self(x)**other(x).
         """
         other_is_func = isinstance(other, Function)
-        other_array = other._source_type is SourceType.ARRAY if other_is_func else False
+        other_is_array = (
+            other._source_type is SourceType.ARRAY if other_is_func else False
+        )
         inputs = self.__inputs__[:]
         interp = self.__interpolation__
         extrap = self.__extrapolation__
@@ -2534,7 +2544,7 @@ class Function:  # pylint: disable=too-many-public-methods
 
         if (
             self._source_type is SourceType.ARRAY
-            and other_array
+            and other_is_array
             and np.array_equal(self._domain, other._domain)
         ):
             source = np.column_stack(
@@ -2559,7 +2569,7 @@ class Function:  # pylint: disable=too-many-public-methods
         elif callable(other):
             if other_is_func:
                 other_dim = other.__dom_dim__
-                other = other.get_value_opt if other_array else other.source
+                other = other.get_value_opt if other_is_array else other.source
             else:
                 other_dim = len(signature(other).parameters)
 
@@ -2652,7 +2662,9 @@ class Function:  # pylint: disable=too-many-public-methods
     def __mod__(self, other):  # pylint: disable=too-many-statements
         """Operator % as an alias for modulo operation."""
         other_is_func = isinstance(other, Function)
-        other_array = other._source_type is SourceType.ARRAY if other_is_func else False
+        other_is_array = (
+            other._source_type is SourceType.ARRAY if other_is_func else False
+        )
         inputs = self.__inputs__[:]
         interp = self.__interpolation__
         extrap = self.__extrapolation__
@@ -2660,7 +2672,7 @@ class Function:  # pylint: disable=too-many-public-methods
 
         if (
             self._source_type is SourceType.ARRAY
-            and other_array
+            and other_is_array
             and np.array_equal(self._domain, other._domain)
         ):
             source = np.column_stack((self._domain, np.mod(self._image, other._image)))
@@ -2683,7 +2695,7 @@ class Function:  # pylint: disable=too-many-public-methods
         elif callable(other):
             if other_is_func:
                 other_dim = other.__dom_dim__
-                other = other.get_value_opt if other_array else other.source
+                other = other.get_value_opt if other_is_array else other.source
             else:
                 other_dim = len(signature(other).parameters)
 

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -2175,10 +2175,12 @@ class Function:  # pylint: disable=too-many-public-methods
                     )
                 )
             else:
+                # pragma: no cover
                 raise TypeError(
                     f"The number of parameters in the function to be added ({other_dim}) "
                     f"does not match the number of parameters of the Function ({dom_dim})."
                 )
+        # pragma: no cover
         raise TypeError("Unsupported type for addition")
 
     def __radd__(self, other):
@@ -2264,10 +2266,12 @@ class Function:  # pylint: disable=too-many-public-methods
                     )
                 )
             else:
+                # pragma: no cover
                 raise TypeError(
                     f"The number of parameters in the function to be subtracted ({other_dim}) "
                     f"does not match the number of parameters of the Function ({dom_dim})."
                 )
+        # pragma: no cover
         raise TypeError("Unsupported type for subtraction")
 
     def __rsub__(self, other):
@@ -2354,10 +2358,12 @@ class Function:  # pylint: disable=too-many-public-methods
                     )
                 )
             else:
+                # pragma: no cover
                 raise TypeError(
                     f"The number of parameters in the function to be multiplied ({other_dim}) "
                     f"does not match the number of parameters of the Function ({dom_dim})."
                 )
+        # pragma: no cover
         raise TypeError("Unsupported type for multiplication")
 
     def __rmul__(self, other):
@@ -2447,10 +2453,12 @@ class Function:  # pylint: disable=too-many-public-methods
                     )
                 )
             else:
+                # pragma: no cover
                 raise TypeError(
                     f"The number of parameters in the function to be divided ({other_dim}) "
                     f"does not match the number of parameters of the Function ({dom_dim})."
                 )
+        # pragma: no cover
         raise TypeError("Unsupported type for division")
 
     def __rtruediv__(self, other):
@@ -2506,11 +2514,12 @@ class Function:  # pylint: disable=too-many-public-methods
                     )
                 )
             else:
+                # pragma: no cover
                 raise TypeError(
                     f"The number of parameters in the function dividing by this Function ({other_dim}) "
                     f"does not match the number of parameters of this Function ({dom_dim})."
                 )
-
+        # pragma: no cover
         raise TypeError("Unsupported type for division")
 
     def __pow__(self, other):  # pylint: disable=too-many-statements
@@ -2580,10 +2589,12 @@ class Function:  # pylint: disable=too-many-public-methods
                     )
                 )
             else:
+                # pragma: no cover
                 raise TypeError(
                     f"The number of parameters in the function to be exponentiated by ({other_dim}) "
                     f"does not match the number of parameters of the Function ({dom_dim})."
                 )
+        # pragma: no cover
         raise TypeError("Unsupported type for exponentiation")
 
     def __rpow__(self, other):
@@ -2633,10 +2644,12 @@ class Function:  # pylint: disable=too-many-public-methods
                     inputs,
                 )
             else:
+                # pragma: no cover
                 raise TypeError(
                     f"The number of parameters in the base function ({other_dim}) "
                     f"does not match the number of parameters of the Function exponent ({dom_dim})."
                 )
+        # pragma: no cover
         raise TypeError("Unsupported type for exponentiation")
 
     def __matmul__(self, other):
@@ -2706,10 +2719,12 @@ class Function:  # pylint: disable=too-many-public-methods
                     )
                 )
             else:
+                # pragma: no cover
                 raise TypeError(
                     f"The number of parameters in the function used as divisor ({other_dim}) "
                     f"does not match the number of parameters of the Function ({dom_dim})."
                 )
+        # pragma: no cover
         raise TypeError("Unsupported type for modulo operation")
 
     def integral(self, a, b, numerical=False):  # pylint: disable=too-many-statements

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -749,6 +749,320 @@ def test_pow_arithmetic_priority(other):
     assert isinstance(other**func_array, Function)
 
 
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+    ],
+)
+def test_2d_function_arithmetic_add(other):
+    """Test the add operation of the Function class with 2D functions."""
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)], interpolation="linear")
+
+    assert np.isclose((func_lambda + other)(2), 7)
+    assert np.isclose((func_array + other)(2), 7)
+    assert np.isclose((other + func_lambda)(2), 7)
+    assert np.isclose((other + func_array)(2), 7)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+    ],
+)
+def test_2d_function_arithmetic_sub(other):
+    """Test the sub operation of the Function class with 2D functions."""
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)], interpolation="linear")
+
+    assert np.isclose((func_lambda - other)(2), 1)
+    assert np.isclose((func_array - other)(2), 1)
+    assert np.isclose((other - func_lambda)(2), -1)
+    assert np.isclose((other - func_array)(2), -1)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+    ],
+)
+def test_2d_function_arithmetic_mul(other):
+    """Test the mul operation of the Function class with 2D functions."""
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)], interpolation="linear")
+
+    assert np.isclose((func_lambda * other)(2), 12)
+    assert np.isclose((func_array * other)(2), 12)
+    assert np.isclose((other * func_lambda)(2), 12)
+    assert np.isclose((other * func_array)(2), 12)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+    ],
+)
+def test_2d_function_arithmetic_div(other):
+    """Test the div operation of the Function class with 2D functions."""
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)], interpolation="linear")
+
+    assert np.isclose((func_lambda / other)(2), 4 / 3)
+    assert np.isclose((func_array / other)(2), 4 / 3)
+    assert np.isclose((other / func_lambda)(2), 0.75)
+    assert np.isclose((other / func_array)(2), 0.75)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+    ],
+)
+def test_2d_function_arithmetic_pow(other):
+    """Test the pow operation of the Function class with 2D functions."""
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)], interpolation="linear")
+
+    assert np.isclose((func_lambda**other)(2), 64)
+    assert np.isclose((func_array**other)(2), 64)
+    assert np.isclose((other**func_lambda)(2), 3**4)
+    assert np.isclose((other**func_array)(2), 3**4)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+    ],
+)
+def test_2d_function_arithmetic_mod(other):
+    """Test the mod operation of the Function class with 2D functions."""
+    func_lambda = Function(lambda x: x**2)
+    func_array = Function([(0, 0), (1, 1), (2, 4)], interpolation="linear")
+
+    assert np.isclose((func_lambda % other)(2), 1)
+    assert np.isclose((func_array % other)(2), 1)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+        Function(
+            [(0, 0, 0, 3), (1, 0, 0, 3), (0, 1, 0, 3), (0, 0, 1, 3), (1, 1, 1, 3)]
+        ),
+        lambda x, y, z: 3,
+        Function(lambda x, y, z: 3),
+    ],
+)
+def test_nd_function_arithmetic_add(other):
+    """Test the add operation of the Function class with ND functions."""
+    func_lambda = Function(lambda x, y, z: x + y + z)
+    func_array = Function(
+        [(0, 0, 0, 0), (1, 0, 0, 1), (0, 1, 0, 1), (0, 0, 1, 1), (1, 1, 1, 3)]
+    )
+
+    assert np.isclose((func_lambda + other)(1, 0, 0), 4)
+    assert np.isclose((func_array + other)(1, 0, 0), 4)
+    assert np.isclose((other + func_lambda)(1, 0, 0), 4)
+    assert np.isclose((other + func_array)(1, 0, 0), 4)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+        Function(
+            [(0, 0, 0, 3), (1, 0, 0, 3), (0, 1, 0, 3), (0, 0, 1, 3), (1, 1, 1, 3)]
+        ),
+        lambda x, y, z: 3,
+        Function(lambda x, y, z: 3),
+    ],
+)
+def test_nd_function_arithmetic_sub(other):
+    """Test the sub operation of the Function class with ND functions."""
+    func_lambda = Function(lambda x, y, z: x + y + z)
+    func_array = Function(
+        [(0, 0, 0, 0), (1, 0, 0, 1), (0, 1, 0, 1), (0, 0, 1, 1), (1, 1, 1, 3)]
+    )
+
+    assert np.isclose((func_lambda - other)(1, 0, 0), -2)
+    assert np.isclose((func_array - other)(1, 0, 0), -2)
+    assert np.isclose((other - func_lambda)(1, 0, 0), 2)
+    assert np.isclose((other - func_array)(1, 0, 0), 2)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+        Function(
+            [(0, 0, 0, 3), (1, 0, 0, 3), (0, 1, 0, 3), (0, 0, 1, 3), (1, 1, 1, 3)]
+        ),
+        lambda x, y, z: 3,
+        Function(lambda x, y, z: 3),
+    ],
+)
+def test_nd_function_arithmetic_mul(other):
+    """Test the mul operation of the Function class with ND functions."""
+    func_lambda = Function(lambda x, y, z: x + y + z)
+    func_array = Function(
+        [(0, 0, 0, 0), (1, 0, 0, 1), (0, 1, 0, 1), (0, 0, 1, 1), (1, 1, 1, 3)]
+    )
+
+    assert np.isclose((func_lambda * other)(1, 0, 0), 3)
+    assert np.isclose((func_array * other)(1, 0, 0), 3)
+    assert np.isclose((other * func_lambda)(1, 0, 0), 3)
+    assert np.isclose((other * func_array)(1, 0, 0), 3)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+        Function(
+            [(0, 0, 0, 3), (1, 0, 0, 3), (0, 1, 0, 3), (0, 0, 1, 3), (1, 1, 1, 3)]
+        ),
+        lambda x, y, z: 3,
+        Function(lambda x, y, z: 3),
+    ],
+)
+def test_nd_function_arithmetic_div(other):
+    """Test the div operation of the Function class with ND functions."""
+    func_lambda = Function(lambda x, y, z: x + y + z)
+    func_array = Function(
+        [(0, 0, 0, 0), (1, 0, 0, 1), (0, 1, 0, 1), (0, 0, 1, 1), (1, 1, 1, 3)]
+    )
+
+    assert np.isclose((func_lambda / other)(1, 0, 0), 1 / 3)
+    assert np.isclose((func_array / other)(1, 0, 0), 1 / 3)
+    assert np.isclose((other / func_lambda)(1, 0, 0), 3)
+    assert np.isclose((other / func_array)(1, 0, 0), 3)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+        Function(
+            [(0, 0, 0, 3), (1, 0, 0, 3), (0, 1, 0, 3), (0, 0, 1, 3), (1, 1, 1, 3)]
+        ),
+        lambda x, y, z: 3,
+        Function(lambda x, y, z: 3),
+    ],
+)
+def test_nd_function_arithmetic_pow(other):
+    """Test the pow operation of the Function class with ND functions."""
+    func_lambda = Function(lambda x, y, z: x + y + z)
+    func_array = Function(
+        [(0, 0, 0, 0), (1, 0, 0, 1), (0, 1, 0, 1), (0, 0, 1, 1), (1, 1, 1, 3)]
+    )
+
+    assert np.isclose((func_lambda**other)(1, 0, 0), 1)
+    assert np.isclose((func_array**other)(1, 0, 0), 1)
+    assert np.isclose((other**func_lambda)(1, 0, 0), 3)
+    assert np.isclose((other**func_array)(1, 0, 0), 3)
+
+
+@pytest.mark.parametrize(
+    "other",
+    [
+        3.0,
+        np.float64(3.0),
+        np.array(3),
+        np.array([3]),
+        lambda _: 3,
+        Function(3.0),
+        Function([(0, 3), (1, 3), (2, 3)], interpolation="linear"),
+        Function(
+            [(0, 0, 0, 3), (1, 0, 0, 3), (0, 1, 0, 3), (0, 0, 1, 3), (1, 1, 1, 3)]
+        ),
+        lambda x, y, z: 3,
+        Function(lambda x, y, z: 3),
+    ],
+)
+def test_nd_function_arithmetic_mod(other):
+    """Test the mod operation of the Function class with ND functions."""
+    func_lambda = Function(lambda x, y, z: x + y + z)
+    func_array = Function(
+        [(0, 0, 0, 0), (1, 0, 0, 1), (0, 1, 0, 1), (0, 0, 1, 1), (1, 1, 1, 3)]
+    )
+
+    assert np.isclose((func_lambda % other)(1, 0, 0), 1)
+    assert np.isclose((func_array % other)(1, 0, 0), 1)
+
+
 @pytest.mark.parametrize("alpha", [0.1, 0.5, 0.9])
 def test_low_pass_filter(alpha):
     """Test the low_pass_filter method of the Function class.

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -283,7 +283,7 @@ def test_remove_outliers_iqr(x, y, expected_x, expected_y):
 def test_set_get_value_opt():
     """Test the set_value_opt and get_value_opt methods of the Function class."""
     func = Function(lambda x: x**2)
-    func.source = np.array([[1, 1], [2, 4], [3, 9], [4, 16], [5, 25]])
+    func.set_source(np.array([[1, 1], [2, 4], [3, 9], [4, 16], [5, 25]]))
     func.x_array = np.array([1, 2, 3, 4, 5])
     func.y_array = np.array([1, 4, 9, 16, 25])
     func.x_initial = 1

--- a/tests/unit/test_function.py
+++ b/tests/unit/test_function.py
@@ -284,10 +284,6 @@ def test_set_get_value_opt():
     """Test the set_value_opt and get_value_opt methods of the Function class."""
     func = Function(lambda x: x**2)
     func.set_source(np.array([[1, 1], [2, 4], [3, 9], [4, 16], [5, 25]]))
-    func.x_array = np.array([1, 2, 3, 4, 5])
-    func.y_array = np.array([1, 4, 9, 16, 25])
-    func.x_initial = 1
-    func.x_final = 5
     func.set_interpolation("linear")
     func.set_get_value_opt()
     assert func.get_value_opt(2.5) == 6.5


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [X] Tests for the changes have been added (if needed)
- [X] Docs have been reviewed and added / updated
- [X] All tests (`pytest tests -m slow --runslow`) have passed locally
- [X] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

PR #785 introduced the possibility of 2D `Function` multiplication. The intent of this PR is to generalize this to the other arithmetical operations and to ND `Functions` for better scalability (e.g. so as not keep adding if blocks for every dimension, like 3D, 4D etc).

## New behavior
<!-- Describe changes introduced by this PR. -->

The generalization is done with the following changes:
- Use the `self._domain` and `self._image` for array manipulation, instead of unidimensional `self.x_array` and `self.y_array`;
- Multivariate lambda expressions are generated to allow callable operations:
    - The implementation is less trivial, requiring dynamically building a multivariate `lambda`;
    - This PR implementation worked very well on testing, but, if it does not hold review scrutinity due the use of `eval`, it can easily be converted into an `exception` and disallowing it.
    
Tests were introduced for both existing 2D operations and for the new generalized ones.

Overall the structure of the arithmetic methods of `Function` got a bit simpler and more regular. Another important notice, is that the current multivariable implementation of `mul` from #785 is non commutative when dealing with 1D*2D, which is fixed by this PR.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [X] No
