### PR TITLE
TST: Add unit tests for evaluate_reduced_mass and remove TODO

### DIFF
--- a/rocketpy/rocket/rocket.py
+++ b/rocketpy/rocket/rocket.py
@@ -612,7 +612,6 @@ class Rocket:
         self.reduced_mass : Function
             Function of time expressing the reduced mass of the rocket.
         """
-        # TODO: add tests for reduced_mass values
         # Make sure there is a motor associated with the rocket
         if self.motor is None:
             logger.warning("Please associate this rocket with a motor!")

--- a/tests/unit/rocket/test_rocket.py
+++ b/tests/unit/rocket/test_rocket.py
@@ -996,3 +996,52 @@ def test_power_drag_exposed_as_function_objects_and_inputs_preserved():
     # Raw user input is preserved for serialization / round-tripping.
     assert rocket._power_off_drag_input == off_input
     assert rocket._power_on_drag_input == on_input
+
+
+def test_evaluate_reduced_mass_without_motor(calisto_motorless):
+    """Test evaluate_reduced_mass returns False when there is no motor
+    associated with the rocket (self.motor is None).
+    """
+    # Arrange
+    rocket = calisto_motorless
+    rocket.motor = None
+
+    # Act
+    result = rocket.evaluate_reduced_mass()
+
+    # Assert
+    assert result is False
+
+
+def test_evaluate_reduced_mass_empty_motor(calisto_motorless):
+    """Test evaluate_reduced_mass returns a Function evaluating to 0 when
+    the motor is an EmptyMotor.
+    """
+    # Arrange
+    rocket = calisto_motorless
+
+    # Act
+    reduced_mass = rocket.evaluate_reduced_mass()
+
+    # Assert
+    assert isinstance(reduced_mass, Function)
+    assert reduced_mass(0) == pytest.approx(0)
+
+
+def test_evaluate_reduced_mass_with_motor(calisto):
+    """Test evaluate_reduced_mass returns the correct Function when a motor
+    is associated with the rocket.
+    """
+    # Arrange
+    rocket = calisto
+    dry_mass = rocket.dry_mass
+    prop_mass = rocket.motor.propellant_mass
+
+    # Act
+    reduced_mass = rocket.evaluate_reduced_mass()
+
+    # Assert
+    assert isinstance(reduced_mass, Function)
+    for t in [0.0, 1.0, 2.0, 3.0]:
+        expected = prop_mass(t) * dry_mass / (prop_mass(t) + dry_mass)
+        assert reduced_mass(t) == pytest.approx(expected)


### PR DESCRIPTION
## Context
This PR resolves a TODO comment in `rocketpy/rocket/rocket.py:615`: `# TODO: add tests for reduced_mass values`.

## Modifications Checklist
- [x] Remove the `# TODO: add tests for reduced_mass values` comment in `rocketpy/rocket/rocket.py`.
- [x] Add three unit tests in `tests/unit/rocket/test_rocket.py` to cover `evaluate_reduced_mass()` behavior:
  - `test_evaluate_reduced_mass_without_motor`: Verifies that calling `evaluate_reduced_mass()` when the motor is `None` returns `False`.
  - `test_evaluate_reduced_mass_empty_motor`: Verifies that calling `evaluate_reduced_mass()` when the motor is `EmptyMotor` returns a Function that evaluates to 0.
  - `test_evaluate_reduced_mass_with_motor`: Verifies that calling `evaluate_reduced_mass()` when a motor is associated returns a Function calculating the correct reduced mass.

## Expected Outcome
- The TODO comment is cleared.
- `evaluate_reduced_mass()` is fully covered by unit tests.
- All unit tests pass successfully.
