### PR TITLE
Enh/zero inertia tensor check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Attention: The newest changes should be on top -->
 
 ### Added
+
+
+### Changed
+
+
+### Fixed
+
+
+## [v1.10.0] - 2025-05-16
+
+### Added
 - ENH: Support for ND arithmetic in Function class. [#810] (https://github.com/RocketPy-Team/RocketPy/pull/810)
 - ENH: allow users to provide custom samplers [#803](https://github.com/RocketPy-Team/RocketPy/pull/803)
 - ENH: Implement Multivariate Rejection Sampling (MRS) [#738] (https://github.com/RocketPy-Team/RocketPy/pull/738) 
@@ -50,7 +61,7 @@ Attention: The newest changes should be on top -->
 - BUG: Wrong Phi Initialization For nose_to_tail Rockets [#809](https://github.com/RocketPy-Team/RocketPy/pull/809)
 - BUG: Fix StochasticFlight time_overshoot None bug [#805](https://github.com/RocketPy-Team/RocketPy/pull/805)
 
-## v1.9.0 - 2025-03-24
+## [v1.9.0] - 2025-03-24
 
 ### Added
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ copyright = "2024, RocketPy Team"
 author = "RocketPy Team"
 
 # The full version, including alpha/beta/rc tags
-release = "1.9.0"
+release = "1.10.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/user/installation.rst
+++ b/docs/user/installation.rst
@@ -19,7 +19,7 @@ If you want to choose a specific version to guarantee compatibility, you may ins
 
 .. code-block:: shell
 
-    pip install rocketpy==1.9.0
+    pip install rocketpy==1.10.0
 
 
 Optional Installation Method: ``conda``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rocketpy"
-version = "1.9.0"
+version = "1.10.0"
 description="Advanced 6-DOF trajectory simulation for High-Power Rocketry."
 dynamic = ["dependencies"]
 readme = "README.md"

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -294,6 +294,12 @@ class Rocket:
         self.I_13_without_motor = inertia[4]
         self.I_23_without_motor = inertia[5]
 
+        # Initial Inertia Tensor determinant singularity check
+        if abs(inertia) == 0:
+            raise ValueError(
+                "The rocket inertia tensor is singular (determinant is zero). "
+            )
+
         # Define rocket geometrical parameters in SI units
         self.center_of_mass_without_motor = center_of_mass_without_motor
         self.radius = radius

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -293,9 +293,12 @@ class Rocket:
         self.I_12_without_motor = inertia[3]
         self.I_13_without_motor = inertia[4]
         self.I_23_without_motor = inertia[5]
-
-        # Initial Inertia Tensor determinant singularity check
-        if abs(inertia) == 0:
+        inertia_matrix = Matrix([
+            [self.I_11_without_motor, self.I_12_without_motor, self.I_13_without_motor],
+            [self.I_12_without_motor, self.I_22_without_motor, self.I_23_without_motor],
+            [self.I_13_without_motor, self.I_23_without_motor, self.I_33_without_motor],
+        ])    # Initial Inertia Tensor determinant singularity check
+        if abs(inertia_matrix) == 0:
             raise ValueError(
                 "The rocket inertia tensor is singular (determinant is zero). "
             )

--- a/rocketpy/utilities.py
+++ b/rocketpy/utilities.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
+from packaging import version as packaging_version
 from scipy.integrate import solve_ivp
 
 from ._encoders import RocketPyDecoder, RocketPyEncoder
@@ -750,7 +751,9 @@ def load_from_rpy(filename: str, resimulate=False):
 
     with open(filename, "r") as f:
         data = json.load(f)
-        if data["version"] > version("rocketpy"):
+        if packaging_version.parse(data["version"]) > packaging_version.parse(
+            version("rocketpy")
+        ):
             warnings.warn(
                 "The file was saved in an updated version of",
                 f"RocketPy (v{data['version']}), the current",


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code changes (bugfix, features)
- [ ] Code maintenance (refactoring, formatting, tests)
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other (please describe):

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [ ] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [ ] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

As of now there are no checks on the singularity of input inertia tensor. This can create some issues where the simulation may still run even if the input inertia tensor was singular and give ill defined results. This was pointed by an user on discord but could not be recreated

## New behavior
<!-- Describe changes introduced by this PR. -->

A simple check has been added to rocket initialisation for checking the input dry inertia.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

For future this check can be extended to dynamically testing the singularity of inertia tensor. Need for this is to be evaluated.