### PR TITLE
ENH: Add Monte Carlo outputs export to CSV/JSON (#242)

### DIFF
--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -591,8 +591,8 @@ class MonteCarlo:
 
     def export_results(self, output_filename, output_format):
         txt_data = []
-        with open(self.filename, "r", encoding="utf-8") as f:
-            for line in enumerate(f):
+        with open(f"{self.filename}.outputs.txt", "r", encoding="utf-8") as f:
+            for line in f:
                 line = line.strip()
                 data = json.loads(line)
                 txt_data.append(data)
@@ -603,7 +603,7 @@ class MonteCarlo:
                 json.dump(txt_data, f, indent=4)
         elif output_format == "csv":
             output_csv_header = txt_data[0].keys()
-            with open(f"{output_filename}.csv", "w", newLine='', encoding="utf-8") as f:
+            with open(f"{output_filename}.csv", "w", newline= "") as f:
                 output_writer = csv.DictWriter(f, fieldnames=output_csv_header)
                 output_writer.writeheader()
                 output_writer.writerows(txt_data)

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -601,12 +601,14 @@ class MonteCarlo:
         if output_format == "json":
             with open(f"{output_filename}.json", "w", encoding="utf-8") as f:
                 json.dump(txt_data, f, indent=4)
+                _SimMonitor.reprint(f"Results saved to {Path(output_filename)} as .json file")
         elif output_format == "csv":
             output_csv_header = txt_data[0].keys()
             with open(f"{output_filename}.csv", "w", newline= "") as f:
                 output_writer = csv.DictWriter(f, fieldnames=output_csv_header)
                 output_writer.writeheader()
                 output_writer.writerows(txt_data)
+                _SimMonitor.reprint(f"Results saved to {Path(output_filename)} as .csv file")
 
     def __terminate_simulation(self):
         """

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -590,6 +590,20 @@ class MonteCarlo:
         )
 
     def export_results(self, output_filename, output_format):
+        """Converts the default Monte Carlo .txt output to .cvs or .json file
+        depending on the user's choice
+
+        Parameters
+        ----------
+        output_filename : str
+            Name of the file in which the converted data will be saved
+        output_format : str
+            Format of the output file
+
+        Returns
+        -------
+        None
+        """
         txt_data = []
         with open(f"{self.filename}.outputs.txt", "r", encoding="utf-8") as f:
             for line in f:

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -14,6 +14,7 @@ latest documentation.
 """
 
 import json
+import csv
 import os
 import traceback
 import warnings
@@ -587,6 +588,25 @@ class MonteCarlo:
         return (
             json.dumps(outputs_dict, cls=RocketPyEncoder, **self._export_config) + "\n"
         )
+
+    def export_results(self, output_filename, output_format):
+        txt_data = []
+        with open(self.filename, "r", encoding="utf-8") as f:
+            for line in enumerate(f):
+                line = line.strip()
+                data = json.loads(line)
+                txt_data.append(data)
+
+        output_format = output_format.strip().lower()
+        if output_format == "json":
+            with open(f"{output_filename}.json", "w", encoding="utf-8") as f:
+                json.dump(txt_data, f, indent=4)
+        elif output_format == "csv":
+            output_csv_header = txt_data[0].keys()
+            with open(f"{output_filename}.csv", "w", newLine='', encoding="utf-8") as f:
+                output_writer = csv.DictWriter(f, fieldnames=output_csv_header)
+                output_writer.writeheader()
+                output_writer.writerows(txt_data)
 
     def __terminate_simulation(self):
         """

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -209,7 +209,7 @@ def test_export_results_creates_csv_and_json_files(monte_carlo_calisto, tmp_path
         assert expected_file_in_csv.exists()
 
         mc.export_results(tmp_path / "mock_output_in_json", "json")
-        expected_file_in_json = tmp_path / f"{"mock_output_in_json"}.json"
+        expected_file_in_json = tmp_path / "mock_output_in_json.json"
         assert expected_file_in_json.exists()
     finally:
         os.remove("monte_carlo_test.errors.txt")

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -189,7 +189,7 @@ def test_estimate_confidence_interval_raises_type_error_for_invalid_statistic():
         mc.estimate_confidence_interval("apogee", statistic="not_a_function")
 
 
-def test_monte_carlo_export_results_to_csv_and_json_files(monte_carlo_calisto, tmp_path):
+def test_export_results_creates_csv_and_json_files(monte_carlo_calisto, tmp_path):
     """Checks that the export_results create .csv and .json files
 
     Parameters

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -224,6 +224,10 @@ def test_export_results_creates_csv_and_json_files(monte_carlo_calisto, tmp_path
             assert data[0]["apogee"] == 100
             assert data[0]["max_velocity"] == 255
     finally:
-        os.remove("monte_carlo_test.errors.txt")
-        os.remove("monte_carlo_test.inputs.txt")
-        os.remove("monte_carlo_test.outputs.txt")
+        for filepath in [
+            "monte_carlo_test.errors.txt",
+            "monte_carlo_test.inputs.txt",
+            "monte_carlo_test.outputs.txt",
+        ]:
+            if os.path.exists(filepath):
+                os.remove(filepath)

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -1,6 +1,8 @@
 import matplotlib as plt
 import numpy as np
 import pytest
+import json
+import os
 
 from rocketpy.simulation import MonteCarlo
 
@@ -185,3 +187,31 @@ def test_estimate_confidence_interval_raises_type_error_for_invalid_statistic():
 
     with pytest.raises(TypeError):
         mc.estimate_confidence_interval("apogee", statistic="not_a_function")
+
+
+def test_monte_carlo_export_results_to_csv_and_json_files(monte_carlo_calisto, tmp_path):
+    """Checks that the export_results create .csv and .json files
+
+    Parameters
+    ----------
+    monte_carlo_calisto : MonteCarlo
+        Fixture that has the .txt files necessary for the export_results
+    """
+    try:
+        mc = monte_carlo_calisto
+        mc.filename = tmp_path / "mock_output"
+        mock_data = {"apogee": 100, "max_velocity": 255}
+        with open(tmp_path / "mock_output.outputs.txt", "w") as f:
+            f.write(json.dumps(mock_data) + "\n")
+
+        mc.export_results(tmp_path / "mock_outputs_in_csv", "csv")
+        expected_file_in_csv = tmp_path / f"{"mock_outputs_in_csv"}.csv"
+        assert expected_file_in_csv.exists()
+
+        mc.export_results(tmp_path / "mock_output_in_json", "json")
+        expected_file_in_json = tmp_path / f"{"mock_output_in_json"}.json"
+        assert expected_file_in_json.exists()
+    finally:
+        os.remove("monte_carlo_test.errors.txt")
+        os.remove("monte_carlo_test.inputs.txt")
+        os.remove("monte_carlo_test.outputs.txt")

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -2,6 +2,7 @@ import matplotlib as plt
 import numpy as np
 import pytest
 import json
+import csv
 import os
 
 from rocketpy.simulation import MonteCarlo
@@ -207,10 +208,21 @@ def test_export_results_creates_csv_and_json_files(monte_carlo_calisto, tmp_path
         mc.export_results(tmp_path / "mock_outputs_in_csv", "csv")
         expected_file_in_csv = tmp_path / f"{"mock_outputs_in_csv"}.csv"
         assert expected_file_in_csv.exists()
+        with open(expected_file_in_csv, "r") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+            assert len(rows) == 1
+            assert rows[0]["apogee"] == "100"
+            assert rows[0]["max_velocity"] == "255"
 
         mc.export_results(tmp_path / "mock_output_in_json", "json")
         expected_file_in_json = tmp_path / "mock_output_in_json.json"
         assert expected_file_in_json.exists()
+        with open(expected_file_in_json, "r") as f:
+            data = json.load(f)
+            assert len(data) == 1
+            assert data[0]["apogee"] == 100
+            assert data[0]["max_velocity"] == 255
     finally:
         os.remove("monte_carlo_test.errors.txt")
         os.remove("monte_carlo_test.inputs.txt")


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Implement export functionality for `.csv`.

- [x] Implement export functionality for `.json`.

- [x] Ensure that `export_list` and custom `data_collector` variables are included in the export.

- [x] Add unit tests in `tests/` ensuring the files are created and contain correct data.

- [x] Update the documentation to include examples of how to export data.

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Currently the `MonteCarlo` class saves the simulation results into `.outputs.txt` files. There is no method that allowa users to export these results into `.csv` or `.json` files. See issue #242.

## New behavior
<!-- Describe changes introduced by this PR. -->

Implements the `export_results` method in the `MonteCarlo` class. This method reads the data from `.outputs.txt` files and rewrites them to `.csv` and `.json` format, based on the user`s selection

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

