### PR TITLE
ENH: Monte Carlo Formatting Options (#945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Attention: The newest changes should be on top -->
 
 ### Added
 
+- ENH: Monte Carlo Formatting Options [#947](https://github.com/RocketPy-Team/RocketPy/pull/947)
 - ENH: ENH: Auto-Detection of Pressure Conversion Factor [#966](https://github.com/RocketPy-Team/RocketPy/pull/966)
 - ENH: Auto-Detection of Pressure Conversion Factor [#966](https://github.com/RocketPy-Team/RocketPy/pull/966)
 - ENH: MNT: introduce pressure unit conversion when using forecast/reanalysis/ensemble data [#955](https://github.com/RocketPy-Team/RocketPy/pull/955)

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -13,6 +13,7 @@ change in future versions. Users are encouraged to check for updates and read th
 latest documentation.
 """
 
+import csv
 import json
 import os
 import traceback

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -875,6 +875,182 @@ class MonteCarlo:
         self._error_file = value
         self.set_errors_log()
 
+    # File format helpers
+
+    @staticmethod
+    def _detect_file_format(filepath):
+        """Detect file format from the file extension.
+
+        Parameters
+        ----------
+        filepath : str or Path
+            Path to the file.
+
+        Returns
+        -------
+        str
+            One of ``"jsonl"``, ``"csv"``, or ``"json"``.
+
+        Raises
+        ------
+        ValueError
+            If the file extension is not supported.
+        """
+        suffix = Path(filepath).suffix.lower()
+        format_map = {".txt": "jsonl", ".csv": "csv", ".json": "json"}
+        if suffix not in format_map:
+            raise ValueError(
+                f"Unsupported file extension '{suffix}'. "
+                "Expected '.txt', '.csv', or '.json'."
+            )
+        return format_map[suffix]
+
+    @staticmethod
+    def _parse_csv_value(value):
+        """Parse a string value from a CSV cell into its appropriate type.
+
+        Parameters
+        ----------
+        value : str
+            The raw string value from the CSV cell.
+
+        Returns
+        -------
+        int, float, dict, list, or str
+            The parsed value in its appropriate Python type.
+        """
+        if value == "":
+            return value
+        # Try parsing JSON objects/arrays
+        if value.startswith(("{", "[")):
+            try:
+                return json.loads(value)
+            except (json.JSONDecodeError, ValueError):
+                pass
+        # Try numeric types
+        try:
+            int_val = int(value)
+            # Ensure the string was truly an integer (not "1.0")
+            if str(int_val) == value:
+                return int_val
+        except ValueError:
+            pass
+        try:
+            return float(value)
+        except ValueError:
+            pass
+        return value
+
+    def _read_log_file(self, filepath):
+        """Read a log file in any supported format and return a list of dicts.
+
+        Parameters
+        ----------
+        filepath : str or Path
+            Path to the log file. Format is detected from the extension.
+
+        Returns
+        -------
+        list of dict
+            A list of dictionaries, one per simulation record.
+        """
+        fmt = self._detect_file_format(filepath)
+        result = []
+        with open(filepath, mode="r", encoding="utf-8") as f:
+            if fmt == "jsonl":
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        result.append(json.loads(line))
+            elif fmt == "json":
+                content = f.read().strip()
+                if content:
+                    result = json.load(open(filepath, encoding="utf-8"))
+            elif fmt == "csv":
+                reader = csv.DictReader(f)
+                for row in reader:
+                    result.append(
+                        {k: self._parse_csv_value(v) for k, v in row.items()}
+                    )
+        return result
+
+    @staticmethod
+    def _write_log_to_csv(log_data, filepath, flatten=False):
+        """Write a list of dicts to a CSV file.
+
+        Parameters
+        ----------
+        log_data : list of dict
+            The data to write. Each dict is one row.
+        filepath : str or Path
+            Output file path.
+        flatten : bool, optional
+            If True, non-scalar columns (dicts, lists) are omitted.
+            If False (default), non-scalar values are serialized as JSON
+            strings in the CSV cells.
+
+        Raises
+        ------
+        ValueError
+            If ``log_data`` is empty.
+        """
+        if not log_data:
+            raise ValueError(
+                "No data to export. Run a simulation first or import "
+                "existing data."
+            )
+        # Collect all keys preserving insertion order
+        all_keys = list(dict.fromkeys(k for row in log_data for k in row))
+
+        if flatten:
+            # Identify scalar-only keys
+            scalar_keys = []
+            for key in all_keys:
+                if all(
+                    not isinstance(row.get(key), (dict, list))
+                    for row in log_data
+                ):
+                    scalar_keys.append(key)
+            fieldnames = scalar_keys
+        else:
+            fieldnames = all_keys
+
+        with open(filepath, mode="w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for row in log_data:
+                csv_row = {}
+                for key in fieldnames:
+                    value = row.get(key, "")
+                    if isinstance(value, (dict, list)):
+                        csv_row[key] = json.dumps(value)
+                    else:
+                        csv_row[key] = value
+                writer.writerow(csv_row)
+
+    def _write_log_to_json(self, log_data, filepath):
+        """Write a list of dicts to a JSON file as a proper JSON array.
+
+        Parameters
+        ----------
+        log_data : list of dict
+            The data to write. Each dict becomes one element of the array.
+        filepath : str or Path
+            Output file path.
+
+        Raises
+        ------
+        ValueError
+            If ``log_data`` is empty.
+        """
+        if not log_data:
+            raise ValueError(
+                "No data to export. Run a simulation first or import "
+                "existing data."
+            )
+        with open(filepath, mode="w", encoding="utf-8") as f:
+            json.dump(log_data, f, cls=RocketPyEncoder, indent=2)
+
     # Setters for post simulation attributes
 
     def set_inputs_log(self):

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -969,9 +969,7 @@ class MonteCarlo:
             elif fmt == "csv":
                 reader = csv.DictReader(f)
                 for row in reader:
-                    result.append(
-                        {k: self._parse_csv_value(v) for k, v in row.items()}
-                    )
+                    result.append({k: self._parse_csv_value(v) for k, v in row.items()})
         return result
 
     @staticmethod
@@ -996,8 +994,7 @@ class MonteCarlo:
         """
         if not log_data:
             raise ValueError(
-                "No data to export. Run a simulation first or import "
-                "existing data."
+                "No data to export. Run a simulation first or import existing data."
             )
         # Collect all keys preserving insertion order
         all_keys = list(dict.fromkeys(k for row in log_data for k in row))
@@ -1006,10 +1003,7 @@ class MonteCarlo:
             # Identify scalar-only keys
             scalar_keys = []
             for key in all_keys:
-                if all(
-                    not isinstance(row.get(key), (dict, list))
-                    for row in log_data
-                ):
+                if all(not isinstance(row.get(key), (dict, list)) for row in log_data):
                     scalar_keys.append(key)
             fieldnames = scalar_keys
         else:
@@ -1045,8 +1039,7 @@ class MonteCarlo:
         """
         if not log_data:
             raise ValueError(
-                "No data to export. Run a simulation first or import "
-                "existing data."
+                "No data to export. Run a simulation first or import existing data."
             )
         with open(filepath, mode="w", encoding="utf-8") as f:
             json.dump(log_data, f, cls=RocketPyEncoder, indent=2)

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -1089,14 +1089,25 @@ class MonteCarlo:
     def set_num_of_loaded_sims(self):
         """
         Determines the number of simulations loaded from output_file being
-        currently used.
+        currently used. Supports .txt (JSONL), .csv, and .json formats.
 
         Returns
         -------
         None
         """
+        fmt = self._detect_file_format(self.output_file)
         with open(self.output_file, mode="r", encoding="utf-8") as outputs:
-            self.num_of_loaded_sims = sum(1 for _ in outputs)
+            if fmt == "jsonl":
+                self.num_of_loaded_sims = sum(1 for _ in outputs)
+            elif fmt == "csv":
+                # Subtract 1 for the header row
+                self.num_of_loaded_sims = max(0, sum(1 for _ in outputs) - 1)
+            elif fmt == "json":
+                content = outputs.read().strip()
+                if content:
+                    self.num_of_loaded_sims = len(json.loads(content))
+                else:
+                    self.num_of_loaded_sims = 0
 
     def set_results(self):
         """

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -1056,41 +1056,35 @@ class MonteCarlo:
     def set_inputs_log(self):
         """
         Sets inputs_log from a file into an attribute for easy access.
+        Supports .txt (JSONL), .csv, and .json file formats.
 
         Returns
         -------
         None
         """
-        self.inputs_log = []
-        with open(self.input_file, mode="r", encoding="utf-8") as rows:
-            for line in rows:
-                self.inputs_log.append(json.loads(line))
+        self.inputs_log = self._read_log_file(self.input_file)
 
     def set_outputs_log(self):
         """
         Sets outputs_log from a file into an attribute for easy access.
+        Supports .txt (JSONL), .csv, and .json file formats.
 
         Returns
         -------
         None
         """
-        self.outputs_log = []
-        with open(self.output_file, mode="r", encoding="utf-8") as rows:
-            for line in rows:
-                self.outputs_log.append(json.loads(line))
+        self.outputs_log = self._read_log_file(self.output_file)
 
     def set_errors_log(self):
         """
         Sets errors_log from a file into an attribute for easy access.
+        Supports .txt (JSONL), .csv, and .json file formats.
 
         Returns
         -------
         None
         """
-        self.errors_log = []
-        with open(self.error_file, mode="r", encoding="utf-8") as errors:
-            for line in errors:
-                self.errors_log.append(json.loads(line))
+        self.errors_log = self._read_log_file(self.error_file)
 
     def set_num_of_loaded_sims(self):
         """

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -38,7 +38,7 @@ from rocketpy.tools import (
 # TODO: Create evolution plots to analyze convergence
 
 
-class MonteCarlo:
+class MonteCarlo:  # pylint: disable=too-many-public-methods
     """Class to run a Monte Carlo simulation of a rocket flight.
 
     Attributes
@@ -965,7 +965,7 @@ class MonteCarlo:
             elif fmt == "json":
                 content = f.read().strip()
                 if content:
-                    result = json.load(open(filepath, encoding="utf-8"))
+                    result = json.loads(content)
             elif fmt == "csv":
                 reader = csv.DictReader(f)
                 for row in reader:

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -1469,6 +1469,109 @@ class MonteCarlo:
         """
         self.plots.ellipses_comparison(other_monte_carlo, **kwargs)
 
+    # CSV and JSON export methods
+
+    def export_outputs_to_csv(self, filename):
+        """Export simulation outputs to a CSV file.
+
+        Each row represents one simulation. All output values are scalar,
+        so the CSV is directly usable in spreadsheet applications.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the output CSV file.
+
+        Raises
+        ------
+        ValueError
+            If no output data is available to export.
+        """
+        self._write_log_to_csv(self.outputs_log, filename)
+
+    def export_outputs_to_json(self, filename):
+        """Export simulation outputs to a JSON file as an array of objects.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the output JSON file.
+
+        Raises
+        ------
+        ValueError
+            If no output data is available to export.
+        """
+        self._write_log_to_json(self.outputs_log, filename)
+
+    def export_inputs_to_csv(self, filename, flatten=False):
+        """Export simulation inputs to a CSV file.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the output CSV file.
+        flatten : bool, optional
+            If True, columns with non-scalar values (dicts, lists) are
+            omitted from the CSV. If False (default), non-scalar values
+            are serialized as JSON strings within the CSV cells.
+
+        Raises
+        ------
+        ValueError
+            If no input data is available to export.
+        """
+        self._write_log_to_csv(self.inputs_log, filename, flatten=flatten)
+
+    def export_inputs_to_json(self, filename):
+        """Export simulation inputs to a JSON file as an array of objects.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the output JSON file.
+
+        Raises
+        ------
+        ValueError
+            If no input data is available to export.
+        """
+        self._write_log_to_json(self.inputs_log, filename)
+
+    def export_errors_to_csv(self, filename, flatten=False):
+        """Export simulation errors to a CSV file.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the output CSV file.
+        flatten : bool, optional
+            If True, columns with non-scalar values (dicts, lists) are
+            omitted from the CSV. If False (default), non-scalar values
+            are serialized as JSON strings within the CSV cells.
+
+        Raises
+        ------
+        ValueError
+            If no error data is available to export.
+        """
+        self._write_log_to_csv(self.errors_log, filename, flatten=flatten)
+
+    def export_errors_to_json(self, filename):
+        """Export simulation errors to a JSON file as an array of objects.
+
+        Parameters
+        ----------
+        filename : str
+            Path to the output JSON file.
+
+        Raises
+        ------
+        ValueError
+            If no error data is available to export.
+        """
+        self._write_log_to_json(self.errors_log, filename)
+
 
 def _import_multiprocess():
     """Import the necessary modules and submodules for the

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -1164,13 +1164,15 @@ class MonteCarlo:
 
     def import_outputs(self, filename=None):
         """
-        Import Monte Carlo results from .txt file and save it into a dictionary.
+        Import Monte Carlo results from a file and save it into a dictionary.
+        Supports .txt (JSONL), .csv, and .json file formats.
 
         Parameters
         ----------
         filename : str, optional
             Name or directory path to the file to be imported. If none,
-            self.filename will be used.
+            self.filename will be used with the default .outputs.txt suffix.
+            Files with .csv or .json extensions are also accepted.
 
         Returns
         -------
@@ -1178,7 +1180,7 @@ class MonteCarlo:
 
         Notes
         -----
-        Notice that you can import the outputs, inputs, and errors from the a
+        Notice that you can import the outputs, inputs, and errors from a
         file without the need to run simulations. You can use previously saved
         files to process analyze the results or to continue a simulation.
         """
@@ -1198,13 +1200,15 @@ class MonteCarlo:
 
     def import_inputs(self, filename=None):
         """
-        Import Monte Carlo inputs from .txt file and save it into a dictionary.
+        Import Monte Carlo inputs from a file and save it into a dictionary.
+        Supports .txt (JSONL), .csv, and .json file formats.
 
         Parameters
         ----------
         filename : str, optional
             Name or directory path to the file to be imported. If none,
-            self.filename will be used.
+            self.filename will be used with the default .inputs.txt suffix.
+            Files with .csv or .json extensions are also accepted.
 
         Returns
         -------
@@ -1223,13 +1227,15 @@ class MonteCarlo:
 
     def import_errors(self, filename=None):
         """
-        Import Monte Carlo errors from .txt file and save it into a dictionary.
+        Import Monte Carlo errors from a file and save it into a dictionary.
+        Supports .txt (JSONL), .csv, and .json file formats.
 
         Parameters
         ----------
         filename : str, optional
             Name or directory path to the file to be imported. If none,
-            self.filename will be used.
+            self.filename will be used with the default .errors.txt suffix.
+            Files with .csv or .json extensions are also accepted.
 
         Returns
         -------
@@ -1248,7 +1254,7 @@ class MonteCarlo:
 
     def import_results(self, filename=None):
         """
-        Import Monte Carlo results from .txt file and save it into a dictionary.
+        Import Monte Carlo results from a file and save it into a dictionary.
 
         Parameters
         ----------

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -204,9 +204,24 @@ class MockMonteCarloWithLogs(MonteCarlo):
             {"apogee": 4500.00, "x_impact": 480.10, "index": 2},
         ]
         self.inputs_log = [
-            {"elevation": 1413.6, "radius": 0.0635, "parachutes": [{"cd_s": 9.84}], "index": 0},
-            {"elevation": 1400.0, "radius": 0.0640, "parachutes": [{"cd_s": 10.0}], "index": 1},
-            {"elevation": 1420.0, "radius": 0.0630, "parachutes": [{"cd_s": 9.50}], "index": 2},
+            {
+                "elevation": 1413.6,
+                "radius": 0.0635,
+                "parachutes": [{"cd_s": 9.84}],
+                "index": 0,
+            },
+            {
+                "elevation": 1400.0,
+                "radius": 0.0640,
+                "parachutes": [{"cd_s": 10.0}],
+                "index": 1,
+            },
+            {
+                "elevation": 1420.0,
+                "radius": 0.0630,
+                "parachutes": [{"cd_s": 9.50}],
+                "index": 2,
+            },
         ]
         self.errors_log = []
         self.results = {}

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -1,3 +1,6 @@
+import csv
+import json
+
 import matplotlib as plt
 import numpy as np
 import pytest
@@ -185,3 +188,223 @@ def test_estimate_confidence_interval_raises_type_error_for_invalid_statistic():
 
     with pytest.raises(TypeError):
         mc.estimate_confidence_interval("apogee", statistic="not_a_function")
+
+
+# --- CSV and JSON export/import tests ---
+
+
+class MockMonteCarloWithLogs(MonteCarlo):
+    """Mock class with populated logs for testing export/import methods."""
+
+    def __init__(self):
+        # pylint: disable=super-init-not-called
+        self.outputs_log = [
+            {"apogee": 5742.42, "x_impact": 553.49, "index": 0},
+            {"apogee": 3844.41, "x_impact": 402.31, "index": 1},
+            {"apogee": 4500.00, "x_impact": 480.10, "index": 2},
+        ]
+        self.inputs_log = [
+            {"elevation": 1413.6, "radius": 0.0635, "parachutes": [{"cd_s": 9.84}], "index": 0},
+            {"elevation": 1400.0, "radius": 0.0640, "parachutes": [{"cd_s": 10.0}], "index": 1},
+            {"elevation": 1420.0, "radius": 0.0630, "parachutes": [{"cd_s": 9.50}], "index": 2},
+        ]
+        self.errors_log = []
+        self.results = {}
+        self.processed_results = {}
+        self.num_of_loaded_sims = 3
+
+
+def test_export_outputs_to_csv(tmp_path):
+    """Tests that outputs are correctly exported to CSV."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "outputs.csv"
+
+    mc.export_outputs_to_csv(str(filepath))
+
+    with open(filepath, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert float(rows[0]["apogee"]) == pytest.approx(5742.42)
+    assert float(rows[1]["x_impact"]) == pytest.approx(402.31)
+
+
+def test_export_outputs_to_json(tmp_path):
+    """Tests that outputs are correctly exported to JSON."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "outputs.json"
+
+    mc.export_outputs_to_json(str(filepath))
+
+    with open(filepath, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert len(data) == 3
+    assert data[0]["apogee"] == pytest.approx(5742.42)
+    assert data[2]["index"] == 2
+
+
+def test_export_inputs_to_csv_no_flatten(tmp_path):
+    """Tests that inputs with nested values are serialized as JSON in CSV cells."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "inputs.csv"
+
+    mc.export_inputs_to_csv(str(filepath), flatten=False)
+
+    with open(filepath, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    # The parachutes column should contain a JSON string
+    parachutes_val = json.loads(rows[0]["parachutes"])
+    assert parachutes_val == [{"cd_s": 9.84}]
+
+
+def test_export_inputs_to_csv_flatten(tmp_path):
+    """Tests that flatten=True omits non-scalar columns."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "inputs.csv"
+
+    mc.export_inputs_to_csv(str(filepath), flatten=True)
+
+    with open(filepath, encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert "parachutes" not in rows[0]
+    assert "elevation" in rows[0]
+    assert "radius" in rows[0]
+
+
+def test_export_inputs_to_json(tmp_path):
+    """Tests that inputs are correctly exported to JSON."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "inputs.json"
+
+    mc.export_inputs_to_json(str(filepath))
+
+    with open(filepath, encoding="utf-8") as f:
+        data = json.load(f)
+
+    assert len(data) == 3
+    assert data[0]["parachutes"] == [{"cd_s": 9.84}]
+
+
+def test_export_empty_log_raises_error(tmp_path):
+    """Tests that exporting an empty log raises ValueError."""
+    mc = MockMonteCarloWithLogs()
+    mc.outputs_log = []
+
+    with pytest.raises(ValueError, match="No data to export"):
+        mc.export_outputs_to_csv(str(tmp_path / "empty.csv"))
+
+    with pytest.raises(ValueError, match="No data to export"):
+        mc.export_outputs_to_json(str(tmp_path / "empty.json"))
+
+
+def test_import_outputs_from_csv(tmp_path):
+    """Tests that outputs can be imported from a CSV file."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "outputs.csv"
+
+    # Export first
+    mc.export_outputs_to_csv(str(filepath))
+
+    # Create a fresh mock and import
+    mc2 = MockMonteCarloWithLogs()
+    mc2.output_file = str(filepath)
+
+    assert len(mc2.outputs_log) == 3
+    assert mc2.outputs_log[0]["apogee"] == pytest.approx(5742.42)
+    assert mc2.outputs_log[1]["x_impact"] == pytest.approx(402.31)
+
+
+def test_import_outputs_from_json(tmp_path):
+    """Tests that outputs can be imported from a JSON file."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "outputs.json"
+
+    # Export first
+    mc.export_outputs_to_json(str(filepath))
+
+    # Create a fresh mock and import
+    mc2 = MockMonteCarloWithLogs()
+    mc2.output_file = str(filepath)
+
+    assert len(mc2.outputs_log) == 3
+    assert mc2.outputs_log[0]["apogee"] == pytest.approx(5742.42)
+
+
+def test_round_trip_outputs_csv(tmp_path):
+    """Tests that outputs survive a CSV export/import round trip."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "outputs.csv"
+
+    mc.export_outputs_to_csv(str(filepath))
+    mc.output_file = str(filepath)
+
+    for i, original in enumerate(MockMonteCarloWithLogs().outputs_log):
+        for key, value in original.items():
+            assert mc.outputs_log[i][key] == pytest.approx(value)
+
+
+def test_round_trip_outputs_json(tmp_path):
+    """Tests that outputs survive a JSON export/import round trip."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "outputs.json"
+
+    mc.export_outputs_to_json(str(filepath))
+    mc.output_file = str(filepath)
+
+    for i, original in enumerate(MockMonteCarloWithLogs().outputs_log):
+        for key, value in original.items():
+            assert mc.outputs_log[i][key] == pytest.approx(value)
+
+
+def test_round_trip_inputs_csv(tmp_path):
+    """Tests that inputs with nested values survive a CSV round trip."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "inputs.csv"
+
+    mc.export_inputs_to_csv(str(filepath), flatten=False)
+    mc.input_file = str(filepath)
+
+    assert mc.inputs_log[0]["parachutes"] == [{"cd_s": 9.84}]
+    assert mc.inputs_log[0]["elevation"] == pytest.approx(1413.6)
+
+
+def test_detect_file_format_unsupported():
+    """Tests that unsupported file extensions raise ValueError."""
+    mc = MockMonteCarloWithLogs()
+
+    with pytest.raises(ValueError, match="Unsupported file extension"):
+        mc._detect_file_format("data.xlsx")
+
+    with pytest.raises(ValueError, match="Unsupported file extension"):
+        mc._detect_file_format("data.parquet")
+
+
+def test_set_num_of_loaded_sims_csv(tmp_path):
+    """Tests that set_num_of_loaded_sims works with CSV files."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "outputs.csv"
+
+    mc.export_outputs_to_csv(str(filepath))
+    mc._output_file = str(filepath)
+    mc.set_num_of_loaded_sims()
+
+    assert mc.num_of_loaded_sims == 3
+
+
+def test_set_num_of_loaded_sims_json(tmp_path):
+    """Tests that set_num_of_loaded_sims works with JSON files."""
+    mc = MockMonteCarloWithLogs()
+    filepath = tmp_path / "outputs.json"
+
+    mc.export_outputs_to_json(str(filepath))
+    mc._output_file = str(filepath)
+    mc.set_num_of_loaded_sims()
+
+    assert mc.num_of_loaded_sims == 3


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code changes (bugfix, features)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Tests for the changes have been added (if needed)
- [ ] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [ ] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

The MonteCarlo class only reads and writes .txt files (JSONL format, one JSON object per line) for simulation inputs, outputs, and errors. Users who want to analyze results in Excel or other tools must manually convert these files to CSV or JSON themselves.

## New behavior
<!-- Describe changes introduced by this PR. -->

The MonteCarlo class can now directly export simulation results to CSV and JSON formats, and import previously exported CSV/JSON files back in. New methods:                                                                                                                                                                                                                                                                    
   
  - export_outputs_to_csv(filename) / export_outputs_to_json(filename)                                                                                                                                                                                                                                                                                                                                                            
  - export_inputs_to_csv(filename, flatten=False) / export_inputs_to_json(filename)
  - export_errors_to_csv(filename, flatten=False) / export_errors_to_json(filename)                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                                                                  
  The existing .txt (JSONL) format remains the default for simulation output since it supports streaming writes. CSV/JSON are post-processing export targets. The import_outputs, import_inputs, and import_errors methods also now accept .csv and .json files in addition to .txt.

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->
Related to issue #945.
