### PR TITLE
BUG: fix wind heading and direction wraparound interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
+- BUG: fix wind heading and direction wraparound interpolation [#974](https://github.com/RocketPy-Team/RocketPy/pull/974)
 - BUG: fix NaN in ND linear interpolation outside convex hull [#926](https://github.com/RocketPy-Team/RocketPy/issues/926)
 - BUG: Add wraparound logic for wind direction in environment plots [#939](https://github.com/RocketPy-Team/RocketPy/pull/939)
 

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -537,20 +537,42 @@ class Environment:
             interpolation="linear",
         )
 
+    def __set_wind_angle_function(self, source, attribute, output):
+        """Set ``attribute`` (e.g. ``wind_direction``) as a Function of height.
+        For 2D-array sources the angles are unwrapped across the 360/0 boundary
+        before linear interpolation, avoiding spurious spikes near the wrap."""
+        if isinstance(source, (np.ndarray, list, tuple)) and np.ndim(source) == 2:
+            array = np.asarray(source)
+            unwrapped_deg = np.rad2deg(np.unwrap(np.deg2rad(array[:, 1])))
+            unwrapped = Function(
+                np.column_stack((array[:, 0], unwrapped_deg)),
+                inputs="Height Above Sea Level (m)",
+                outputs=output,
+                interpolation="linear",
+            )
+            setattr(self, f"{attribute}_unwrapped", unwrapped)
+            source = Function(
+                lambda h: unwrapped(h) % 360,
+                inputs="Height Above Sea Level (m)",
+                outputs=output,
+            )
+        else:
+            source = Function(
+                source,
+                inputs="Height Above Sea Level (m)",
+                outputs=output,
+                interpolation="linear",
+            )
+        setattr(self, attribute, source)
+
     def __set_wind_direction_function(self, source):
-        self.wind_direction = Function(
-            source,
-            inputs="Height Above Sea Level (m)",
-            outputs="Wind Direction (Deg True)",
-            interpolation="linear",
+        self.__set_wind_angle_function(
+            source, "wind_direction", "Wind Direction (Deg True)"
         )
 
     def __set_wind_heading_function(self, source):
-        self.wind_heading = Function(
-            source,
-            inputs="Height Above Sea Level (m)",
-            outputs="Wind Heading (Deg True)",
-            interpolation="linear",
+        self.__set_wind_angle_function(
+            source, "wind_heading", "Wind Heading (Deg True)"
         )
 
     def __reset_barometric_height_function(self):

--- a/tests/unit/environment/test_environment.py
+++ b/tests/unit/environment/test_environment.py
@@ -604,6 +604,34 @@ def test_set_atmospheric_model_raises_for_unknown_model_type(example_plain_env):
         environment.set_atmospheric_model(type="unknown_type")
 
 
+def test_wind_heading_direction_wraparound_interpolation(example_plain_env):
+    """Test that wind heading and direction interpolation wraps around correctly
+    across the 360°/0° boundary when initialized with a 2D array.
+    """
+    # Create discrete points at 1000m and 1100m
+    # 350 deg at 1000m, 10 deg at 1100m.
+    # Midpoint should be 360 deg or 0 deg, NOT 180 deg.
+    heading_data = np.array([[1000, 350], [1100, 10]])
+    direction_data = np.array([[1000, 350], [1100, 10]])
+
+    example_plain_env._Environment__set_wind_heading_function(heading_data)
+    example_plain_env._Environment__set_wind_direction_function(direction_data)
+
+    # Evaluate at midpoint (1050m)
+    mid_heading = example_plain_env.wind_heading(1050)
+    mid_direction = example_plain_env.wind_direction(1050)
+
+    # Check that it's close to 0 or 360 (which is also 0 modulo 360)
+    assert np.isclose(mid_heading, 0.0) or np.isclose(mid_heading, 360.0)
+    assert np.isclose(mid_direction, 0.0) or np.isclose(mid_direction, 360.0)
+
+    # Also test another wrap-around case, e.g. 10 to 350
+    heading_data2 = np.array([[1000, 10], [1100, 350]])
+    example_plain_env._Environment__set_wind_heading_function(heading_data2)
+    mid_heading2 = example_plain_env.wind_heading(1050)
+    assert np.isclose(mid_heading2, 0.0) or np.isclose(mid_heading2, 360.0)
+
+
 @pytest.mark.parametrize("shortcut_name", ["AIGFS", "HRRR"])
 def test_forecast_shortcut_and_dictionary_are_case_insensitive(
     monkeypatch, shortcut_name


### PR DESCRIPTION
This fixes the issue where linear interpolation of wind heading and direction values over discrete altitudes caused unexpected spikes/wiggles around the 360/0 wraparound boundary.

Closes #253