### PR TITLE
ENH: time based triggering of parachute

### DIFF
--- a/rocketpy/rocket/parachute.py
+++ b/rocketpy/rocket/parachute.py
@@ -46,11 +46,11 @@ class Parachute:
 
         - The string "apogee" which triggers the parachute at apogee, i.e.,
           when the rocket reaches its highest point and starts descending.
-        
+
         - The string "launch + X" where X is a number in seconds. The parachute
           will be ejected X seconds after launch (t=0). This is useful for
           simulating delay charges that activate at a fixed time from launch.
-        
+
         - The string "burnout + X" where X is a number in seconds. The parachute
           will be ejected X seconds after motor burnout. This is useful for
           simulating delay charges in motors with delay elements.
@@ -59,8 +59,8 @@ class Parachute:
         Trigger function created from the trigger used to evaluate the trigger
         condition for the parachute ejection system. It is a callable function
         that takes six arguments: Freestream pressure in Pa, Height above
-        ground level in meters, the state vector of the simulation, sensors 
-        list, current time t, and rocket object. It returns ``True`` if the 
+        ground level in meters, the state vector of the simulation, sensors
+        list, current time t, and rocket object. It returns ``True`` if the
         parachute ejection system should be triggered and ``False`` otherwise.
 
         .. note:
@@ -252,6 +252,7 @@ class Parachute:
 
                 def triggerfunc(p, h, y, sensors, t=None, rocket=None):
                     return trigger(p, h, y, sensors)
+
             self.triggerfunc = triggerfunc
 
         elif isinstance(trigger, (int, float)):
@@ -266,7 +267,7 @@ class Parachute:
 
         elif isinstance(trigger, str):
             trigger_lower = trigger.lower().strip()
-            
+
             if trigger_lower == "apogee":
                 # The parachute is deployed at apogee
                 def triggerfunc(p, h, y, sensors, t=None, rocket=None):  # pylint: disable=unused-argument
@@ -276,7 +277,7 @@ class Parachute:
                     return y[5] < 0
 
                 self.triggerfunc = triggerfunc
-            
+
             elif "+" in trigger_lower:
                 # Time-based trigger: "launch + X" or "burnout + X"
                 parts = trigger_lower.split("+")
@@ -286,7 +287,7 @@ class Parachute:
                         + "Expected format: 'launch + delay' or 'burnout + delay' "
                         + "where delay is a number in seconds."
                     )
-                
+
                 event = parts[0].strip()
                 try:
                     delay = float(parts[1].strip())
@@ -295,16 +296,16 @@ class Parachute:
                         f"Invalid delay value in trigger '{trigger}' for parachute '{self.name}'. "
                         + "Delay must be a number in seconds."
                     )
-                
+
                 if event == "launch":
                     # Deploy at launch time + delay
                     def triggerfunc(p, h, y, sensors, t=None, rocket=None):  # pylint: disable=unused-argument
                         if t is None:
                             return False
                         return t >= delay
-                    
+
                     self.triggerfunc = triggerfunc
-                
+
                 elif event == "burnout":
                     # Deploy at motor burnout time + delay
                     def triggerfunc(p, h, y, sensors, t=None, rocket=None):  # pylint: disable=unused-argument
@@ -312,15 +313,15 @@ class Parachute:
                             return False
                         burnout_time = rocket.motor.burn_out_time
                         return t >= burnout_time + delay
-                    
+
                     self.triggerfunc = triggerfunc
-                
+
                 else:
                     raise ValueError(
                         f"Invalid time-based trigger event '{event}' for parachute '{self.name}'. "
                         + "Supported events are 'launch' and 'burnout'."
                     )
