### PR TITLE
ENH: Auto-Detection of Pressure Conversion Factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Attention: The newest changes should be on top -->
 
 ### Added
 
+- ENH: Auto-Detection of Pressure Conversion Factor [#966](https://github.com/RocketPy-Team/RocketPy/pull/966)
 - ENH: MNT: introduce pressure unit conversion when using forecast/reanalysis/ensemble data [#955](https://github.com/RocketPy-Team/RocketPy/pull/955)
 - ENH: Auto Populate Changelog [#919](https://github.com/RocketPy-Team/RocketPy/pull/919)
 - ENH: Adaptive Monte Carlo via Convergence Criteria [#922](https://github.com/RocketPy-Team/RocketPy/pull/922)

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -1111,7 +1111,46 @@ class Environment:
 
         return elevation
 
-    def set_atmospheric_model(  # pylint: disable=too-many-statements, too-many-branches
+    def __determine_pressure_conversion_factor(
+        self, pressure_conversion_factor, input_dict, input_file
+    ):
+        """Determine the numeric conversion factor (pressure -> Pa) based on
+        either the user's explicit input or auto-detection.
+
+        Parameters
+        ----------
+        pressure_conversion_factor : string, int, float or None
+            The user-supplied pressure conversion factor.
+        input_dict : string or None
+            The upper-case string name of the dictionary.
+        input_file : string or None
+            The upper-case string name of the file/model shortcut.
+
+        Returns
+        -------
+        conversion_factor : float, int or None
+            The numeric conversion factor to Pascal, or None if it needs to be
+            read from the file's units attribute.
+        """
+        if pressure_conversion_factor is not None:
+            # User explicitly supplied a value — honour it.
+            if isinstance(pressure_conversion_factor, str):
+                return (
+                    100 if pressure_conversion_factor.lower() in ("mbar", "hpa") else 1
+                )
+            return pressure_conversion_factor
+
+        # Auto-detect. Primary source: known-model lookup table.
+        # Fallback: units attribute inside the file.
+        _hpa_dicts = {"ECMWF", "ECMWF_V0", "ERA5", "MERRA2"}
+        _pa_files = {"GFS", "NAM", "RAP", "HRRR", "AIGFS", "HIRESW", "GEFS"}
+        if input_dict in _hpa_dicts or input_file in _hpa_dicts:
+            return 100
+        if input_file in _pa_files:
+            return 1
+        return None
+
+    def set_atmospheric_model(  # pylint: disable=too-many-statements
         self,
         type,  # pylint: disable=redefined-builtin
         file=None,
@@ -1148,33 +1187,29 @@ class Environment:
               ``netCDF4.Dataset``, or ``"GEFS"`` for the latest available
               forecast.
         dictionary : dict | str, optional
-            Variable-name mapping for ``"forecast"``, ``"reanalysis"`` and
-            ``"ensemble"``. It may be a custom dictionary or a built-in
-            mapping name (for example: ``"ECMWF"``, ``"ECMWF_v0"``,
-            ``"NOAA"``, ``"AIGFS"``, ``"GFS"``, ``"NAM"``, ``"RAP"``,
-            ``"HRRR"``, ``"HIRESW"``, ``"GEFS"``, ``"MERRA2"`` or
-            ``"CMC"``).
+            A dictionary mapping variables in the netCDF4 file to standard
+            names. Meaning depends on ``type``:
 
-            If ``dictionary`` is omitted and ``file`` is one of RocketPy's
-            latest-model shortcuts, the matching built-in mapping is selected
-            automatically. For ensemble datasets, the mapping must include the
-            ensemble dimension key (typically ``"ensemble"``).
-
+            - ``"standard_atmosphere"``, ``"custom_atmosphere"`` and
+              ``"wyoming_sounding"``: ignored.
+            - ``"windy"``: ignored.
+            - ``"forecast"``, ``"reanalysis"`` and ``"ensemble"``: local
+              dictionary, or one of the built-in mappings (e.g. ``"ECMWF"``,
+              ``"GFS"``, ``"ERA5"``, ``"RAP"``, ``"HRRR"``, etc.) corresponding
+              to the file structure.
         pressure : float, string, array, callable, optional
-            This defines the atmospheric pressure profile.
-            Should be given if the type parameter is ``custom_atmosphere``. If not,
-            than the the ``Standard Atmosphere`` pressure will be used.
-            If a float is given, it will define a constant pressure
-            profile. The float should be in units of Pa.
-            If a string is given, it should point to a `.CSV` file
-            containing at most one header line and two columns of data.
-            The first column must be the geometric height above sea level in
-            meters while the second column must be the pressure in Pa.
-            If an array is given, it is expected to be a list or array
-            of coordinates (height in meters, pressure in Pa).
-            Finally, a callable or function is also accepted. The
-            function should take one argument, the height above sea
-            level in meters and return a corresponding pressure in Pa.
+            This defines the atmospheric pressure profile. Should be given if
+            the type parameter is ``custom_atmosphere``. If not, than the the
+            ``Standard Atmosphere`` pressure will be used. If a float is given,
+            it will define a constant pressure profile. The float should be in
+            units of Pa. If a string is given, it should point to a `.CSV` file
+            containing at most one header line and two columns of data. The first
+            column must be the geometric height above sea level in meters while
+            the second column must be the pressure in Pa. If an array is given,
+            it is expected to be a list or array of coordinates (height in
+            meters, pressure in Pa). Finally, a callable or function is also
+            accepted. The function should take one argument, the height above
+            sea level in meters and return a corresponding pressure in Pa.
         temperature : float, string, array, callable, optional
             This defines the atmospheric temperature profile. Should be given
             if the type parameter is ``custom_atmosphere``. If not, than the the
@@ -1217,16 +1252,16 @@ class Environment:
             m/s). Finally, a callable or function is also accepted. The function
             should take one argument, the height above sea level in meters and
             return a corresponding wind-v in m/s.
-        pressure_conversion_factor : string, int, float
+        pressure_conversion_factor : string, int, float, optional
             This defines the pressure conversion factor to Pa when type is
             ``forecast``, ``reanalysis``, or ``ensemble``. The pressure unit
             from the data may not be in Pascal, so the correction is necessary.
             Valid strings are ``"mbar"``, ``"hPa"``, or ``"Pa"``, or a strictly
-            positive number if using a custom pressure unit. ERA5 and ECMWF
-            reanalysis ``.nc`` files store pressure in hPa; use ``"hPa"`` for
-            those. MERRA2 files and online forecast models (GFS, NAM, RAP,
-            HRRR) store pressure in Pa; the default ``"Pa"`` is correct for
-            these.
+            positive number if using a custom pressure unit. If None (the default),
+            the conversion factor will be automatically detected based on the
+            model name (e.g. ERA5/ECMWF/MERRA2 reanalysis files commonly use hPa,
+            while online GFS/NAM/RAP/HRRR forecast models use Pa) or, if
+            unavailable, by reading the pressure unit attribute from the file.
 
         Returns
         -------
@@ -1338,29 +1373,9 @@ class Environment:
                 dictionary = self.__validate_dictionary(file, dictionary)
 
                 # Determine the numeric conversion factor (pressure → Pa).
-                if pressure_conversion_factor is not None:
-                    # User explicitly supplied a value — honour it.
-                    if isinstance(pressure_conversion_factor, str):
-                        conversion_factor = (
-                            100
-                            if pressure_conversion_factor.lower() in ("mbar", "hpa")
-                            else 1
-                        )
-                    else:
-                        conversion_factor = pressure_conversion_factor
-                else:
-                    # Auto-detect.  Primary source: known-model lookup table.
-                    # Fallback: units attribute inside the file (handled inside
-                    # get_pressure_levels_from_file when conversion_factor=None).
-                    _hpa_dicts = {"ECMWF", "ECMWF_V0", "ERA5", "MERRA2"}
-                    _pa_files = {"GFS", "NAM", "RAP", "HRRR", "AIGFS", "HIRESW", "GEFS"}
-                    if _input_dict in _hpa_dicts or _input_file in _hpa_dicts:
-                        conversion_factor = 100
-                    elif _input_file in _pa_files:
-                        conversion_factor = 1
-                    else:
-                        # Unknown model or custom dict: read units from file.
-                        conversion_factor = None
+                conversion_factor = self.__determine_pressure_conversion_factor(
+                    pressure_conversion_factor, _input_dict, _input_file
+                )
 
                 try:
                     fetch_function = self.__atm_type_file_to_function_map[type][file]
@@ -1382,16 +1397,16 @@ class Environment:
                     if pressure_conversion_factor is None:
                         hint = (
                             "The unit was auto-detected from the file's pressure "
-                            "level variable, but the result is still out of range. "
+                            "level variable or model name, but the result is still out of range. "
                             "Override by passing pressure_conversion_factor explicitly "
-                            "('hPa' for ERA5/ECMWF files, 'Pa' for MERRA2 and online "
+                            "('hPa' for ERA5/ECMWF/MERRA2 files, 'Pa' for online "
                             "forecast models such as GFS, NAM, RAP, HRRR)."
                         )
                     else:
                         hint = (
                             f"pressure_conversion_factor='{pressure_conversion_factor}' "
-                            f"may be wrong. ERA5/ECMWF reanalysis files store pressure "
-                            f"in hPa — use 'hPa'. MERRA2 and online forecast models "
+                            f"may be wrong. ERA5/ECMWF/MERRA2 reanalysis files store pressure "
+                            f"in hPa — use 'hPa'. Online forecast models "
                             f"(GFS, NAM, RAP, HRRR) store pressure in Pa — use 'Pa'."
                         )
                     warnings.warn(

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -1111,7 +1111,7 @@ class Environment:
 
         return elevation
 
-    def set_atmospheric_model(  # pylint: disable=too-many-statements
+    def set_atmospheric_model(  # pylint: disable=too-many-statements, too-many-branches
         self,
         type,  # pylint: disable=redefined-builtin
         file=None,

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -1281,9 +1281,7 @@ class Environment:
                 _input_dict = (
                     dictionary.upper() if isinstance(dictionary, str) else None
                 )
-                _input_file = (
-                    file.upper() if isinstance(file, str) else None
-                )
+                _input_file = file.upper() if isinstance(file, str) else None
 
                 # Validate format of user-supplied value (if any).
                 # When None, auto-detection runs after dictionary resolution.
@@ -1380,7 +1378,7 @@ class Environment:
                     self.process_ensemble(dataset, dictionary, conversion_factor)
 
                 ground_pressure = self.pressure(self.elevation)
-                if not (30_000 <= ground_pressure <= 120_000):
+                if not 30000 <= ground_pressure <= 120_000:
                     if pressure_conversion_factor is None:
                         hint = (
                             "The unit was auto-detected from the file's pressure "

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -1120,7 +1120,7 @@ class Environment:
         temperature=None,
         wind_u=0,
         wind_v=0,
-        pressure_conversion_factor="Pa",
+        pressure_conversion_factor=None,
     ):
         """Define the atmospheric model for this Environment.
 
@@ -1219,10 +1219,14 @@ class Environment:
             return a corresponding wind-v in m/s.
         pressure_conversion_factor : string, int, float
             This defines the pressure conversion factor to Pa when type is
-            ``forecast`` or ``reanalysis``. The pressure unit from the data may
-            not be in Pascal, so the correction is necessary. Valid strings are
-            ("mbar", "hPa", "Pa"), or a strictly positive number if using a
-            custom pressure unit.
+            ``forecast``, ``reanalysis``, or ``ensemble``. The pressure unit
+            from the data may not be in Pascal, so the correction is necessary.
+            Valid strings are ``"mbar"``, ``"hPa"``, or ``"Pa"``, or a strictly
+            positive number if using a custom pressure unit. ERA5 and ECMWF
+            reanalysis ``.nc`` files store pressure in hPa; use ``"hPa"`` for
+            those. MERRA2 files and online forecast models (GFS, NAM, RAP,
+            HRRR) store pressure in Pa; the default ``"Pa"`` is correct for
+            these.
 
         Returns
         -------
@@ -1272,27 +1276,36 @@ class Environment:
             case "windy":
                 self.process_windy_atmosphere(file)
             case "forecast" | "reanalysis" | "ensemble":
-                conversion_factor = 1
-                if not isinstance(pressure_conversion_factor, (float, int, str)):
-                    raise ValueError(
-                        "Argument 'pressure_conversion_factor' must be numeric or a standard pressure unit ('mbar', 'hPa', 'Pa')!"
-                    )
-                if isinstance(pressure_conversion_factor, (float, int)):
-                    if pressure_conversion_factor <= 0:
+                # Capture the user-supplied names before __validate_dictionary
+                # converts them to dicts, so they can drive auto-detection.
+                _input_dict = (
+                    dictionary.upper() if isinstance(dictionary, str) else None
+                )
+                _input_file = (
+                    file.upper() if isinstance(file, str) else None
+                )
+
+                # Validate format of user-supplied value (if any).
+                # When None, auto-detection runs after dictionary resolution.
+                if pressure_conversion_factor is not None:
+                    if not isinstance(pressure_conversion_factor, (float, int, str)):
                         raise ValueError(
-                            "Argument 'pressure_conversion_factor' must be strictly positive!"
+                            "Argument 'pressure_conversion_factor' must be numeric or a standard pressure unit ('mbar', 'hPa', 'Pa')!"
                         )
-                    else:
-                        conversion_factor = pressure_conversion_factor
-                if isinstance(pressure_conversion_factor, str):
-                    if pressure_conversion_factor.lower() in ("mbar", "hpa"):
-                        conversion_factor = 100
-                    elif pressure_conversion_factor.lower() == "pa":
-                        conversion_factor = 1
-                    else:
-                        raise ValueError(
-                            "Argument 'pressure_conversion_factor' unit must be a standard pressure unit ('mbar', 'hPa', 'Pa')!"
-                        )
+                    if isinstance(pressure_conversion_factor, (float, int)):
+                        if pressure_conversion_factor <= 0:
+                            raise ValueError(
+                                "Argument 'pressure_conversion_factor' must be strictly positive!"
+                            )
+                    if isinstance(pressure_conversion_factor, str):
+                        if pressure_conversion_factor.lower() not in (
+                            "mbar",
+                            "hpa",
+                            "pa",
+                        ):
+                            raise ValueError(
+                                "Argument 'pressure_conversion_factor' unit must be a standard pressure unit ('mbar', 'hPa', 'Pa')!"
+                            )
 
                 if isinstance(file, str):
                     shortcut_map = self.__atm_type_file_to_function_map.get(type, {})
@@ -1325,6 +1338,32 @@ class Environment:
                         )
 
                 dictionary = self.__validate_dictionary(file, dictionary)
+
+                # Determine the numeric conversion factor (pressure → Pa).
+                if pressure_conversion_factor is not None:
+                    # User explicitly supplied a value — honour it.
+                    if isinstance(pressure_conversion_factor, str):
+                        conversion_factor = (
+                            100
+                            if pressure_conversion_factor.lower() in ("mbar", "hpa")
+                            else 1
+                        )
+                    else:
+                        conversion_factor = pressure_conversion_factor
+                else:
+                    # Auto-detect.  Primary source: known-model lookup table.
+                    # Fallback: units attribute inside the file (handled inside
+                    # get_pressure_levels_from_file when conversion_factor=None).
+                    _hpa_dicts = {"ECMWF", "ECMWF_V0", "ERA5", "MERRA2"}
+                    _pa_files = {"GFS", "NAM", "RAP", "HRRR", "AIGFS", "HIRESW", "GEFS"}
+                    if _input_dict in _hpa_dicts or _input_file in _hpa_dicts:
+                        conversion_factor = 100
+                    elif _input_file in _pa_files:
+                        conversion_factor = 1
+                    else:
+                        # Unknown model or custom dict: read units from file.
+                        conversion_factor = None
+
                 try:
                     fetch_function = self.__atm_type_file_to_function_map[type][file]
                 except KeyError:
@@ -1339,6 +1378,30 @@ class Environment:
                     )
                 else:
                     self.process_ensemble(dataset, dictionary, conversion_factor)
+
+                ground_pressure = self.pressure(self.elevation)
+                if not (30_000 <= ground_pressure <= 120_000):
+                    if pressure_conversion_factor is None:
+                        hint = (
+                            "The unit was auto-detected from the file's pressure "
+                            "level variable, but the result is still out of range. "
+                            "Override by passing pressure_conversion_factor explicitly "
+                            "('hPa' for ERA5/ECMWF files, 'Pa' for MERRA2 and online "
+                            "forecast models such as GFS, NAM, RAP, HRRR)."
+                        )
+                    else:
+                        hint = (
+                            f"pressure_conversion_factor='{pressure_conversion_factor}' "
+                            f"may be wrong. ERA5/ECMWF reanalysis files store pressure "
+                            f"in hPa — use 'hPa'. MERRA2 and online forecast models "
+                            f"(GFS, NAM, RAP, HRRR) store pressure in Pa — use 'Pa'."
+                        )
+                    warnings.warn(
+                        f"Ground-level pressure is {ground_pressure:.0f} Pa, which is "
+                        f"outside the expected range [30 000 Pa, 120 000 Pa]. {hint}",
+                        UserWarning,
+                        stacklevel=2,
+                    )
             case _:  # pragma: no cover
                 raise ValueError(f"Unknown model type '{type}'.")
 

--- a/rocketpy/environment/tools.py
+++ b/rocketpy/environment/tools.py
@@ -178,9 +178,11 @@ def get_pressure_levels_from_file(data, dictionary, conversion_factor):
         The netCDF4 dataset containing the pressure level data.
     dictionary : dict
         A dictionary mapping variable names to dataset keys.
-    conversion_factor : float, int
-        Specifies the factor by which the pressure will be multiplied
-        in order to transform it to Pascal.
+    conversion_factor : float, int, or None
+        Specifies the factor by which the pressure will be multiplied to
+        transform it to Pascal. If ``None``, the factor is auto-detected from
+        the ``units`` attribute of the pressure level variable in the dataset
+        (e.g. ``"millibars"`` or ``"hPa"`` → 100; ``"Pa"`` → 1).
 
     Returns
     -------
@@ -193,7 +195,14 @@ def get_pressure_levels_from_file(data, dictionary, conversion_factor):
         If the pressure levels cannot be read from the file.
     """
     try:
-        levels = conversion_factor * data.variables[dictionary["level"]][:]
+        level_var = data.variables[dictionary["level"]]
+        if conversion_factor is None:
+            raw_units = getattr(level_var, "units", "").lower().strip()
+            if raw_units in ("hpa", "mbar", "millibars", "hectopascal", "hectopascals"):
+                conversion_factor = 100
+            else:
+                conversion_factor = 1
+        levels = conversion_factor * level_var[:]
     except KeyError as e:
         raise ValueError(
             "Unable to read pressure levels from file. Check file and dictionary."

--- a/tests/integration/environment/test_environment.py
+++ b/tests/integration/environment/test_environment.py
@@ -51,6 +51,20 @@ def test_era5_atmosphere(mock_show, example_spaceport_env):  # pylint: disable=u
 
 
 @patch("matplotlib.pyplot.show")
+def test_era5_atmosphere_auto_detect_pressure(mock_show, example_spaceport_env):  # pylint: disable=unused-argument
+    """Tests the Reanalysis model with the ERA5 file using the default
+    pressure_conversion_factor=None (auto-detection).
+    """
+    example_spaceport_env.set_date((2018, 10, 15, 12))
+    example_spaceport_env.set_atmospheric_model(
+        type="Reanalysis",
+        file="data/weather/SpaceportAmerica_2018_ERA-5.nc",
+        dictionary="ECMWF",
+    )
+    assert example_spaceport_env.all_info() is None
+
+
+@patch("matplotlib.pyplot.show")
 def test_custom_atmosphere(mock_show, example_plain_env):  # pylint: disable=unused-argument
     """Tests the custom atmosphere model in the environment object.
 


### PR DESCRIPTION
## Description

In #955 a pressure unit conversion was added to the `set_atmospheric_model`. This fixed the pressure units for the new "Forecast" models added in #943. However, currently the default pressure unit is "Pa" when it used to be "hPa", this broke the definition of atmospheric models defined by files (such as reanalysis usage). One example of this breaking can be found in `camoes_flight_sim.ipynb`

This PR adds the functionality to automatically set the pressure unit based on the File/Model type

## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No
