### PR TITLE
BUG: fix NaN in ND linear interpolation outside convex hull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
+- BUG: fix NaN in ND linear interpolation outside convex hull [#926](https://github.com/RocketPy-Team/RocketPy/issues/926)
 - BUG: Add wraparound logic for wind direction in environment plots [#939](https://github.com/RocketPy-Team/RocketPy/pull/939)
 
 ## [v1.12.1] - 2026-04-03

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -830,7 +830,7 @@ class Function:  # pylint: disable=too-many-public-methods
         min_domain = self._domain.T.min(axis=1)
         max_domain = self._domain.T.max(axis=1)
 
-        if hasattr(self, "_nd_triangulation"):
+        if self.__interpolation__ == "linear" and hasattr(self, "_nd_triangulation"):
             extrap = self._nd_triangulation.find_simplex(args) < 0
         else:
             lower, upper = args < min_domain, args > max_domain

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -25,6 +25,7 @@ from scipy.interpolate import (
     RBFInterpolator,
     RegularGridInterpolator,
 )
+from scipy.spatial import Delaunay
 
 from rocketpy.plots.plot_helpers import show_or_save_plot
 from rocketpy.tools import deprecated, from_hex_decode, to_hex_encode
@@ -510,7 +511,9 @@ class Function:  # pylint: disable=too-many-public-methods
             case 0:  # linear
                 if self.__dom_dim__ == 1:
 
-                    def linear_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                    def linear_interpolation(
+                        x, x_min, x_max, x_data, y_data, coeffs
+                    ):  # pylint: disable=unused-argument
                         x_interval = bisect_left(x_data, x)
                         x_left = x_data[x_interval - 1]
                         y_left = y_data[x_interval - 1]
@@ -519,23 +522,31 @@ class Function:  # pylint: disable=too-many-public-methods
                         return (x - x_left) * (dy / dx) + y_left
 
                 else:
-                    interpolator = LinearNDInterpolator(self._domain, self._image)
+                    tri = Delaunay(self._domain)
+                    interpolator = LinearNDInterpolator(tri, self._image)
+                    self._nd_triangulation = tri
 
-                    def linear_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                    def linear_interpolation(
+                        x, x_min, x_max, x_data, y_data, coeffs
+                    ):  # pylint: disable=unused-argument
                         return interpolator(x)
 
                 self._interpolation_func = linear_interpolation
 
             case 1:  # polynomial
 
-                def polynomial_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                def polynomial_interpolation(
+                    x, x_min, x_max, x_data, y_data, coeffs
+                ):  # pylint: disable=unused-argument
                     return np.sum(coeffs * x ** np.arange(len(coeffs)))
 
                 self._interpolation_func = polynomial_interpolation
 
             case 2:  # akima
 
-                def akima_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                def akima_interpolation(
+                    x, x_min, x_max, x_data, y_data, coeffs
+                ):  # pylint: disable=unused-argument
                     x_interval = bisect_left(x_data, x)
                     x_interval = x_interval if x_interval != 0 else 1
                     a = coeffs[4 * x_interval - 4 : 4 * x_interval]
@@ -545,7 +556,9 @@ class Function:  # pylint: disable=too-many-public-methods
 
             case 3:  # spline
 
-                def spline_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                def spline_interpolation(
+                    x, x_min, x_max, x_data, y_data, coeffs
+                ):  # pylint: disable=unused-argument
                     x_interval = bisect_left(x_data, x)
                     x_interval = max(x_interval, 1)
                     a = coeffs[:, x_interval - 1]
@@ -581,7 +594,9 @@ class Function:  # pylint: disable=too-many-public-methods
             case 5:  # RBF
                 interpolator = RBFInterpolator(self._domain, self._image, neighbors=100)
 
-                def rbf_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                def rbf_interpolation(
+                    x, x_min, x_max, x_data, y_data, coeffs
+                ):  # pylint: disable=unused-argument
                     return interpolator(x)
 
                 self._interpolation_func = rbf_interpolation
@@ -602,7 +617,9 @@ class Function:  # pylint: disable=too-many-public-methods
                 # Store so extrapolation funcs can reuse it
                 self._grid_interpolator = grid_interpolator
 
-                def grid_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                def grid_interpolation(
+                    x, x_min, x_max, x_data, y_data, coeffs
+                ):  # pylint: disable=unused-argument
                     return grid_interpolator(x)
 
                 self._interpolation_func = grid_interpolation
@@ -622,7 +639,9 @@ class Function:  # pylint: disable=too-many-public-methods
         match extrapolation:
             case 0:  # zero
 
-                def zero_extrapolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                def zero_extrapolation(
+                    x, x_min, x_max, x_data, y_data, coeffs
+                ):  # pylint: disable=unused-argument
                     return 0
 
                 self._extrapolation_func = zero_extrapolation
@@ -739,14 +758,18 @@ class Function:  # pylint: disable=too-many-public-methods
             case 2:  # constant
                 if self.__dom_dim__ == 1:
 
-                    def constant_extrapolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                    def constant_extrapolation(
+                        x, x_min, x_max, x_data, y_data, coeffs
+                    ):  # pylint: disable=unused-argument
                         return y_data[0] if x < x_min else y_data[-1]
 
                 elif self.__interpolation__ == "regular_grid":
                     grid_axes = self._grid_axes
                     grid_interpolator_const = self._grid_interpolator
 
-                    def constant_extrapolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                    def constant_extrapolation(
+                        x, x_min, x_max, x_data, y_data, coeffs
+                    ):  # pylint: disable=unused-argument
                         # Clamp each coordinate to its axis bounds, then interpolate
                         x_clamped = np.copy(x)
                         for i, axis in enumerate(grid_axes):
@@ -758,7 +781,9 @@ class Function:  # pylint: disable=too-many-public-methods
                 else:
                     extrapolator = NearestNDInterpolator(self._domain, self._image)
 
-                    def constant_extrapolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
+                    def constant_extrapolation(
+                        x, x_min, x_max, x_data, y_data, coeffs
+                    ):  # pylint: disable=unused-argument
                         return extrapolator(x)
 
                 self._extrapolation_func = constant_extrapolation
@@ -827,8 +852,11 @@ class Function:  # pylint: disable=too-many-public-methods
         min_domain = self._domain.T.min(axis=1)
         max_domain = self._domain.T.max(axis=1)
 
-        lower, upper = args < min_domain, args > max_domain
-        extrap = np.logical_or(lower.any(axis=1), upper.any(axis=1))
+        if hasattr(self, "_nd_triangulation"):
+            extrap = self._nd_triangulation.find_simplex(args) < 0
+        else:
+            lower, upper = args < min_domain, args > max_domain
+            extrap = np.logical_or(lower.any(axis=1), upper.any(axis=1))
 
         if extrap.any():
             result[extrap] = self._extrapolation_func(

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -511,9 +511,7 @@ class Function:  # pylint: disable=too-many-public-methods
             case 0:  # linear
                 if self.__dom_dim__ == 1:
 
-                    def linear_interpolation(
-                        x, x_min, x_max, x_data, y_data, coeffs
-                    ):  # pylint: disable=unused-argument
+                    def linear_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                         x_interval = bisect_left(x_data, x)
                         x_left = x_data[x_interval - 1]
                         y_left = y_data[x_interval - 1]
@@ -526,27 +524,21 @@ class Function:  # pylint: disable=too-many-public-methods
                     interpolator = LinearNDInterpolator(tri, self._image)
                     self._nd_triangulation = tri
 
-                    def linear_interpolation(
-                        x, x_min, x_max, x_data, y_data, coeffs
-                    ):  # pylint: disable=unused-argument
+                    def linear_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                         return interpolator(x)
 
                 self._interpolation_func = linear_interpolation
 
             case 1:  # polynomial
 
-                def polynomial_interpolation(
-                    x, x_min, x_max, x_data, y_data, coeffs
-                ):  # pylint: disable=unused-argument
+                def polynomial_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                     return np.sum(coeffs * x ** np.arange(len(coeffs)))
 
                 self._interpolation_func = polynomial_interpolation
 
             case 2:  # akima
 
-                def akima_interpolation(
-                    x, x_min, x_max, x_data, y_data, coeffs
-                ):  # pylint: disable=unused-argument
+                def akima_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                     x_interval = bisect_left(x_data, x)
                     x_interval = x_interval if x_interval != 0 else 1
                     a = coeffs[4 * x_interval - 4 : 4 * x_interval]
@@ -556,9 +548,7 @@ class Function:  # pylint: disable=too-many-public-methods
 
             case 3:  # spline
 
-                def spline_interpolation(
-                    x, x_min, x_max, x_data, y_data, coeffs
-                ):  # pylint: disable=unused-argument
+                def spline_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                     x_interval = bisect_left(x_data, x)
                     x_interval = max(x_interval, 1)
                     a = coeffs[:, x_interval - 1]
@@ -594,9 +584,7 @@ class Function:  # pylint: disable=too-many-public-methods
             case 5:  # RBF
                 interpolator = RBFInterpolator(self._domain, self._image, neighbors=100)
 
-                def rbf_interpolation(
-                    x, x_min, x_max, x_data, y_data, coeffs
-                ):  # pylint: disable=unused-argument
+                def rbf_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                     return interpolator(x)
 
                 self._interpolation_func = rbf_interpolation
@@ -617,9 +605,7 @@ class Function:  # pylint: disable=too-many-public-methods
                 # Store so extrapolation funcs can reuse it
                 self._grid_interpolator = grid_interpolator
 
-                def grid_interpolation(
-                    x, x_min, x_max, x_data, y_data, coeffs
-                ):  # pylint: disable=unused-argument
+                def grid_interpolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                     return grid_interpolator(x)
 
                 self._interpolation_func = grid_interpolation
@@ -639,9 +625,7 @@ class Function:  # pylint: disable=too-many-public-methods
         match extrapolation:
             case 0:  # zero
 
-                def zero_extrapolation(
-                    x, x_min, x_max, x_data, y_data, coeffs
-                ):  # pylint: disable=unused-argument
+                def zero_extrapolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                     return 0
 
                 self._extrapolation_func = zero_extrapolation
@@ -758,18 +742,14 @@ class Function:  # pylint: disable=too-many-public-methods
             case 2:  # constant
                 if self.__dom_dim__ == 1:
 
-                    def constant_extrapolation(
-                        x, x_min, x_max, x_data, y_data, coeffs
-                    ):  # pylint: disable=unused-argument
+                    def constant_extrapolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                         return y_data[0] if x < x_min else y_data[-1]
 
                 elif self.__interpolation__ == "regular_grid":
                     grid_axes = self._grid_axes
                     grid_interpolator_const = self._grid_interpolator
 
-                    def constant_extrapolation(
-                        x, x_min, x_max, x_data, y_data, coeffs
-                    ):  # pylint: disable=unused-argument
+                    def constant_extrapolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                         # Clamp each coordinate to its axis bounds, then interpolate
                         x_clamped = np.copy(x)
                         for i, axis in enumerate(grid_axes):
@@ -781,9 +761,7 @@ class Function:  # pylint: disable=too-many-public-methods
                 else:
                     extrapolator = NearestNDInterpolator(self._domain, self._image)
 
-                    def constant_extrapolation(
-                        x, x_min, x_max, x_data, y_data, coeffs
-                    ):  # pylint: disable=unused-argument
+                    def constant_extrapolation(x, x_min, x_max, x_data, y_data, coeffs):  # pylint: disable=unused-argument
                         return extrapolator(x)
 
                 self._extrapolation_func = constant_extrapolation

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -25,7 +25,7 @@ from scipy.interpolate import (
     RBFInterpolator,
     RegularGridInterpolator,
 )
-from scipy.spatial import Delaunay # pylint: disable=no-name-in-module
+from scipy.spatial import Delaunay  # pylint: disable=no-name-in-module
 
 from rocketpy.plots.plot_helpers import show_or_save_plot
 from rocketpy.tools import deprecated, from_hex_decode, to_hex_encode

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -25,7 +25,7 @@ from scipy.interpolate import (
     RBFInterpolator,
     RegularGridInterpolator,
 )
-from scipy.spatial import Delaunay
+from scipy.spatial import Delaunay # pylint: disable=no-name-in-module
 
 from rocketpy.plots.plot_helpers import show_or_save_plot
 from rocketpy.tools import deprecated, from_hex_decode, to_hex_encode

--- a/tests/unit/mathutils/test_function.py
+++ b/tests/unit/mathutils/test_function.py
@@ -1186,18 +1186,18 @@ def test_low_pass_filter(alpha):
 
     # Check that the method works as intended and returns the right object with no issue
     assert isinstance(filtered_func, Function), "The returned type is not a Function"
-    assert np.array_equal(
-        filtered_func.source[0], source[0]
-    ), "The initial value is not the expected value"
-    assert len(filtered_func.source) == len(
-        source
-    ), "The filtered Function and the Function have different lengths"
-    assert (
-        filtered_func.__interpolation__ == func.__interpolation__
-    ), "The interpolation method was unexpectedly changed"
-    assert (
-        filtered_func.__extrapolation__ == func.__extrapolation__
-    ), "The extrapolation method was unexpectedly changed"
+    assert np.array_equal(filtered_func.source[0], source[0]), (
+        "The initial value is not the expected value"
+    )
+    assert len(filtered_func.source) == len(source), (
+        "The filtered Function and the Function have different lengths"
+    )
+    assert filtered_func.__interpolation__ == func.__interpolation__, (
+        "The interpolation method was unexpectedly changed"
+    )
+    assert filtered_func.__extrapolation__ == func.__extrapolation__, (
+        "The extrapolation method was unexpectedly changed"
+    )
     for i in range(1, len(source)):
         expected = alpha * source[i][1] + (1 - alpha) * filtered_func.source[i - 1][1]
         assert np.isclose(filtered_func.source[i][1], expected, atol=1e-6), (

--- a/tests/unit/mathutils/test_function.py
+++ b/tests/unit/mathutils/test_function.py
@@ -1186,18 +1186,18 @@ def test_low_pass_filter(alpha):
 
     # Check that the method works as intended and returns the right object with no issue
     assert isinstance(filtered_func, Function), "The returned type is not a Function"
-    assert np.array_equal(filtered_func.source[0], source[0]), (
-        "The initial value is not the expected value"
-    )
-    assert len(filtered_func.source) == len(source), (
-        "The filtered Function and the Function have different lengths"
-    )
-    assert filtered_func.__interpolation__ == func.__interpolation__, (
-        "The interpolation method was unexpectedly changed"
-    )
-    assert filtered_func.__extrapolation__ == func.__extrapolation__, (
-        "The extrapolation method was unexpectedly changed"
-    )
+    assert np.array_equal(
+        filtered_func.source[0], source[0]
+    ), "The initial value is not the expected value"
+    assert len(filtered_func.source) == len(
+        source
+    ), "The filtered Function and the Function have different lengths"
+    assert (
+        filtered_func.__interpolation__ == func.__interpolation__
+    ), "The interpolation method was unexpectedly changed"
+    assert (
+        filtered_func.__extrapolation__ == func.__extrapolation__
+    ), "The extrapolation method was unexpectedly changed"
     for i in range(1, len(source)):
         expected = alpha * source[i][1] + (1 - alpha) * filtered_func.source[i - 1][1]
         assert np.isclose(filtered_func.source[i][1], expected, atol=1e-6), (
@@ -1505,3 +1505,27 @@ def test_regular_grid_invalid_source_raises(bad_source, match):
             outputs=["z"],
             interpolation="regular_grid",
         )
+
+
+def test_2d_linear_interpolation_no_nan_outside_convex_hull():
+    """Test that querying a point inside the bounding box but outside the
+    convex hull does not silently return NaN.
+
+    Regression test for https://github.com/RocketPy-Team/RocketPy/issues/926.
+    The point (0.3, 0.3) lies within the axis-aligned bounding box of the
+    data but outside the convex hull, so LinearNDInterpolator would return
+    NaN without proper hull detection.
+    """
+    data = [
+        [0.0, 0.0, 0.000],
+        [0.0, 0.1, 0.100],
+        [0.0, 0.4, 0.400],
+        [0.3, 0.2, 0.150],
+    ]
+    func = Function(data, interpolation="linear")
+    result = func(0.3, 0.3)
+
+    assert not np.isnan(result), (
+        "f(0.3, 0.3) returned NaN. Point is outside the convex hull and "
+        "should be routed to extrapolation, not silently return NaN."
+    )


### PR DESCRIPTION
<!-- You are awesome! Your contribution to RocketPy is fundamental in our endeavour to create the next generation solution for rocketry trajectory simulation! -->

<!-- You may use this template to describe your Pull Request. But if you believe there is a better way to express yourself, don't hesitate! -->

## Pull request type
<!-- Remove unchecked box items. -->

- [x] Code changes (bugfix, features)
- [x] Code maintenance (refactoring, formatting, tests)

## Checklist
<!-- Remove irrelevant items to this PR. -->

- [x] Tests for the changes have been added (if needed)
- [x] Lint (`black rocketpy/ tests/`) has passed locally 
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally
- [x] `CHANGELOG.md` has been updated (if relevant)

## Current behavior
<!-- Describe current behavior or link to an issue. -->

Closes #926.

When using `Function(..., interpolation="linear")` with N-D data,
querying a point inside the axis-aligned bounding box but outside
the convex hull silently returns `nan` with no warning.

```python
data = [
    [0.0, 0.0, 0.000],
    [0.0, 0.1, 0.100],
    [0.0, 0.4, 0.400],
    [0.3, 0.2, 0.150],
]
f = Function(data, interpolation="linear")
print(f(0.3, 0.3))  # nan
```


## New behavior
<!-- Describe changes introduced by this PR. -->

`f(0.3, 0.3)` no longer returns `nan`. Points outside the convex
hull are correctly identified and routed to the extrapolation method.


## Breaking change
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. Remove the unchecked box item. -->

- [ ] Yes
- [x] No

## Additional information
<!-- Include any relevant details or screenshots. If none, remove this section. -->

`__get_value_opt_nd` used per-axis min/max (bounding box) to decide
between interpolation and extrapolation. `LinearNDInterpolator`
operates on the Delaunay triangulation (convex hull), not the
bounding box — points in the gap between the two were silently
sent to the interpolator and came back as `nan`.

Fix: compute `Delaunay(self._domain)` once at setup, pass it to
`LinearNDInterpolator` (reuses the triangulation at no extra cost),
and store it as `self._nd_triangulation`. In `__get_value_opt_nd`,
replace the bounding box check with `find_simplex(args) < 0`.
Shepard, RBF and other ND interpolators are unaffected.

