### PR TITLE
ENH: Enable only radial burning

### DIFF
--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -300,6 +300,11 @@ class SolidMotor(Motor):
             positions specified. Options are "nozzle_to_combustion_chamber" and
             "combustion_chamber_to_nozzle". Default is
             "nozzle_to_combustion_chamber".
+        only_radial_burn : boolean, optional
+            If True, inhibits the grain from burning axially, only computing
+            radial burn. Otherwise, if False, allows the grain to also burn 
+            axially. May be useful for axially inhibited grains or hybrid motors.
+            Default is False.
 
         Returns
         -------
@@ -316,7 +321,6 @@ class SolidMotor(Motor):
             reshape_thrust_curve=reshape_thrust_curve,
             interpolation_method=interpolation_method,
             coordinate_system_orientation=coordinate_system_orientation,
-            only_radial_burn = only_radial_burn,
         )
         # Nozzle parameters
         self.throat_radius = throat_radius
@@ -484,13 +488,7 @@ class SolidMotor(Motor):
             # Compute state vector derivative
             grain_inner_radius, grain_height = y
             if self.only_radial_burn:
-                burn_area = (
-                    2
-                    * np.pi
-                    * (
-                        grain_inner_radius * grain_height
-                    )
-                )
+                burn_area = 2 * np.pi * (grain_inner_radius * grain_height)
             else:
                 burn_area = (
                     2
@@ -516,12 +514,7 @@ class SolidMotor(Motor):
             grain_inner_radius, grain_height = y
             if self.only_radial_burn:
                 factor = volume_diff / (
-                    2
-                    * np.pi
-                    * (
-                        grain_inner_radius * grain_height
-                    )
-                    ** 2
+                    2 * np.pi * (grain_inner_radius * grain_height) ** 2
                 )
 
                 inner_radius_derivative_wrt_inner_radius = factor * (
@@ -537,8 +530,6 @@ class SolidMotor(Motor):
                         inner_radius_derivative_wrt_height,
                     ],
                     [height_derivative_wrt_inner_radius, height_derivative_wrt_height],
-
-
                 ]
 
             else:
@@ -568,10 +559,8 @@ class SolidMotor(Motor):
                         inner_radius_derivative_wrt_height,
                     ],
                     [height_derivative_wrt_inner_radius, height_derivative_wrt_height],
-
-
                 ]
-                
+
         def terminate_burn(t, y):  # pylint: disable=unused-argument
             end_function = (self.grain_outer_radius - y[0]) * y[1]
             return end_function
@@ -625,9 +614,7 @@ class SolidMotor(Motor):
             burn_area = (
                 2
                 * np.pi
-                * (
-                    self.grain_inner_radius * self.grain_height
-                )
+                * (self.grain_inner_radius * self.grain_height)
                 * self.grain_number
             )
         else:
@@ -812,6 +799,7 @@ class SolidMotor(Motor):
                 "grain_initial_height": self.grain_initial_height,
                 "grain_separation": self.grain_separation,
                 "grains_center_of_mass_position": self.grains_center_of_mass_position,
+                "only_radial_burn": self.only_radial_burn,
             }
         )
 
@@ -855,4 +843,5 @@ class SolidMotor(Motor):
             throat_radius=data["throat_radius"],
             interpolation_method=data["interpolate"],
             coordinate_system_orientation=data["coordinate_system_orientation"],
+            only_radial_burn=data.get("only_radial_burn", False),
         )

--- a/rocketpy/motors/solid_motor.py
+++ b/rocketpy/motors/solid_motor.py
@@ -302,7 +302,7 @@ class SolidMotor(Motor):
             "nozzle_to_combustion_chamber".
         only_radial_burn : boolean, optional
             If True, inhibits the grain from burning axially, only computing
-            radial burn. Otherwise, if False, allows the grain to also burn 
+            radial burn. Otherwise, if False, allows the grain to also burn
             axially. May be useful for axially inhibited grains or hybrid motors.
             Default is False.
 
@@ -343,10 +343,11 @@ class SolidMotor(Motor):
         )
         self.grain_initial_mass = self.grain_density * self.grain_initial_volume
 
-        self.evaluate_geometry()
-
         # Burn surface definition
         self.only_radial_burn = only_radial_burn
+
+        self.evaluate_geometry()
+
         # Initialize plots and prints object
         self.prints = _SolidMotorPrints(self)
         self.plots = _SolidMotorPlots(self)
@@ -489,6 +490,10 @@ class SolidMotor(Motor):
             grain_inner_radius, grain_height = y
             if self.only_radial_burn:
                 burn_area = 2 * np.pi * (grain_inner_radius * grain_height)
+
+                grain_inner_radius_derivative = -volume_diff / burn_area
+                grain_height_derivative = 0
+
             else:
                 burn_area = (
                     2
@@ -500,8 +505,8 @@ class SolidMotor(Motor):
                     )
                 )
 
-            grain_inner_radius_derivative = -volume_diff / burn_area
-            grain_height_derivative = -2 * grain_inner_radius_derivative
+                grain_inner_radius_derivative = -volume_diff / burn_area
+                grain_height_derivative = -2 * grain_inner_radius_derivative
 
             return [grain_inner_radius_derivative, grain_height_derivative]
 
@@ -520,7 +525,7 @@ class SolidMotor(Motor):
                 inner_radius_derivative_wrt_inner_radius = factor * (
                     grain_height - 2 * grain_inner_radius
                 )
-                inner_radius_derivative_wrt_height = factor * grain_inner_radius
+                inner_radius_derivative_wrt_height = 0
                 height_derivative_wrt_inner_radius = 0
                 height_derivative_wrt_height = 0
 


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [X] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Lint (`black rocketpy/ tests/`) has passed locally 
- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Rocketpy SolidMotor class simulates the grain regression either radially and axially by default.

This PR is related to the following issue:
ENH: Enable only radial burning #801 

## New behavior
<!-- Describe changes introduced by this PR. -->

Now it's possible to the user to change from the default behavior to a only radial regression by setting the new "only_radial_burning" optional parameter as True in the SolidMotor class.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

Here is an example of the comparison between the default burning and the only radial one applied to the getting_started.ipynb simulation. The pytest tests haven't passed locally because of a windows problem.

![GRAFICO1NOVO](https://github.com/user-attachments/assets/bc6f495f-3a46-45bc-b053-55af3086d92e)
![GRAFICO2NOVO](https://github.com/user-attachments/assets/ad715d06-74fd-40b3-8762-8157ed644e7d)
![GRAFICO3NOVO](https://github.com/user-attachments/assets/87c64b9b-73fa-49d2-aa28-92ccf47ec9a2)
