### PR TITLE
BUG: Remove duplicate controller call in Flight.__simulate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Attention: The newest changes should be on top -->
 - BUG: Duplicate _controllers in Flight.TimeNodes.merge() [#931](https://github.com/RocketPy-Team/RocketPy/pull/931)
 - BUG: Fix incorrect Jacobian in `only_radial_burn` branch of `SolidMotor.evaluate_geometry` [#935](https://github.com/RocketPy-Team/RocketPy/pull/935)
 - BUG: Add explicit timeouts to ThrustCurve API requests [#935](https://github.com/RocketPy-Team/RocketPy/pull/935)
+- BUG: Remove duplicate controller call in Flight.__simulate [#959](https://github.com/RocketPy-Team/RocketPy/issues/959)
 
 ## [v1.11.0] - 2025-11-01
 


### PR DESCRIPTION
## Pull request type
- [x] Code changes (bugfix, features)

## Checklist
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
Controllers are called twice per time node in `Flight.__simulate`. See #959.

## New behavior
Controllers are called exactly once per time node, inside 
`__process_sensors_and_controllers_at_current_node` as intended.

## Breaking change
- [x] No

## Additional information
The duplicate loop was introduced in #843 when 
`__process_sensors_and_controllers_at_current_node` was added 
for sensor and controller processing, but the original 
controller loop in `__simulate` was not removed.