-            
+
             else:
                 raise ValueError(
                     f"Unable to set the trigger function for parachute '{self.name}'. "

--- a/tests/integration/test_parachute_time_trig.py
+++ b/tests/integration/test_parachute_time_trig.py
@@ -10,14 +10,14 @@ def test_flight_with_launch_plus_delay_trigger(
     example_spaceport_env, calisto_motorless, cesaroni_m1670
 ):
     """Test a complete flight simulation with a 'launch + X' parachute trigger.
-    
+
     This simulates a rocket with a delay charge that deploys the parachute at a
     fixed time after launch, similar to model rockets without avionics.
     """
     # Use existing rocket and add motor
     rocket = calisto_motorless
     rocket.add_motor(cesaroni_m1670, position=-1.373)
-    
+
     # Add a parachute with "launch + 5" trigger (5 seconds after launch)
     rocket.add_parachute(
         name="Main",
@@ -27,7 +27,7 @@ def test_flight_with_launch_plus_delay_trigger(
         lag=1.5,
         noise=(0, 8.3, 0.5),
     )
-    
+
     # Run flight simulation
     flight = Flight(
         environment=example_spaceport_env,
@@ -37,15 +37,15 @@ def test_flight_with_launch_plus_delay_trigger(
         heading=0,
         terminate_on_apogee=False,
     )
-    
+
     # Verify that the parachute was deployed at approximately the right time
     # The parachute should deploy at t=5s + lag=1.5s = 6.5s (fully deployed)
     assert flight.t is not None
-    
+
     # Check that parachute deployment happened (should have parachute_cd_s set)
     # This attribute is set when parachute is deployed
     assert hasattr(flight, "parachute_cd_s")
-    
+
     # Verify simulation completed successfully
     assert flight.apogee_time > 0
 
@@ -55,17 +55,17 @@ def test_flight_with_burnout_plus_delay_trigger(
     example_spaceport_env, calisto_motorless, cesaroni_m1670
 ):
     """Test a complete flight simulation with a 'burnout + X' parachute trigger.
-    
+
     This simulates a rocket with a motor delay charge that deploys the parachute
     at a fixed time after motor burnout, typical of model rocket motors.
     """
     # Use existing rocket and add motor
     rocket = calisto_motorless
     rocket.add_motor(cesaroni_m1670, position=-1.373)
-    
+
     # Get motor burnout time
     motor_burnout = rocket.motor.burn_out_time
-    
+
     # Add a parachute with "burnout + 3" trigger (3 seconds after burnout)
     rocket.add_parachute(
         name="Main",
@@ -75,7 +75,7 @@ def test_flight_with_burnout_plus_delay_trigger(
         lag=1.5,
         noise=(0, 8.3, 0.5),
     )
-    
+
     # Run flight simulation
     flight = Flight(
         environment=example_spaceport_env,
@@ -85,17 +85,17 @@ def test_flight_with_burnout_plus_delay_trigger(
         heading=0,
         terminate_on_apogee=False,
     )
-    
+
     # Verify that the parachute was deployed
     assert flight.t is not None
-    
+
     # Check that parachute deployment happened
     assert hasattr(flight, "parachute_cd_s")
-    
+
     # The parachute should deploy after motor burnout + delay
     # Expected deployment at burnout_time + 3s + lag
     expected_deploy_time = motor_burnout + 3.0 + 1.5
-    
+
     # Verify simulation completed successfully and parachute deployed after burnout
     assert flight.apogee_time > 0
     # The simulation should run past the expected deployment time
@@ -107,13 +107,13 @@ def test_flight_with_multiple_time_based_parachutes(
     example_spaceport_env, calisto_motorless, cesaroni_m1670
 ):
     """Test a flight with multiple time-based parachutes (drogue and main).
-    
+
     This simulates a dual-deployment system using time-based triggers.
     """
     # Use existing rocket and add motor
     rocket = calisto_motorless
     rocket.add_motor(cesaroni_m1670, position=-1.373)
-    
+
     # Add drogue parachute - deploys at burnout + 2 seconds
     rocket.add_parachute(
         name="Drogue",
@@ -123,7 +123,7 @@ def test_flight_with_multiple_time_based_parachutes(
         lag=0.5,
         noise=(0, 8.3, 0.5),
     )
-    
+
     # Add main parachute - deploys at burnout + 10 seconds
     rocket.add_parachute(
         name="Main",
@@ -133,7 +133,7 @@ def test_flight_with_multiple_time_based_parachutes(
         lag=1.0,
         noise=(0, 8.3, 0.5),
     )
-    
+
     # Run flight simulation
     flight = Flight(
         environment=example_spaceport_env,
@@ -143,11 +143,11 @@ def test_flight_with_multiple_time_based_parachutes(
         heading=0,
         terminate_on_apogee=False,
     )
-    
+
     # Verify simulation completed successfully
     assert flight.t is not None
     assert flight.apogee_time > 0
-    
+
     # Check that parachute deployment happened
     assert hasattr(flight, "parachute_cd_s")
 
@@ -157,13 +157,13 @@ def test_flight_with_mixed_trigger_types(
     example_spaceport_env, calisto_motorless, cesaroni_m1670
 ):
     """Test a flight with both time-based and traditional parachute triggers.
-    
+
     This ensures backward compatibility when mixing trigger types.
     """
     # Use existing rocket and add motor
     rocket = calisto_motorless
     rocket.add_motor(cesaroni_m1670, position=-1.373)
-    
+
     # Add drogue parachute with traditional apogee trigger
     rocket.add_parachute(
         name="Drogue",
@@ -173,7 +173,7 @@ def test_flight_with_mixed_trigger_types(
         lag=0.5,
         noise=(0, 8.3, 0.5),
     )
-    
+
     # Add main parachute with altitude trigger
     rocket.add_parachute(
         name="Main",
@@ -183,7 +183,7 @@ def test_flight_with_mixed_trigger_types(
         lag=1.0,
         noise=(0, 8.3, 0.5),
     )
-    
+
     # Run flight simulation
     flight = Flight(
         environment=example_spaceport_env,
@@ -193,10 +193,10 @@ def test_flight_with_mixed_trigger_types(
         heading=0,
         terminate_on_apogee=False,
     )
-    
+
     # Verify simulation completed successfully
     assert flight.t is not None
     assert flight.apogee_time > 0
-    
+
     # Check that parachute deployment happened
     assert hasattr(flight, "parachute_cd_s")

--- a/tests/integration/test_parachute_time_trig.py
+++ b/tests/integration/test_parachute_time_trig.py
@@ -1,0 +1,202 @@
+"""Integration tests for time-based parachute triggers in flight simulations."""
+
+import pytest
+
+from rocketpy import Flight
+
+
+@pytest.mark.slow
+def test_flight_with_launch_plus_delay_trigger(
+    example_spaceport_env, calisto_motorless, cesaroni_m1670
+):
+    """Test a complete flight simulation with a 'launch + X' parachute trigger.
+    
+    This simulates a rocket with a delay charge that deploys the parachute at a
+    fixed time after launch, similar to model rockets without avionics.
+    """
+    # Use existing rocket and add motor
+    rocket = calisto_motorless
+    rocket.add_motor(cesaroni_m1670, position=-1.373)
+    
+    # Add a parachute with "launch + 5" trigger (5 seconds after launch)
+    rocket.add_parachute(
+        name="Main",
+        cd_s=10.0,
+        trigger="launch + 5",
+        sampling_rate=100,
+        lag=1.5,
+        noise=(0, 8.3, 0.5),
+    )
+    
+    # Run flight simulation
+    flight = Flight(
+        environment=example_spaceport_env,
+        rocket=rocket,
+        rail_length=5.2,
+        inclination=85,
+        heading=0,
+        terminate_on_apogee=False,
+    )
+    
+    # Verify that the parachute was deployed at approximately the right time
+    # The parachute should deploy at t=5s + lag=1.5s = 6.5s (fully deployed)
+    assert flight.t is not None
+    
+    # Check that parachute deployment happened (should have parachute_cd_s set)
+    # This attribute is set when parachute is deployed
+    assert hasattr(flight, "parachute_cd_s")
+    
+    # Verify simulation completed successfully
+    assert flight.apogee_time > 0
+
+
+@pytest.mark.slow
+def test_flight_with_burnout_plus_delay_trigger(
+    example_spaceport_env, calisto_motorless, cesaroni_m1670
+):
+    """Test a complete flight simulation with a 'burnout + X' parachute trigger.
+    
+    This simulates a rocket with a motor delay charge that deploys the parachute
+    at a fixed time after motor burnout, typical of model rocket motors.
+    """
+    # Use existing rocket and add motor
+    rocket = calisto_motorless
+    rocket.add_motor(cesaroni_m1670, position=-1.373)
+    
+    # Get motor burnout time
+    motor_burnout = rocket.motor.burn_out_time
+    
+    # Add a parachute with "burnout + 3" trigger (3 seconds after burnout)
+    rocket.add_parachute(
+        name="Main",
+        cd_s=10.0,
+        trigger="burnout + 3",
+        sampling_rate=100,
+        lag=1.5,
+        noise=(0, 8.3, 0.5),
+    )
+    
+    # Run flight simulation
+    flight = Flight(
+        environment=example_spaceport_env,
+        rocket=rocket,
+        rail_length=5.2,
+        inclination=85,
+        heading=0,
+        terminate_on_apogee=False,
+    )
+    
+    # Verify that the parachute was deployed
+    assert flight.t is not None
+    
+    # Check that parachute deployment happened
+    assert hasattr(flight, "parachute_cd_s")
+    
+    # The parachute should deploy after motor burnout + delay
+    # Expected deployment at burnout_time + 3s + lag
+    expected_deploy_time = motor_burnout + 3.0 + 1.5
+    
+    # Verify simulation completed successfully and parachute deployed after burnout
+    assert flight.apogee_time > 0
+    # The simulation should run past the expected deployment time
+    assert flight.t_final >= expected_deploy_time
+
+
+@pytest.mark.slow
+def test_flight_with_multiple_time_based_parachutes(
+    example_spaceport_env, calisto_motorless, cesaroni_m1670
+):
+    """Test a flight with multiple time-based parachutes (drogue and main).
+    
+    This simulates a dual-deployment system using time-based triggers.
+    """
+    # Use existing rocket and add motor
+    rocket = calisto_motorless
+    rocket.add_motor(cesaroni_m1670, position=-1.373)
+    
+    # Add drogue parachute - deploys at burnout + 2 seconds
+    rocket.add_parachute(
+        name="Drogue",
+        cd_s=1.0,
+        trigger="burnout + 2",
+        sampling_rate=100,
+        lag=0.5,
+        noise=(0, 8.3, 0.5),
+    )
+    
+    # Add main parachute - deploys at burnout + 10 seconds
+    rocket.add_parachute(
+        name="Main",
+        cd_s=10.0,
+        trigger="burnout + 10",
+        sampling_rate=100,
+        lag=1.0,
+        noise=(0, 8.3, 0.5),
+    )
+    
+    # Run flight simulation
+    flight = Flight(
+        environment=example_spaceport_env,
+        rocket=rocket,
+        rail_length=5.2,
+        inclination=85,
+        heading=0,
+        terminate_on_apogee=False,
+    )
+    
+    # Verify simulation completed successfully
+    assert flight.t is not None
+    assert flight.apogee_time > 0
+    
+    # Check that parachute deployment happened
+    assert hasattr(flight, "parachute_cd_s")
+
+
+@pytest.mark.slow
+def test_flight_with_mixed_trigger_types(
+    example_spaceport_env, calisto_motorless, cesaroni_m1670
+):
+    """Test a flight with both time-based and traditional parachute triggers.
+    
+    This ensures backward compatibility when mixing trigger types.
+    """
+    # Use existing rocket and add motor
+    rocket = calisto_motorless
+    rocket.add_motor(cesaroni_m1670, position=-1.373)
+    
+    # Add drogue parachute with traditional apogee trigger
+    rocket.add_parachute(
+        name="Drogue",
+        cd_s=1.0,
+        trigger="apogee",
+        sampling_rate=100,
+        lag=0.5,
+        noise=(0, 8.3, 0.5),
+    )
+    
+    # Add main parachute with altitude trigger
+    rocket.add_parachute(
+        name="Main",
+        cd_s=10.0,
+        trigger=800.0,  # 800 meters AGL
+        sampling_rate=100,
+        lag=1.0,
+        noise=(0, 8.3, 0.5),
+    )
+    
+    # Run flight simulation
+    flight = Flight(
+        environment=example_spaceport_env,
+        rocket=rocket,
+        rail_length=5.2,
+        inclination=85,
+        heading=0,
+        terminate_on_apogee=False,
+    )
+    
+    # Verify simulation completed successfully
+    assert flight.t is not None
+    assert flight.apogee_time > 0
+    
+    # Check that parachute deployment happened
+    assert hasattr(flight, "parachute_cd_s")

--- a/tests/unit/rocket/test_parachute.py
+++ b/tests/unit/rocket/test_parachute.py
@@ -17,14 +17,18 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         # Test trigger function with descending velocity (should trigger)
         state_descending = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
-        assert parachute.triggerfunc(101325, 1000, state_descending, [], 5.0, None) is True
-        
+        assert (
+            parachute.triggerfunc(101325, 1000, state_descending, [], 5.0, None) is True
+        )
+
         # Test trigger function with ascending velocity (should not trigger)
         state_ascending = [0, 0, 1000, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0]
-        assert parachute.triggerfunc(101325, 1000, state_ascending, [], 3.0, None) is False
+        assert (
+            parachute.triggerfunc(101325, 1000, state_ascending, [], 3.0, None) is False
+        )
 
     def test_altitude_trigger(self):
         """Test that altitude-based trigger works correctly."""
@@ -35,18 +39,20 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         # Test at altitude above trigger point with descending velocity (should not trigger)
         state_above = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
         assert parachute.triggerfunc(101325, 600, state_above, [], 10.0, None) is False
-        
+
         # Test at altitude below trigger point with descending velocity (should trigger)
         state_below = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
         assert parachute.triggerfunc(101325, 400, state_below, [], 15.0, None) is True
-        
+
         # Test at altitude below trigger point with ascending velocity (should not trigger)
         state_ascending = [0, 0, 1000, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0]
-        assert parachute.triggerfunc(101325, 400, state_ascending, [], 2.0, None) is False
+        assert (
+            parachute.triggerfunc(101325, 400, state_ascending, [], 2.0, None) is False
+        )
 
     def test_launch_plus_delay_trigger_parsing(self):
         """Test that 'launch + X' trigger string is correctly parsed."""
@@ -57,7 +63,7 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         # Check that the parachute was created successfully
         assert parachute.name == "test_launch_delay"
         assert parachute.trigger == "launch + 5"
@@ -72,15 +78,15 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
-        
+
         # Before delay time - should not trigger
         assert parachute.triggerfunc(101325, 1000, state, [], 3.0, None) is False
-        
+
         # Exactly at delay time - should trigger
         assert parachute.triggerfunc(101325, 1000, state, [], 5.0, None) is True
-        
+
         # After delay time - should trigger
         assert parachute.triggerfunc(101325, 1000, state, [], 7.0, None) is True
 
@@ -93,22 +99,23 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         # Check that the parachute was created successfully
         assert parachute.name == "test_burnout_delay"
         assert parachute.trigger == "burnout + 3.5"
 
     def test_burnout_plus_delay_trigger_functionality(self):
         """Test that 'burnout + X' trigger works correctly."""
+
         # Create a mock rocket with motor
         class MockMotor:
             def __init__(self, burn_out_time):
                 self.burn_out_time = burn_out_time
-        
+
         class MockRocket:
             def __init__(self, burn_out_time):
                 self.motor = MockMotor(burn_out_time)
-        
+
         delay = 3.5
         burnout_time = 2.0
         parachute = Parachute(
@@ -118,16 +125,16 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         rocket = MockRocket(burnout_time)
         state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
-        
+
         # Before burnout + delay - should not trigger
         assert parachute.triggerfunc(101325, 1000, state, [], 4.0, rocket) is False
-        
+
         # Exactly at burnout + delay - should trigger
         assert parachute.triggerfunc(101325, 1000, state, [], 5.5, rocket) is True
-        
+
         # After burnout + delay - should trigger
         assert parachute.triggerfunc(101325, 1000, state, [], 10.0, rocket) is True
 
@@ -140,7 +147,7 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         parachute2 = Parachute(
             name="test2",
             cd_s=1.0,
@@ -148,7 +155,7 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         parachute3 = Parachute(
             name="test3",
             cd_s=1.0,
@@ -156,9 +163,9 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
-        
+
         # All should behave the same way
         assert parachute1.triggerfunc(101325, 1000, state, [], 6.0, None) is True
         assert parachute2.triggerfunc(101325, 1000, state, [], 6.0, None) is True
@@ -175,7 +182,7 @@ class TestParachuteTriggers:
                 sampling_rate=100,
                 lag=0,
             )
-        
+
         # Invalid event name
         with pytest.raises(ValueError, match="Invalid time-based trigger event"):
             Parachute(
@@ -185,7 +192,7 @@ class TestParachuteTriggers:
                 sampling_rate=100,
                 lag=0,
             )
-        
+
         # Invalid delay value (not a number)
         with pytest.raises(ValueError, match="Invalid delay value"):
             Parachute(
@@ -195,7 +202,7 @@ class TestParachuteTriggers:
                 sampling_rate=100,
                 lag=0,
             )
-        
+
         # Invalid format (multiple '+')
         with pytest.raises(ValueError, match="Invalid time-based trigger format"):
             Parachute(
@@ -215,22 +222,23 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
-        
+
         # Just before delay - should not trigger
         assert parachute.triggerfunc(101325, 1000, state, [], 2.74, None) is False
-        
+
         # At and after delay - should trigger
         assert parachute.triggerfunc(101325, 1000, state, [], 2.75, None) is True
         assert parachute.triggerfunc(101325, 1000, state, [], 3.0, None) is True
 
     def test_custom_callable_trigger_backward_compatibility(self):
         """Test that custom callable triggers still work with backward compatibility."""
+
         # 3-parameter trigger (old style)
         def old_trigger(p, h, y):
             return y[5] < 0 and h < 800
-        
+
         parachute_old = Parachute(
             name="test_old",
             cd_s=1.0,
@@ -238,11 +246,11 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         # 4-parameter trigger (with sensors)
         def new_trigger(p, h, y, sensors):
             return y[5] < 0 and h < 800
-        
+
         parachute_new = Parachute(
             name="test_new",
             cd_s=1.0,
@@ -250,13 +258,13 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
-        
+
         # Both should work with the new 6-parameter signature
         assert parachute_old.triggerfunc(101325, 700, state, [], 10.0, None) is True
         assert parachute_new.triggerfunc(101325, 700, state, [], 10.0, None) is True
-        
+
         # Should not trigger above altitude
         assert parachute_old.triggerfunc(101325, 900, state, [], 10.0, None) is False
         assert parachute_new.triggerfunc(101325, 900, state, [], 10.0, None) is False
@@ -270,11 +278,11 @@ class TestParachuteTriggers:
             sampling_rate=100,
             lag=0,
         )
-        
+
         state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
-        
+
         # Should trigger immediately at t=0
         assert parachute.triggerfunc(101325, 1000, state, [], 0.0, None) is True
-        
+
         # Should also trigger at any positive time
         assert parachute.triggerfunc(101325, 1000, state, [], 0.1, None) is True

--- a/tests/unit/rocket/test_parachute.py
+++ b/tests/unit/rocket/test_parachute.py
@@ -1,0 +1,280 @@
+"""Unit tests for the Parachute class, specifically focusing on trigger mechanisms."""
+
+import pytest
+
+from rocketpy import Parachute
+
+
+class TestParachuteTriggers:
+    """Test class for parachute trigger functionality."""
+
+    def test_apogee_trigger(self):
+        """Test that the 'apogee' trigger is correctly parsed and works."""
+        parachute = Parachute(
+            name="test_apogee",
+            cd_s=1.0,
+            trigger="apogee",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        # Test trigger function with descending velocity (should trigger)
+        state_descending = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
+        assert parachute.triggerfunc(101325, 1000, state_descending, [], 5.0, None) is True
+        
+        # Test trigger function with ascending velocity (should not trigger)
+        state_ascending = [0, 0, 1000, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0]
+        assert parachute.triggerfunc(101325, 1000, state_ascending, [], 3.0, None) is False
+
+    def test_altitude_trigger(self):
+        """Test that altitude-based trigger works correctly."""
+        parachute = Parachute(
+            name="test_altitude",
+            cd_s=1.0,
+            trigger=500.0,  # 500 meters
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        # Test at altitude above trigger point with descending velocity (should not trigger)
+        state_above = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
+        assert parachute.triggerfunc(101325, 600, state_above, [], 10.0, None) is False
+        
+        # Test at altitude below trigger point with descending velocity (should trigger)
+        state_below = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
+        assert parachute.triggerfunc(101325, 400, state_below, [], 15.0, None) is True
+        
+        # Test at altitude below trigger point with ascending velocity (should not trigger)
+        state_ascending = [0, 0, 1000, 0, 0, 10, 1, 0, 0, 0, 0, 0, 0]
+        assert parachute.triggerfunc(101325, 400, state_ascending, [], 2.0, None) is False
+
+    def test_launch_plus_delay_trigger_parsing(self):
+        """Test that 'launch + X' trigger string is correctly parsed."""
+        parachute = Parachute(
+            name="test_launch_delay",
+            cd_s=1.0,
+            trigger="launch + 5",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        # Check that the parachute was created successfully
+        assert parachute.name == "test_launch_delay"
+        assert parachute.trigger == "launch + 5"
+
+    def test_launch_plus_delay_trigger_functionality(self):
+        """Test that 'launch + X' trigger works correctly."""
+        delay = 5.0
+        parachute = Parachute(
+            name="test_launch_delay",
+            cd_s=1.0,
+            trigger=f"launch + {delay}",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
+        
+        # Before delay time - should not trigger
+        assert parachute.triggerfunc(101325, 1000, state, [], 3.0, None) is False
+        
+        # Exactly at delay time - should trigger
+        assert parachute.triggerfunc(101325, 1000, state, [], 5.0, None) is True
+        
+        # After delay time - should trigger
+        assert parachute.triggerfunc(101325, 1000, state, [], 7.0, None) is True
+
+    def test_burnout_plus_delay_trigger_parsing(self):
+        """Test that 'burnout + X' trigger string is correctly parsed."""
+        parachute = Parachute(
+            name="test_burnout_delay",
+            cd_s=1.0,
+            trigger="burnout + 3.5",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        # Check that the parachute was created successfully
+        assert parachute.name == "test_burnout_delay"
+        assert parachute.trigger == "burnout + 3.5"
+
+    def test_burnout_plus_delay_trigger_functionality(self):
+        """Test that 'burnout + X' trigger works correctly."""
+        # Create a mock rocket with motor
+        class MockMotor:
+            def __init__(self, burn_out_time):
+                self.burn_out_time = burn_out_time
+        
+        class MockRocket:
+            def __init__(self, burn_out_time):
+                self.motor = MockMotor(burn_out_time)
+        
+        delay = 3.5
+        burnout_time = 2.0
+        parachute = Parachute(
+            name="test_burnout_delay",
+            cd_s=1.0,
+            trigger=f"burnout + {delay}",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        rocket = MockRocket(burnout_time)
+        state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
+        
+        # Before burnout + delay - should not trigger
+        assert parachute.triggerfunc(101325, 1000, state, [], 4.0, rocket) is False
+        
+        # Exactly at burnout + delay - should trigger
+        assert parachute.triggerfunc(101325, 1000, state, [], 5.5, rocket) is True
+        
+        # After burnout + delay - should trigger
+        assert parachute.triggerfunc(101325, 1000, state, [], 10.0, rocket) is True
+
+    def test_launch_trigger_with_whitespace(self):
+        """Test that whitespace in trigger string is handled correctly."""
+        parachute1 = Parachute(
+            name="test1",
+            cd_s=1.0,
+            trigger="launch + 5",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        parachute2 = Parachute(
+            name="test2",
+            cd_s=1.0,
+            trigger="  launch  +  5  ",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        parachute3 = Parachute(
+            name="test3",
+            cd_s=1.0,
+            trigger="LAUNCH + 5",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
+        
+        # All should behave the same way
+        assert parachute1.triggerfunc(101325, 1000, state, [], 6.0, None) is True
+        assert parachute2.triggerfunc(101325, 1000, state, [], 6.0, None) is True
+        assert parachute3.triggerfunc(101325, 1000, state, [], 6.0, None) is True
+
+    def test_invalid_trigger_format(self):
+        """Test that invalid trigger formats raise appropriate errors."""
+        # Invalid string without '+'
+        with pytest.raises(ValueError, match="Unable to set the trigger function"):
+            Parachute(
+                name="test",
+                cd_s=1.0,
+                trigger="invalid_trigger",
+                sampling_rate=100,
+                lag=0,
+            )
+        
+        # Invalid event name
+        with pytest.raises(ValueError, match="Invalid time-based trigger event"):
+            Parachute(
+                name="test",
+                cd_s=1.0,
+                trigger="invalid_event + 5",
+                sampling_rate=100,
+                lag=0,
+            )
+        
+        # Invalid delay value (not a number)
+        with pytest.raises(ValueError, match="Invalid delay value"):
+            Parachute(
+                name="test",
+                cd_s=1.0,
+                trigger="launch + not_a_number",
+                sampling_rate=100,
+                lag=0,
+            )
+        
+        # Invalid format (multiple '+')
+        with pytest.raises(ValueError, match="Invalid time-based trigger format"):
+            Parachute(
+                name="test",
+                cd_s=1.0,
+                trigger="launch + 5 + 3",
+                sampling_rate=100,
+                lag=0,
+            )
+
+    def test_decimal_delay_values(self):
+        """Test that decimal delay values work correctly."""
+        parachute = Parachute(
+            name="test_decimal",
+            cd_s=1.0,
+            trigger="launch + 2.75",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
+        
+        # Just before delay - should not trigger
+        assert parachute.triggerfunc(101325, 1000, state, [], 2.74, None) is False
+        
+        # At and after delay - should trigger
+        assert parachute.triggerfunc(101325, 1000, state, [], 2.75, None) is True
+        assert parachute.triggerfunc(101325, 1000, state, [], 3.0, None) is True
+
+    def test_custom_callable_trigger_backward_compatibility(self):
+        """Test that custom callable triggers still work with backward compatibility."""
+        # 3-parameter trigger (old style)
+        def old_trigger(p, h, y):
+            return y[5] < 0 and h < 800
+        
+        parachute_old = Parachute(
+            name="test_old",
+            cd_s=1.0,
+            trigger=old_trigger,
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        # 4-parameter trigger (with sensors)
+        def new_trigger(p, h, y, sensors):
+            return y[5] < 0 and h < 800
+        
+        parachute_new = Parachute(
+            name="test_new",
+            cd_s=1.0,
+            trigger=new_trigger,
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
+        
+        # Both should work with the new 6-parameter signature
+        assert parachute_old.triggerfunc(101325, 700, state, [], 10.0, None) is True
+        assert parachute_new.triggerfunc(101325, 700, state, [], 10.0, None) is True
+        
+        # Should not trigger above altitude
+        assert parachute_old.triggerfunc(101325, 900, state, [], 10.0, None) is False
+        assert parachute_new.triggerfunc(101325, 900, state, [], 10.0, None) is False
+
+    def test_zero_delay_trigger(self):
+        """Test that zero delay triggers work correctly."""
+        parachute = Parachute(
+            name="test_zero",
+            cd_s=1.0,
+            trigger="launch + 0",
+            sampling_rate=100,
+            lag=0,
+        )
+        
+        state = [0, 0, 1000, 0, 0, -10, 1, 0, 0, 0, 0, 0, 0]
+        
+        # Should trigger immediately at t=0
+        assert parachute.triggerfunc(101325, 1000, state, [], 0.0, None) is True
+        
+        # Should also trigger at any positive time
+        assert parachute.triggerfunc(101325, 1000, state, [], 0.1, None) is True


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code changes (bugfix, features)
- [x] Code maintenance (refactoring, formatting, tests)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
RocketPy cannot simulate rockets with motor delay charges (fixed-time deployment) like model rocket motors or high-power motors without avionics. Users must resort to workarounds or cannot accurately simulate kits like Loc-IV powered by Aerotech motors with delay elements. https://github.com/RocketPy-Team/RocketPy/issues/437

## New behavior
<!-- Describe changes introduced by this PR. -->


Parachute triggers now accept time-based string formats:
- `"launch + X"` - deploys X seconds after t=0
- `"burnout + X"` - deploys X seconds after motor burnout

**Implementation:**
- Extended `Parachute.__evaluate_trigger_function()` to parse time-based triggers
- Added `t` (current time) and `rocket` (motor access) parameters to trigger function signature
- Maintained backward compatibility via parameter count detection (existing pattern)
- Updated all four call sites in `Flight` class to pass additional parameters (two original + two new)

**Example usage:**
```python
# Model rocket with 3-second motor delay (like Estes C6-3)
rocket.add_parachute(
    name="Main",
    cd_s=10.0,
    trigger="burnout + 3",
    sampling_rate=100,
    lag=1.5,
)

# Simple timer deployment 5 seconds after launch
rocket.add_parachute(
    name="Drogue",
    cd_s=1.0,
    trigger="launch + 5",
    sampling_rate=100,
    lag=0.5,
)
```
**Testing:**
- 11 unit tests covering parsing, functionality, edge cases, backward compatibility
- 4 integration tests with full flight simulations with time-based triggers

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

Existing trigger types (callable, float altitude, "apogee") remain unchanged. The trigger function signature extension uses optional parameters with defaults, ensuring zero-impact to existing code