### PR TITLE
MNT: final fixes before next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,27 +32,25 @@ Attention: The newest changes should be on top -->
 
 ### Added
 
-- ENH: MNT: refactor parachute implementation [#958](https://github.com/RocketPy-Team/RocketPy/pull/958)
+- ENH: Individual Fins: add `Fin`, `TrapezoidalFin`, `EllipticalFin`, and `FreeFormFin` classes for modeling asymmetric or individually-positioned fins [#818](https://github.com/RocketPy-Team/RocketPy/pull/818)
+- ENH: Add AIGFS and HRRR forecast models to the Environment class [#951](https://github.com/RocketPy-Team/RocketPy/pull/951)
+- ENH: Add RingClusterMotor for annular clustered motor modeling [#924](https://github.com/RocketPy-Team/RocketPy/pull/924)
+- ENH: Discrete and Continuous Controllers [#946](https://github.com/RocketPy-Team/RocketPy/pull/946)
 - ENH: Add custom exceptions and unstable rocket warning [#970](https://github.com/RocketPy-Team/RocketPy/pull/970)
-- ENH: MNT: Remove redundant wind_heading/wind_direction functions from EnvironmentAnalysis [#1041](https://github.com/RocketPy-Team/RocketPy/pull/1041)
+- ENH: Adopt built-in Python logging instead of print() calls (closes [#450](https://github.com/RocketPy-Team/RocketPy/issues/450)) [#973](https://github.com/RocketPy-Team/RocketPy/pull/973)
 - ENH: Pass acceleration (`u_dot`) data to parachute trigger functions [#911](https://github.com/RocketPy-Team/RocketPy/pull/911)
 - ENH: Add 3D flight trajectory and attitude animations in Flight plots layer [#909](https://github.com/RocketPy-Team/RocketPy/pull/909)
-- ENH: DOC: Configure AI instructions and update developer docs [#975](https://github.com/RocketPy-Team/RocketPy/pull/975)
-- ENH: BUG: fix wind heading and direction wraparound interpolation [#974](https://github.com/RocketPy-Team/RocketPy/pull/974)
-- ENH: MNT: Sync develop's Renovate config with master (#1039) [#1040](https://github.com/RocketPy-Team/RocketPy/pull/1040)
-- ENH: MNT: Configure Renovate Bot targeting develop branch [#972](https://github.com/RocketPy-Team/RocketPy/pull/972)
-- MNT: Refactor parachute implementation with abstract base and hemispherical model split [#958](https://github.com/RocketPy-Team/RocketPy/pull/958)
 - ENH: Monte Carlo Formatting Options [#947](https://github.com/RocketPy-Team/RocketPy/pull/947)
-- ENH: ENH: Auto-Detection of Pressure Conversion Factor [#966](https://github.com/RocketPy-Team/RocketPy/pull/966)
-- ENH: Auto-Detection of Pressure Conversion Factor [#966](https://github.com/RocketPy-Team/RocketPy/pull/966)
-- ENH: Discrete and Continuous Controllers [#946](https://github.com/RocketPy-Team/RocketPy/pull/946)
-- DOC: Add aerodynamic surfaces user guide [#1043](https://github.com/RocketPy-Team/RocketPy/pull/1043)
-- ENH: Add RingClusterMotor for annular clustered motor modeling [#924](https://github.com/RocketPy-Team/RocketPy/pull/924)
-- ENH: MNT: introduce pressure unit conversion when using forecast/reanalysis/ensemble data [#955](https://github.com/RocketPy-Team/RocketPy/pull/955)
-- ENH: Auto Populate Changelog [#919](https://github.com/RocketPy-Team/RocketPy/pull/919)
 - ENH: Adaptive Monte Carlo via Convergence Criteria [#922](https://github.com/RocketPy-Team/RocketPy/pull/922)
-- TST: Add acceptance tests for 3DOF flight simulation based on Bella Lui rocket [#914](https://github.com/RocketPy-Team/RocketPy/pull/914)
-- ENH: adopt built-in Python logging instead of print() calls [#450](https://github.com/RocketPy-Team/RocketPy/issues/450)
+- ENH: Auto-Detection of Pressure Conversion Factor [#966](https://github.com/RocketPy-Team/RocketPy/pull/966)
+- ENH: Introduce pressure unit conversion when using forecast/reanalysis/ensemble data [#955](https://github.com/RocketPy-Team/RocketPy/pull/955)
+- MNT: Refactor parachute implementation with abstract base and hemispherical model split [#958](https://github.com/RocketPy-Team/RocketPy/pull/958)
+- DOC: Add aerodynamic surfaces user guide [#1043](https://github.com/RocketPy-Team/RocketPy/pull/1043)
+- DOC: Add Valkyrie flight example (Bisky Team) [#967](https://github.com/RocketPy-Team/RocketPy/pull/967)
+- DOC: Configure AI instructions and update developer docs [#975](https://github.com/RocketPy-Team/RocketPy/pull/975)
+- ENH: Auto Populate Changelog [#919](https://github.com/RocketPy-Team/RocketPy/pull/919)
+- MNT: Sync develop's Renovate config with master (#1039) [#1040](https://github.com/RocketPy-Team/RocketPy/pull/1040)
+- MNT: Configure Renovate Bot targeting develop branch [#972](https://github.com/RocketPy-Team/RocketPy/pull/972)
 
 ### Changed
 
@@ -68,8 +66,9 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
+- BUG: Remove duplicate controller process; controllers were being invoked twice per time node [#949](https://github.com/RocketPy-Team/RocketPy/pull/949)
 - BUG: fix wind heading and direction wraparound interpolation [#974](https://github.com/RocketPy-Team/RocketPy/pull/974)
-- BUG: fix NaN in ND linear interpolation outside convex hull [#926](https://github.com/RocketPy-Team/RocketPy/issues/926)
+- BUG: fix NaN in ND linear interpolation outside convex hull (closes [#926](https://github.com/RocketPy-Team/RocketPy/issues/926)) [#969](https://github.com/RocketPy-Team/RocketPy/pull/969)
 - BUG: Add wraparound logic for wind direction in environment plots [#939](https://github.com/RocketPy-Team/RocketPy/pull/939)
 
 ## [v1.12.1] - 2026-04-03
@@ -109,6 +108,9 @@ Attention: The newest changes should be on top -->
 ### Fixed
 
 - BUG: Fix hard-coded radius value for parachute added mass calculation [#889](https://github.com/RocketPy-Team/RocketPy/pull/889)
+- BUG: Fix incorrect Jacobian in `only_radial_burn` branch of `SolidMotor.evaluate_geometry` [#944](https://github.com/RocketPy-Team/RocketPy/pull/944)
+- ENH: Restore `power_off_drag`/`power_on_drag` as `Function` objects and preserve raw user input in `_input` attributes [#941](https://github.com/RocketPy-Team/RocketPy/pull/941)
+- ENH: Add explicit timeouts to ThrustCurve API requests [#940](https://github.com/RocketPy-Team/RocketPy/pull/940)
 - DOC: Fix documentation build [#908](https://github.com/RocketPy-Team/RocketPy/pull/908)
 - BUG: energy_data plot not working for 3 dof sims [[#906](https://github.com/RocketPy-Team/RocketPy/issues/906)]
 - BUG: Fix CSV column header spacing in FlightDataExporter [#864](https://github.com/RocketPy-Team/RocketPy/issues/864)

--- a/docs/examples/valkyrie_flight_sim.ipynb
+++ b/docs/examples/valkyrie_flight_sim.ipynb
@@ -47,9 +47,10 @@
    "outputs": [],
    "source": [
     "import json\n",
+    "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "from rocketpy import Environment, Flight, Rocket, SolidMotor, Function\n",
+    "from rocketpy import Environment, Flight, Function, Rocket, SolidMotor\n",
     "from rocketpy.simulation.flight_data_importer import FlightDataImporter\n",
     "\n",
     "plt.style.use(\"seaborn-v0_8-colorblind\")\n",

--- a/docs/reference/classes/exceptions.rst
+++ b/docs/reference/classes/exceptions.rst
@@ -1,0 +1,14 @@
+Exceptions and Warnings
+=======================
+
+RocketPy raises a small hierarchy of custom exceptions and warnings so that
+error handling can be more specific than catching plain ``ValueError`` or
+``UserWarning``. All exceptions inherit from :class:`~rocketpy.exceptions.RocketPyError`,
+which makes it possible to catch any RocketPy-specific error with a single
+``except`` clause while still deriving from the relevant built-in type
+(e.g. :class:`~rocketpy.exceptions.InvalidParameterError` is also a
+``ValueError``).
+
+.. automodule:: rocketpy.exceptions
+   :members:
+   :show-inheritance:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -18,9 +18,10 @@ This reference manual details functions, modules, methods and attributes include
    classes/Flight
    Utilities <classes/utils/index>
    classes/EnvironmentAnalysis
-   Monte Carlo Analysis <classes/monte_carlo/index> 
+   Monte Carlo Analysis <classes/monte_carlo/index>
    Sensitivity Analysis <classes/Sensitivity>
    Multivariate Rejection Sampler <classes/MultivariateRejectionSampler>
+   Exceptions and Warnings <classes/exceptions>
 
 .. toctree::
    :maxdepth: 2

--- a/docs/user/airbrakes.rst
+++ b/docs/user/airbrakes.rst
@@ -95,9 +95,11 @@ To create an air brakes model, we essentially need to define the following:
   ``deployment_level`` attribute. Inside this function, any controller logic,
   filters, and apogee prediction can be implemented.
 
-- The **sampling rate** of the controller function, in seconds. This is the time
-  between each call of the controller function, in simulation time. Must be
-  given in Hertz.
+- The **sampling rate** of the controller function, in Hertz. This is how often
+  the controller function is called in simulation time (a **discrete**
+  controller). It can also be set to ``None`` to create a **continuous**
+  controller that is called at every solver step (see
+  :ref:`discrete-vs-continuous-controllers` below).
 
 Defining the Controller Function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -108,8 +110,9 @@ The ``controller_function`` must take in the following arguments, in this
 order:
 
 1. ``time`` (float): The current simulation time in seconds.
-2. ``sampling_rate`` (float): The rate at which the controller
-   function is called, measured in Hertz (Hz).
+2. ``sampling_rate`` (float or ``None``): The rate at which the controller
+   function is called, measured in Hertz (Hz). It is ``None`` for continuous
+   controllers, so guard any ``1 / sampling_rate`` computation against ``None``.
 3. ``state`` (list): The state vector of the simulation. The state
    is a list containing the following values, in this order:
 
@@ -371,6 +374,41 @@ controller function. If you want to disable this feature, set ``clamp`` to
 
     For more information on the :class:`rocketpy.AirBrakes` class
     initialization, see  :class:`rocketpy.AirBrakes.__init__` section.
+
+.. _discrete-vs-continuous-controllers:
+
+Discrete vs. Continuous Controllers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``sampling_rate`` argument determines *when* the controller function is
+called during the flight simulation:
+
+- **Discrete controller** (``sampling_rate`` set to a number, e.g. ``10``):
+  the controller function is called at fixed intervals of ``1 / sampling_rate``
+  seconds. This mirrors a real flight computer that reads its sensors and
+  updates its actuators at a fixed frequency, and is the recommended choice
+  when you want the simulation to reflect the actual control-loop rate of your
+  hardware.
+- **Continuous controller** (``sampling_rate=None``): the controller function
+  is called at *every* solver step of the numerical integrator. Use this when
+  you want the control law to act as a continuous function of the state rather
+  than a sampled one (for example, when validating a control model
+  analytically).
+
+.. warning::
+
+    For continuous controllers, ``sampling_rate`` is passed to your controller
+    function as ``None``. Any computation such as ``1 / sampling_rate`` (a
+    common pattern for rate-limiting deployment, as shown above) must guard
+    against ``None`` to avoid a ``TypeError``.
+
+.. note::
+
+    Discrete controllers add their sampling instants as time nodes to the
+    simulation, so remember to set ``time_overshoot=False`` in the ``Flight``
+    (see below) to make the integrator stop exactly at those instants.
+    Continuous controllers do not add time nodes; they are evaluated on the
+    integrator's own steps.
 
 Simulating a Flight
 -------------------

--- a/docs/user/environment/1-atm-models/forecast.rst
+++ b/docs/user/environment/1-atm-models/forecast.rst
@@ -173,14 +173,14 @@ hourly updates. It is generally best for day-of-launch weather assessment and
 rapidly changing local conditions.
 
 RocketPy supports HRRR through a dedicated THREDDS shortcut.
-Like NAM and RAP, HRRR is a regional model over North America.
+Like NAM and RAP, HRRR is a regional model over North America, so you need to
+specify latitude and longitude points within its coverage area. The same
+SpacePort America coordinates used above will be reused here.
 
-If you have a HIRESW-compatible dataset from another provider (or a local copy),
-you can still load it explicitly by passing the path/URL in ``file`` and an
-appropriate mapping in ``dictionary``.
+.. code-block:: python
 
     env_hrrr = Environment(
-        date=now_plus_twelve,
+        date=tomorrow,
         latitude=32.988528,
         longitude=-106.975056,
     )

--- a/docs/user/motors/tanks.rst
+++ b/docs/user/motors/tanks.rst
@@ -104,7 +104,13 @@ The predefined ``CylindricalTank`` class is easy to use and is defined as such:
 
 .. jupyter-execute::
 
-  cylindrical_geometry = CylindricalTank(radius=0.1, height=2.0, spherical_caps=False)
+  cylindrical_geometry = CylindricalTank(radius_function=0.1, height=2.0, spherical_caps=False)
+
+.. deprecated:: 1.13.0
+  The ``radius`` keyword argument of ``CylindricalTank`` and ``SphericalTank``
+  has been renamed to ``radius_function``. Passing ``radius=`` still works but
+  now raises a ``DeprecationWarning`` and will be removed in v2.0.0. Use
+  ``radius_function=`` instead (it accepts the same constant radius value).
 
 .. note::
   The ``spherical_caps`` parameter is optional and defaults to ``False``. If set
@@ -116,7 +122,7 @@ The predefined ``SphericalTank`` is defined with:
 
 .. jupyter-execute::
 
-    spherical_geometry = SphericalTank(radius=0.1)
+    spherical_geometry = SphericalTank(radius_function=0.1)
 
 .. seealso::
   :class:`rocketpy.CylindricalTank` and :class:`rocketpy.SphericalTank`

--- a/docs/user/rocket/rocket_usage.rst
+++ b/docs/user/rocket/rocket_usage.rst
@@ -290,6 +290,17 @@ Optionally, we can also define:
 - The parachute trigger system lag ``lag``.
 - The parachute trigger system noise ``noise``.
 
+.. note::
+
+    Since v1.13.0, :class:`~rocketpy.Parachute` is an **abstract base class**
+    and can no longer be instantiated directly. Instead, instantiate a concrete
+    parachute model such as :class:`~rocketpy.HemisphericalParachute` (used
+    below), which derives its geometry-dependent quantities (e.g. the added
+    mass during descent) from the parachute ``radius`` and ``height``. As a
+    convenience shortcut, ``Rocket.add_parachute(...)`` can still be called with
+    keyword arguments (``name``, ``cd_s``, ``trigger``, ...) and will build a
+    hemispherical parachute for you.
+
 Lets add two parachutes to the rocket, one that will be deployed at
 apogee and another that will be deployed at 800 meters above ground level:
 
@@ -434,6 +445,18 @@ First, lets guarantee that the rocket is stable, by plotting the static margin:
 
     If it is unreasonably **high**, your rocket is **super stable** and the
     simulation will most likely **fail**.
+
+.. note::
+
+    RocketPy helps you catch this automatically: if the static margin is
+    **negative at motor ignition**, an
+    :class:`~rocketpy.exceptions.UnstableRocketWarning` is issued when the
+    rocket is used in a simulation. The check is skipped when the rocket has
+    any ``GenericSurface`` aerodynamic surfaces, since their lift coefficient
+    derivative is not accounted for in the center of pressure calculation,
+    which makes the static margin unreliable in that case. See
+    :doc:`/reference/classes/exceptions` for the full list of RocketPy
+    exceptions and warnings.
 
 The lets check all the information available about the rocket:
 

--- a/rocketpy/__init__.py
+++ b/rocketpy/__init__.py
@@ -1,5 +1,6 @@
 import logging
 
+from . import utils
 from .control import _Controller
 from .environment import Environment, EnvironmentAnalysis
 from .exceptions import (
@@ -56,7 +57,6 @@ from .rocket import (
     TrapezoidalFins,
 )
 from .sensitivity import SensitivityModel
-from . import utils
 from .sensors import Accelerometer, Barometer, GnssReceiver, Gyroscope
 from .simulation import Flight, MonteCarlo, MultivariateRejectionSampler
 from .stochastic import (

--- a/rocketpy/environment/environment.py
+++ b/rocketpy/environment/environment.py
@@ -4,7 +4,6 @@ import json
 import logging
 import re
 import warnings
-
 from collections import namedtuple
 from datetime import datetime
 

--- a/rocketpy/environment/environment_analysis.py
+++ b/rocketpy/environment/environment_analysis.py
@@ -4,7 +4,6 @@ import datetime
 import json
 import logging
 import warnings
-
 from collections import defaultdict
 from functools import cached_property
 

--- a/rocketpy/environment/tools.py
+++ b/rocketpy/environment/tools.py
@@ -7,7 +7,6 @@ future to improve their performance and usability.
 
 import logging
 import math
-
 import warnings
 
 import netCDF4

--- a/rocketpy/mathutils/function.py
+++ b/rocketpy/mathutils/function.py
@@ -8,7 +8,6 @@ carefully as it may impact all the rest of the project.
 import logging
 import operator
 import warnings
-
 from bisect import bisect_left
 from collections.abc import Iterable
 from copy import deepcopy

--- a/rocketpy/plots/aero_surface_plots.py
+++ b/rocketpy/plots/aero_surface_plots.py
@@ -3,7 +3,6 @@
 from abc import ABC, abstractmethod
 
 import matplotlib.pyplot as plt
-
 import numpy as np
 from matplotlib.patches import Ellipse
 

--- a/rocketpy/plots/compare/compare_flights.py
+++ b/rocketpy/plots/compare/compare_flights.py
@@ -6,7 +6,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from ..plot_helpers import show_or_save_fig, show_or_save_plot
-
 from .compare import Compare
 
 logger = logging.getLogger(__name__)

--- a/rocketpy/plots/flight_plots.py
+++ b/rocketpy/plots/flight_plots.py
@@ -5,7 +5,6 @@ from functools import cached_property
 from importlib import resources
 
 import matplotlib.pyplot as plt
-
 import numpy as np
 
 from ..mathutils import Function

--- a/rocketpy/plots/monte_carlo_plots.py
+++ b/rocketpy/plots/monte_carlo_plots.py
@@ -3,7 +3,6 @@ import urllib
 from pathlib import Path
 
 import matplotlib.pyplot as plt
-
 import numpy as np
 from matplotlib.transforms import offset_copy
 from PIL import UnidentifiedImageError

--- a/rocketpy/plots/rocket_plots.py
+++ b/rocketpy/plots/rocket_plots.py
@@ -2,7 +2,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from rocketpy.mathutils.vector_matrix import Vector
-
 from rocketpy.motors import HybridMotor, LiquidMotor, SolidMotor
 from rocketpy.rocket.aero_surface import Fin, Fins, NoseCone, Tail
 from rocketpy.rocket.aero_surface.generic_surface import GenericSurface

--- a/rocketpy/rocket/aero_surface/nose_cone.py
+++ b/rocketpy/rocket/aero_surface/nose_cone.py
@@ -2,7 +2,6 @@ import logging
 import warnings
 
 import numpy as np
-
 from scipy.optimize import fsolve
 
 from rocketpy.mathutils.function import Function

--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -3,13 +3,17 @@ import inspect
 import logging
 import math
 import warnings
-
 from typing import Iterable
 from warnings import warn
 
 import numpy as np
 
 from rocketpy.control.controller import _Controller
+from rocketpy.exceptions import (
+    InvalidInertiaError,
+    InvalidParameterError,
+    UnstableRocketWarning,
+)
 from rocketpy.mathutils.function import Function
 from rocketpy.mathutils.vector_matrix import Matrix, Vector
 from rocketpy.motors.empty_motor import EmptyMotor
@@ -29,11 +33,6 @@ from rocketpy.rocket.aero_surface.fins.free_form_fin import FreeFormFin
 from rocketpy.rocket.aero_surface.fins.free_form_fins import FreeFormFins
 from rocketpy.rocket.aero_surface.fins.trapezoidal_fin import TrapezoidalFin
 from rocketpy.rocket.aero_surface.generic_surface import GenericSurface
-from rocketpy.exceptions import (
-    InvalidInertiaError,
-    InvalidParameterError,
-    UnstableRocketWarning,
-)
 from rocketpy.rocket.components import Components
 from rocketpy.rocket.parachutes.hemispherical_parachute import HemisphericalParachute
 from rocketpy.rocket.parachutes.parachute import Parachute

--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -2,7 +2,6 @@
 import logging
 import math
 import warnings
-
 from copy import deepcopy
 from functools import cached_property
 

--- a/rocketpy/simulation/flight_data_exporter.py
+++ b/rocketpy/simulation/flight_data_exporter.py
@@ -6,7 +6,6 @@ import json
 import logging
 
 import numpy as np
-
 import simplekml
 
 logger = logging.getLogger(__name__)

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -16,7 +16,6 @@ import math
 import re
 import time
 import warnings
-
 from bisect import bisect_left
 
 import dill

--- a/rocketpy/utilities.py
+++ b/rocketpy/utilities.py
@@ -3,7 +3,6 @@ import json
 import logging
 import os
 import warnings
-
 from datetime import date
 from importlib.metadata import version
 from pathlib import Path

--- a/tests/integration/environment/test_environment.py
+++ b/tests/integration/environment/test_environment.py
@@ -1,6 +1,7 @@
 import time
 from datetime import date, datetime, timedelta, timezone
 from unittest.mock import patch
+
 import numpy as np
 import pytest
 

--- a/tests/integration/motors/test_ring_cluster_motor.py
+++ b/tests/integration/motors/test_ring_cluster_motor.py
@@ -1,7 +1,7 @@
 # pylint: disable=invalid-name
 import pytest
 import numpy as np
-from rocketpy import SolidMotor, Function
+from rocketpy import Flight, Function, Rocket, SolidMotor
 from rocketpy.motors.ring_cluster_motor import RingClusterMotor
 
 
@@ -137,3 +137,73 @@ def test_cluster_propellant_inertia_dynamic(base_motor):
 
     assert np.isclose(cluster.propellant_I_11(t), expected_ixx)  # pylint: disable=not-callable
     assert np.isclose(cluster.propellant_I_33(t), expected_izz)
+
+
+def test_ring_cluster_motor_full_flight(
+    calisto_motorless,
+    calisto_nose_cone,
+    calisto_tail,
+    calisto_trapezoidal_fins,
+    example_plain_env,
+):
+    """Integration test for PR #924: a ``RingClusterMotor`` must work
+    end-to-end when mounted on a ``Rocket`` and flown to apogee. The clustered
+    motor scales the base motor's thrust and total impulse by the number of
+    motors, and the rocket must reach a positive apogee.
+
+    A lightweight base motor is used on purpose so the Calisto airframe stays
+    aerodynamically stable (positive static margin) with the extra aft mass.
+    """
+    # Lightweight base motor so the clustered aft mass keeps the rocket stable.
+    base = SolidMotor(
+        thrust_source=lambda t: 800 if t < 3 else 0,
+        burn_time=3,
+        dry_mass=0.2,
+        dry_inertia=(0.01, 0.01, 0.001),
+        grain_number=1,
+        grain_density=1700,
+        grain_outer_radius=0.02,
+        grain_initial_inner_radius=0.01,
+        grain_initial_height=0.1,
+        nozzle_radius=0.01,
+        grain_separation=0.001,
+        grains_center_of_mass_position=0.1,
+        center_of_dry_mass_position=0.1,
+        coordinate_system_orientation="nozzle_to_combustion_chamber",
+    )
+    number = 2
+    cluster = RingClusterMotor(motor=base, number=number, radius=0.03)
+
+    # Clustered thrust / total impulse scale with the number of motors.
+    assert np.isclose(cluster.thrust(1), base.thrust(1) * number)
+    assert np.isclose(cluster.total_impulse, base.total_impulse * number)
+
+    rocket = calisto_motorless
+    rocket.add_motor(cluster, position=-1.373)
+    # Add all aerodynamic surfaces at once so the intermediate (fin-less) state
+    # is never evaluated as unstable during construction.
+    rocket.add_surfaces(
+        [calisto_nose_cone, calisto_tail, calisto_trapezoidal_fins],
+        [1.160, -1.313, -1.168],
+    )
+    rocket.set_rail_buttons(
+        upper_button_position=0.082,
+        lower_button_position=-0.618,
+        angular_position=0,
+    )
+
+    # The clustered motor keeps the rocket aerodynamically stable.
+    assert rocket.static_margin(0) > 0
+
+    flight = Flight(
+        rocket=rocket,
+        environment=example_plain_env,
+        rail_length=5.2,
+        inclination=85,
+        heading=0,
+        terminate_on_apogee=True,
+    )
+
+    assert flight.rocket.motor is cluster
+    assert flight.t_final > 0
+    assert flight.apogee > flight.env.elevation

--- a/tests/integration/motors/test_ring_cluster_motor.py
+++ b/tests/integration/motors/test_ring_cluster_motor.py
@@ -1,7 +1,8 @@
 # pylint: disable=invalid-name
-import pytest
 import numpy as np
-from rocketpy import Flight, Function, Rocket, SolidMotor
+import pytest
+
+from rocketpy import Flight, Function, SolidMotor
 from rocketpy.motors.ring_cluster_motor import RingClusterMotor
 
 

--- a/tests/integration/motors/test_solid_motor.py
+++ b/tests/integration/motors/test_solid_motor.py
@@ -56,3 +56,32 @@ def test_evaluate_geometry_updates_properties(cesaroni_m1670):
 
     # evaluate at intermediate time
     assert isinstance(motor.grain_inner_radius(0.5), float)
+
+
+def test_only_radial_burn_grain_geometry_time_evolution(cesaroni_m1670):
+    """Regression for PR #944 (corrected Jacobian of the ``only_radial_burn``
+    branch of ``evaluate_geometry``).
+
+    With radial-only burning the integrated grain geometry over the full burn
+    must have a constant grain height (no axial regression) and a monotonically
+    growing inner radius, bounded by the initial inner radius and the grain
+    outer radius. A wrong Jacobian corrupts this integration.
+    """
+    motor = cesaroni_m1670
+    motor.only_radial_burn = True
+    motor.evaluate_geometry()
+
+    times = np.linspace(0, motor.grain_burn_out, 30)
+    heights = np.array([motor.grain_height(t) for t in times])
+    radii = np.array([motor.grain_inner_radius(t) for t in times])
+
+    # Radial-only burn: grain height stays at its initial value the whole burn.
+    assert np.allclose(heights, motor.grain_initial_height, atol=1e-9)
+
+    # Inner radius grows monotonically (non-decreasing) and actually increases.
+    assert np.all(np.diff(radii) >= -1e-12)
+    assert radii[-1] > radii[0]
+
+    # Physical bounds on the inner radius.
+    assert np.isclose(radii[0], motor.grain_initial_inner_radius)
+    assert radii[-1] <= motor.grain_outer_radius + 1e-12

--- a/tests/integration/simulation/test_flight.py
+++ b/tests/integration/simulation/test_flight.py
@@ -916,3 +916,85 @@ def test_continuous_controller_invoked_every_step(calisto_robust, example_plain_
     assert calls["sampling_rates"] == {None}
     # And time-prefixed rows, consistent with the discrete controller path
     assert calls["row_len_matches"]
+
+
+def test_discrete_controller_invoked_once_per_node(calisto_robust, example_plain_env):
+    """Regression for PR #949 (remove duplicate controller process).
+
+    A discrete controller must be invoked exactly once per time node. The
+    removed duplicate loop invoked it a second time back-to-back with the
+    identical simulation time, so no consecutive controller call may share the
+    same time value.
+    """
+    times = []
+
+    def recording_controller(  # pylint: disable=unused-argument
+        time, sampling_rate, state, state_history, observed_variables, air_brakes
+    ):
+        times.append(time)
+
+    calisto_robust.parachutes = []
+    calisto_robust.add_air_brakes(
+        drag_coefficient_curve="data/rockets/calisto/air_brakes_cd.csv",
+        controller_function=recording_controller,
+        sampling_rate=10,  # discrete controller
+        clamp=True,
+    )
+
+    flight = Flight(
+        rocket=calisto_robust,
+        environment=example_plain_env,
+        rail_length=5.2,
+        inclination=85,
+        heading=0,
+        time_overshoot=False,
+        terminate_on_apogee=True,
+    )
+
+    assert flight.t_final > 0
+    assert len(times) > 10
+    # The duplicate-process bug produced two consecutive calls at the same time.
+    assert all(times[i] != times[i + 1] for i in range(len(times) - 1))
+    # No node time is processed more than once over the whole flight.
+    assert len(times) == len(set(times))
+
+
+def test_acceleration_based_parachute_trigger_deploys(
+    calisto_robust, example_plain_env
+):
+    """Integration test for PR #911: a parachute whose trigger consumes the
+    acceleration vector (a 4-argument trigger with a ``u_dot`` parameter) must
+    deploy during a full flight, exercising the u_dot code path end-to-end."""
+
+    def acc_trigger(p, h, y, u_dot):  # pylint: disable=unused-argument
+        # y[5] = vertical velocity; u_dot[5] = vertical acceleration.
+        # Deploy once descending with a downward acceleration (just past apogee).
+        return y[5] < 0 and u_dot[5] < 0
+
+    calisto_robust.parachutes = []
+    chute = HemisphericalParachute(
+        name="acc_chute",
+        cd_s=10.0,
+        trigger=acc_trigger,
+        sampling_rate=100,
+        lag=0,
+    )
+    calisto_robust.add_parachute(parachute=chute)
+
+    # Do NOT terminate at apogee: the flight must descend for the trigger to fire.
+    flight = Flight(
+        rocket=calisto_robust,
+        environment=example_plain_env,
+        rail_length=5.2,
+        inclination=85,
+        heading=0,
+    )
+
+    # The acceleration (u_dot) trigger path was selected for this trigger.
+    assert getattr(chute.triggerfunc, "_expects_udot", False)
+
+    # The chute deployed, and did so essentially at apogee (first downward accel).
+    assert len(flight.parachute_events) >= 1
+    deploy_time, deployed = flight.parachute_events[0]
+    assert deployed.name == "acc_chute"
+    assert abs(flight.z(deploy_time) - flight.apogee) <= 5

--- a/tests/unit/environment/test_environment_analysis.py
+++ b/tests/unit/environment/test_environment_analysis.py
@@ -161,3 +161,37 @@ def test_animation_plots(mock_show, env_analysis):  # pylint: disable=unused-arg
         HTML,
     )
     os.remove("wind_rose.gif")  # remove the files created by the method
+
+
+@pytest.mark.slow
+def test_pressure_level_wind_profile_uses_velocity_components(env_analysis):
+    """Regression for PR #1041: the redundant per-level ``wind_heading`` and
+    ``wind_direction`` functions were removed from the pressure-level data.
+
+    The surviving wind profile is expressed through ``wind_velocity_x`` /
+    ``wind_velocity_y`` (and ``wind_speed``), from which heading/direction are
+    derivable. This guards against re-introducing the removed entries and
+    checks that the surviving API is internally consistent.
+    """
+    data = env_analysis.original_pressure_level_data
+    first_date = next(iter(data))
+    first_hour = next(iter(data[first_date]))
+    hour_data = data[first_date][first_hour]
+
+    # Removed, redundant entries must not come back.
+    assert "wind_heading" not in hour_data
+    assert "wind_direction" not in hour_data
+
+    # Surviving, non-redundant wind-profile entries.
+    assert "wind_velocity_x" in hour_data
+    assert "wind_velocity_y" in hour_data
+    assert "wind_speed" in hour_data
+
+    # wind_speed must remain derivable from the velocity components. Sample at
+    # an actual grid node so interpolation and the sqrt() commute exactly.
+    grid_heights = hour_data["wind_speed"].x_array
+    height = float(grid_heights[len(grid_heights) // 2])
+    vx = hour_data["wind_velocity_x"](height)
+    vy = hour_data["wind_velocity_y"](height)
+    speed = hour_data["wind_speed"](height)
+    assert speed == pytest.approx((vx**2 + vy**2) ** 0.5, rel=1e-6)

--- a/tests/unit/mathutils/test_function.py
+++ b/tests/unit/mathutils/test_function.py
@@ -1529,3 +1529,29 @@ def test_2d_linear_interpolation_no_nan_outside_convex_hull():
         "f(0.3, 0.3) returned NaN. Point is outside the convex hull and "
         "should be routed to extrapolation, not silently return NaN."
     )
+
+
+def test_3d_linear_interpolation_no_nan_outside_convex_hull():
+    """Extend the convex-hull regression (issue #926) to three dimensions.
+
+    The fix in PR #969 targets N-dimensional linear interpolation, so a point
+    inside the axis-aligned bounding box but outside the convex hull must not
+    silently return NaN for 3D data either.
+    """
+    # Tetrahedron-like point cloud in the [0, 1]^3 bounding box.
+    data = [
+        [0.0, 0.0, 0.0, 0.0],
+        [1.0, 0.0, 0.0, 1.0],
+        [0.0, 1.0, 0.0, 1.0],
+        [0.0, 0.0, 1.0, 1.0],
+        [0.2, 0.2, 0.2, 0.6],
+    ]
+    func = Function(data, interpolation="linear")
+    # (0.9, 0.9, 0.9) is inside the bounding box but far outside the hull
+    # (its coordinates sum to 2.7, well beyond the x + y + z <= 1 face).
+    result = func(0.9, 0.9, 0.9)
+
+    assert not np.isnan(result), (
+        "f(0.9, 0.9, 0.9) returned NaN. Point is outside the 3D convex hull "
+        "and should be routed to extrapolation, not silently return NaN."
+    )

--- a/tests/unit/motors/test_genericmotor.py
+++ b/tests/unit/motors/test_genericmotor.py
@@ -440,3 +440,35 @@ def test_thrustcurve_api_cache_robustness(monkeypatch, tmp_path):  # pylint: dis
 
     with pytest.warns(UserWarning, match="Failed to read cached motor file"):
         GenericMotor.load_from_thrustcurve_api("M1670")
+
+
+def test_thrustcurve_api_requests_pass_timeout(monkeypatch, tmp_path):
+    """Regression for PR #940: every ThrustCurve API request must pass an
+    explicit (connect, read) timeout so the call cannot hang indefinitely."""
+    eng_path = "data/motors/cesaroni/Cesaroni_M1670.eng"
+    with open(eng_path, "rb") as f:
+        encoded = base64.b64encode(f.read()).decode("utf-8")
+
+    search_json = {"results": [{"motorId": "12345"}]}
+    download_json = {"results": [{"data": encoded}]}
+
+    captured_timeouts = []
+
+    def _capturing_get(url, **kwargs):
+        captured_timeouts.append(kwargs.get("timeout"))
+        if "search.json" in url:
+            return MockResponse(search_json)
+        if "download.json" in url:
+            return MockResponse(download_json)
+        raise RuntimeError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr(requests, "get", _capturing_get)
+    monkeypatch.setattr("rocketpy.motors.motor.CACHE_DIR", tmp_path)
+
+    GenericMotor.load_from_thrustcurve_api("M1670", no_cache=True)
+
+    assert captured_timeouts, "requests.get was never called"
+    assert all(t == (5, 30) for t in captured_timeouts), (
+        "Every ThrustCurve API request must use a (connect, read) timeout of "
+        f"(5, 30); captured timeouts were {captured_timeouts}"
+    )

--- a/tests/unit/rocket/test_parachute.py
+++ b/tests/unit/rocket/test_parachute.py
@@ -4,7 +4,7 @@ drag_coefficient parameters introduced in PR #889."""
 import numpy as np
 import pytest
 
-from rocketpy import HemisphericalParachute
+from rocketpy import HemisphericalParachute, Parachute
 
 
 def _make_parachute(**kwargs):
@@ -109,3 +109,26 @@ class TestParachuteSerialization:
         }
         parachute = HemisphericalParachute.from_dict(data)
         assert parachute.drag_coefficient == pytest.approx(1.4)
+
+
+class TestParachuteAbstractBase:
+    """After the PR #958 refactor, ``Parachute`` is an abstract base class and
+    users must instantiate a concrete model such as ``HemisphericalParachute``."""
+
+    def test_parachute_abstract_base_cannot_be_instantiated(self):
+        """Instantiating the abstract ``Parachute`` base directly must raise a
+        ``TypeError`` (unimplemented abstract methods)."""
+        with pytest.raises(TypeError, match="abstract"):
+            Parachute(
+                name="test",
+                cd_s=10.0,
+                trigger="apogee",
+                sampling_rate=100,
+            )
+
+    def test_hemispherical_parachute_is_a_parachute_subclass(self):
+        """The concrete ``HemisphericalParachute`` must derive from the abstract
+        ``Parachute`` base."""
+        assert issubclass(HemisphericalParachute, Parachute)
+        parachute = _make_parachute()
+        assert isinstance(parachute, Parachute)

--- a/tests/unit/rocket/test_parachute.py
+++ b/tests/unit/rocket/test_parachute.py
@@ -119,6 +119,8 @@ class TestParachuteAbstractBase:
         """Instantiating the abstract ``Parachute`` base directly must raise a
         ``TypeError`` (unimplemented abstract methods)."""
         with pytest.raises(TypeError, match="abstract"):
+            # pylint: disable=abstract-class-instantiated,unexpected-keyword-arg
+            # pylint: disable=no-value-for-parameter
             Parachute(
                 name="test",
                 cd_s=10.0,

--- a/tests/unit/rocket/test_rocket.py
+++ b/tests/unit/rocket/test_rocket.py
@@ -922,3 +922,35 @@ def test_unstable_rocket_warning_skipped_with_generic_surface(calisto):
         warnings.simplefilter("error", UnstableRocketWarning)
         calisto.add_surfaces([nose, generic_surface], [1.16, 0])
     assert calisto.static_margin(0) < 0
+
+
+def test_power_drag_exposed_as_function_objects_and_inputs_preserved():
+    """Regression for PR #941: ``power_off_drag``/``power_on_drag`` must be
+    exposed as Mach-only ``Function`` objects, while the raw user input is
+    preserved in the ``_power_off_drag_input``/``_power_on_drag_input``
+    attributes."""
+    off_input = "data/rockets/calisto/powerOffDragCurve.csv"
+    on_input = "data/rockets/calisto/powerOnDragCurve.csv"
+    rocket = Rocket(
+        radius=0.0635,
+        mass=14.426,
+        inertia=(6.321, 6.321, 0.034),
+        power_off_drag=off_input,
+        power_on_drag=on_input,
+        center_of_mass_without_motor=0,
+        coordinate_system_orientation="tail_to_nose",
+    )
+
+    # Public drag attributes are Function objects (Mach-only aliases).
+    assert isinstance(rocket.power_off_drag, Function)
+    assert isinstance(rocket.power_on_drag, Function)
+    assert rocket.power_off_drag(0.5) == pytest.approx(
+        rocket.power_off_drag_7d(0, 0, 0.5, 0, 0, 0, 0)
+    )
+    assert rocket.power_on_drag(0.5) == pytest.approx(
+        rocket.power_on_drag_7d(0, 0, 0.5, 0, 0, 0, 0)
+    )
+
+    # Raw user input is preserved for serialization / round-tripping.
+    assert rocket._power_off_drag_input == off_input
+    assert rocket._power_on_drag_input == on_input

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -448,10 +448,12 @@ class ConvergenceMockMonteCarlo(MonteCarlo):
         pass
 
     def simulate(self, number_of_simulations, append=True, **kwargs):
+        # pylint: disable=arguments-differ,unused-argument
         self.simulate_calls += 1
         self.num_of_loaded_sims = number_of_simulations
 
     def estimate_confidence_interval(self, attribute, confidence_level=0.95, **kwargs):
+        # pylint: disable=arguments-differ,unused-argument
         width = self._width_model(self.num_of_loaded_sims)
         return _CI(low=0.0, high=width)
 

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -1,5 +1,7 @@
 import csv
 import json
+import pathlib
+from collections import namedtuple
 
 import matplotlib as plt
 import numpy as np
@@ -423,3 +425,68 @@ def test_set_num_of_loaded_sims_json(tmp_path):
     mc.set_num_of_loaded_sims()
 
     assert mc.num_of_loaded_sims == 3
+
+
+# --- Adaptive Monte Carlo convergence (PR #922) ---
+
+_CI = namedtuple("_CI", ["low", "high"])
+
+
+class ConvergenceMockMonteCarlo(MonteCarlo):
+    """Mock that fakes batch simulation and a scripted confidence-interval
+    width, so ``simulate_convergence``'s stopping decision can be unit-tested
+    without running any real flight simulation."""
+
+    def __init__(self, width_model):
+        # pylint: disable=super-init-not-called
+        self.num_of_loaded_sims = 0
+        self.filename = pathlib.Path("dummy_mc")
+        self._width_model = width_model
+        self.simulate_calls = 0
+
+    def import_outputs(self, *args, **kwargs):  # no-op, avoids file I/O
+        pass
+
+    def simulate(self, number_of_simulations, append=True, **kwargs):
+        self.simulate_calls += 1
+        self.num_of_loaded_sims = number_of_simulations
+
+    def estimate_confidence_interval(self, attribute, confidence_level=0.95, **kwargs):
+        width = self._width_model(self.num_of_loaded_sims)
+        return _CI(low=0.0, high=width)
+
+
+def test_simulate_convergence_stops_early_when_tolerance_met():
+    """The convergence loop must stop as soon as the CI width drops below the
+    tolerance, well before reaching max_simulations."""
+    # width = 40 / n  ->  50 sims: 0.8 (> 0.5),  100 sims: 0.4 (<= 0.5) -> stop
+    mc = ConvergenceMockMonteCarlo(width_model=lambda n: 40.0 / n)
+
+    history = mc.simulate_convergence(
+        target_attribute="apogee_time",
+        tolerance=0.5,
+        max_simulations=1000,
+        batch_size=50,
+    )
+
+    assert history[-1] <= 0.5
+    assert len(history) == 2  # stopped after the second batch
+    assert mc.num_of_loaded_sims == 100
+    assert mc.num_of_loaded_sims < 1000  # did not exhaust the simulation budget
+
+
+def test_simulate_convergence_runs_until_max_when_not_converging():
+    """When the CI width never drops below the tolerance, the loop must run
+    until max_simulations and never exceed it."""
+    mc = ConvergenceMockMonteCarlo(width_model=lambda n: 10.0)  # constant, > tol
+
+    history = mc.simulate_convergence(
+        target_attribute="apogee_time",
+        tolerance=0.5,
+        max_simulations=200,
+        batch_size=50,
+    )
+
+    assert mc.num_of_loaded_sims == 200
+    assert all(width > 0.5 for width in history)
+    assert len(history) == 4  # 200 / 50 batches


### PR DESCRIPTION
## Summary

Documentation, `CHANGELOG.md` and test polish ahead of the next release (**v1.13.0**), auditing every PR merged since **v1.12.0**. This "dá um tapa" on the changelog and docs and backfills missing tests. A separate PR will do the end-to-end bug hunt.

## CHANGELOG reconciliation

**Added to `[Unreleased]` (were missing):**
- Individual Fins — `Fin`/`TrapezoidalFin`/`EllipticalFin`/`FreeFormFin` (#818)
- AIGFS and HRRR forecast models (#951)
- Duplicate controller process fix (#949)
- Valkyrie flight example (#967)

**Hygiene fixes:** de-duplicated #958/#966; moved #974 to *Fixed* and #1041 to *Removed* only; removed the already-released #914 duplicate; pointed the logging (#973) and ND-interp (#969) entries at their PRs instead of the issues.

**Backfilled the `[v1.12.0]` section** with #940 (ThrustCurve timeouts), #941 (`power_off/on_drag` as `Function` + `_input` attrs) and #944 (radial-burn Jacobian) — these shipped in v1.12.0 code but were never logged.

> Note on git topology: `develop` diverged from the release branch, so `git tag --contains` is misleading. Membership was verified by **content** (`git show v1.12.0:<file>`), which is how the already-released duplicates were identified.

## Documentation

- **New** exceptions reference page (`rocketpy.exceptions`) wired into the reference index; documented `UnstableRocketWarning` in the rocket stability docs (#970).
- `tanks.rst`: examples switched to `radius_function=` + deprecation note (#957).
- `forecast.rst`: fixed the HRRR example (missing code directive + stray copy-pasted sentence) (#951).
- `airbrakes.rst`: new "Discrete vs. Continuous Controllers" section explaining `sampling_rate=None` (#946).
- `rocket_usage.rst`: note that `Parachute` is now an abstract base; use `HemisphericalParachute` (#958).

## Tests

New regression tests (all passing): 3D ND-interp NaN outside convex hull (#969), abstract `Parachute` rejects instantiation (#958), Monte Carlo convergence stopping (#922), `EnvironmentAnalysis` surviving wind API (#1041), radial-burn grain geometry over time (#944), `RingClusterMotor` full flight (#924), discrete controller invoked exactly once per node (#949), acceleration-based parachute trigger deploys (#911). Plus backfill tests for ThrustCurve timeouts (#940) and drag `Function`/`_input` attributes (#941).

## Verification

- All new tests pass; the full modified test files (`test_function.py`, `test_rocket.py`, `test_parachute.py`, `test_genericmotor.py`, `test_monte_carlo.py`, `test_ring_cluster_motor.py`) pass with no regressions (`--runslow` included for the integration/env tests).
- Sphinx is not installed locally, so the HTML docs build runs in CI; RST changes were reviewed for correctness and the new `exceptions.rst` uses `automodule` on an importable module. The HRRR snippet was intentionally made a static `code-block` (not `jupyter-execute`) to avoid a network-dependent build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
