### PR TITLE
MNT: Remove redundant wind_heading/wind_direction functions from EnvironmentAnalysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ Attention: The newest changes should be on top -->
 
 - MNT: Rename `radius` to `radius_function` in `CylindricalTank` and `SphericalTank`; old `radius=` keyword argument now raises `DeprecationWarning` [#957](https://github.com/RocketPy-Team/RocketPy/pull/957)
 
+### Removed
+
+- MNT: Remove redundant, unused per-level `wind_heading`/`wind_direction` functions from `EnvironmentAnalysis` pressure-level data (derivable from `wind_velocity_x`/`wind_velocity_y`) [#1041](https://github.com/RocketPy-Team/RocketPy/pull/1041)
+
 ### Fixed
 
 - BUG: fix wind heading and direction wraparound interpolation [#974](https://github.com/RocketPy-Team/RocketPy/pull/974)

--- a/rocketpy/environment/environment_analysis.py
+++ b/rocketpy/environment/environment_analysis.py
@@ -460,8 +460,6 @@ class EnvironmentAnalysis:  # pylint: disable=too-many-public-methods
             "height_ASL": "m",
             "pressure": "hPa",
             "temperature": "K",
-            "wind_direction": "deg",
-            "wind_heading": "deg",
             "wind_speed": "m/s",
             "wind_velocity_x": "m/s",
             "wind_velocity_y": "m/s",
@@ -570,8 +568,6 @@ class EnvironmentAnalysis:  # pylint: disable=too-many-public-methods
         Must compute the following for each date and hour available in the dataset:
         - pressure = Function(..., inputs="Height Above Ground Level (m)", outputs="Pressure (Pa)")
         - temperature = Function(..., inputs="Height Above Ground Level (m)", outputs="Temperature (K)")
-        - wind_direction = Function(..., inputs="Height Above Ground Level (m)", outputs="Wind Direction (Deg True)")
-        - wind_heading = Function(..., inputs="Height Above Ground Level (m)", outputs="Wind Heading (Deg True)")
         - wind_speed = Function(..., inputs="Height Above Ground Level (m)", outputs="Wind Speed (m/s)")
         - wind_velocity_x = Function(..., inputs="Height Above Ground Level (m)", outputs="Wind Velocity X (m/s)")
         - wind_velocity_y = Function(..., inputs="Height Above Ground Level (m)", outputs="Wind Velocity Y (m/s)")
@@ -721,39 +717,6 @@ class EnvironmentAnalysis:  # pylint: disable=too-many-public-methods
                 extrapolation="constant",
             )
             dictionary[date_string][hour_string]["wind_speed"] = wind_speed_function
-
-            # Create function for wind heading levels
-            wind_heading_array = (
-                np.arctan2(wind_velocity_x_array, wind_velocity_y_array)
-                * (180 / np.pi)
-                % 360
-            )
-
-            wind_heading_points_array = np.array(
-                [height_above_ground_level_array, wind_heading_array]
-            ).T
-            wind_heading_function = Function(
-                wind_heading_points_array,
-                inputs="Height Above Ground Level (m)",
-                outputs="Wind Heading (Deg True)",
-                extrapolation="constant",
-            )
-            dictionary[date_string][hour_string]["wind_heading"] = wind_heading_function
-
-            # Create function for wind direction levels
-            wind_direction_array = (wind_heading_array - 180) % 360
-            wind_direction_points_array = np.array(
-                [height_above_ground_level_array, wind_direction_array]
-            ).T
-            wind_direction_function = Function(
-                wind_direction_points_array,
-                inputs="Height Above Ground Level (m)",
-                outputs="Wind Direction (Deg True)",
-                extrapolation="constant",
-            )
-            dictionary[date_string][hour_string]["wind_direction"] = (
-                wind_direction_function
-            )
 
         return (dictionary, lat0, lat1, lon0, lon1)
 
@@ -985,8 +948,6 @@ class EnvironmentAnalysis:  # pylint: disable=too-many-public-methods
         conversion_dict = {
             "pressure": self.unit_system["pressure"],
             "temperature": self.unit_system["temperature"],
-            "wind_direction": self.unit_system["angle"],
-            "wind_heading": self.unit_system["angle"],
             "wind_speed": self.unit_system["wind_speed"],
             "wind_velocity_x": self.unit_system["wind_speed"],
             "wind_velocity_y": self.unit_system["wind_speed"],


### PR DESCRIPTION
## Summary

Removes the per-date/hour `wind_heading` and `wind_direction` `Function` objects that `EnvironmentAnalysis` stored inside `original_pressure_level_data` (and converted into `converted_pressure_level_data`). They were **dead and redundant**, and they carried a latent bug.

## Motivation

While reviewing #974 (wind wraparound fix for the `Environment` class), we checked whether `EnvironmentAnalysis` needed the same fix. It does **not** — every consumer derives heading/direction from the wind velocity components (`u`/`v`) via `arctan2`, which is the correct circular method and immune to the 360°/0° seam:

- `surface_wind_direction_by_hour` → `arctan2(vy, vx)`
- `average_wind_heading_profile` / `average_wind_heading_profile_by_hour` → `arctan2(mean_u, mean_v)`
- `wind_heading_profiles_list` → `arctan2(u(alt), v(alt))`

The only code that interpolated **raw degrees** were these two stored `Function`s — and a usage audit shows they were **never read** anywhere (0 consumers), unlike their siblings `wind_velocity_x/y`, `wind_speed`, `pressure`, `temperature`. Because they linearly interpolated degrees, they reproduced the exact wraparound artifact that #974 fixes for `Environment`.

## Changes

- Drop the `wind_heading_function` / `wind_direction_function` constructions and their dict assignments in the pressure-level data builder.
- Remove their now-unused entries from `current_units` and the `converted_pressure_level_data` `conversion_dict`.
- Update the builder docstring accordingly.

Heading/direction remain fully derivable from the retained `wind_velocity_x` / `wind_velocity_y` functions.

## Verification

- `ruff check` / `ruff format` clean; `pylint` 10.00/10.
- `tests/unit/environment/test_environment_analysis.py --runslow` → **5 passed** (exercises `converted_pressure_level_data`, `wind_heading_profile_grid`, `average_wind_heading_profile`, `animate_wind_heading_profile`).

## Note for reviewers — API surface

These functions were technically reachable via the public `original_pressure_level_data` / `converted_pressure_level_data` properties, so strictly this is a public-API removal. They appear unused and undocumented as an access pattern, so I went with outright removal per the cleanup intent — but if you'd prefer a deprecation cycle instead, say so and I'll switch to that.

Split out of the #974 review; #974 stays scoped to the `Environment` class.