### PR TITLE
DEV: fix pip cache on github workflow

### DIFF
--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -29,14 +29,11 @@ jobs:
         uses: actions/setup-python@main
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Cache Python dependencies
-        uses: actions/cache@main
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-tests.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements-tests.txt
+            requirements-optional.txt
 
       - name: Install rocketpy
         run: pip install .


### PR DESCRIPTION
Fix the following message:

```text
Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

See updated docs: https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages