### PR TITLE
ENH: reproducible Monte Carlo via per-simulation-index seeding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Attention: The newest changes should be on top -->
 
 ### Added
 
+- ENH: Reproducible Monte Carlo through per-simulation-index seeding [#1054](https://github.com/RocketPy-Team/RocketPy/pull/1054) [#1053](https://github.com/RocketPy-Team/RocketPy/issues/1053)
 - ENH: Support fixed-time parachute deployment triggers [#1133](https://github.com/RocketPy-Team/RocketPy/pull/1133) [#437](https://github.com/RocketPy-Team/RocketPy/issues/437)
 - DOC: Add SIL parachute ejection integration example [#1131](https://github.com/RocketPy-Team/RocketPy/pull/1131) [#524](https://github.com/RocketPy-Team/RocketPy/issues/524)
 - ENH: List NOAA atmosphere datasets and fetch latest [#1136](https://github.com/RocketPy-Team/RocketPy/pull/1136) [#660](https://github.com/RocketPy-Team/RocketPy/issues/660)

--- a/docs/user/stochastic.rst
+++ b/docs/user/stochastic.rst
@@ -297,3 +297,7 @@ better reflecting the inherent uncertainties in rocketry.
     or split over any number of workers, and appending with the same seed
     carries the same stream on. Without it a run draws fresh entropy and
     reproduces nothing.
+
+    What an index fixes is the inputs it draws. A stochastic input reads its
+    nominal from the object it wraps, and a run moves that as it goes, so the
+    flight itself can still differ by which worker took the index.

--- a/docs/user/stochastic.rst
+++ b/docs/user/stochastic.rst
@@ -289,3 +289,11 @@ better reflecting the inherent uncertainties in rocketry.
 .. note::
     See the ``MonteCarlo`` class documentation for more information on how to run \
     Monte Carlo simulations with stochastic objects.
+
+.. note::
+    A whole run is fixed by ``MonteCarlo.simulate(random_seed=...)`` rather than
+    by seeding these models yourself. Each simulation takes its seed from its
+    own index, so simulation 7 draws the same inputs whether the run was serial
+    or split over any number of workers, and appending with the same seed
+    carries the same stream on. Without it a run draws fresh entropy and
+    reproduces nothing.

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -16,6 +16,7 @@ latest documentation.
 import csv
 import json
 import os
+import threading
 import traceback
 import warnings
 from copy import deepcopy
@@ -489,11 +490,10 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
         )
         sim_idx = sim_monitor.count
         try:
-            while sim_monitor.keep_simulating():
-                # Counted from zero, as the parallel path already does. The two
-                # named the same simulation differently: three of them wrote
-                # 1, 2, 3 here and 0, 1, 2 there.
-                sim_idx = sim_monitor.increment() - 1
+            # Counted from zero, as the parallel path already does: the two
+            # used to name the same simulation 1, 2, 3 and 0, 1, 2.
+            while (claimed := sim_monitor.claim_next_index()) is not None:
+                sim_idx = claimed
                 inputs_json, outputs_json = "", ""
 
                 self.__seed_this_simulation(sim_idx)
@@ -610,8 +610,7 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
             Event signaling an error occurred during the simulation.
         """
         try:
-            while sim_monitor.keep_simulating():
-                sim_idx = sim_monitor.increment() - 1
+            while (sim_idx := sim_monitor.claim_next_index()) is not None:
                 inputs_json, outputs_json = "", ""
 
                 self.__seed_this_simulation(sim_idx)
@@ -911,8 +910,6 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
             export_item: getattr(flight, export_item)
             for export_item in self.export_list
         }
-        outputs_dict["index"] = sim_idx
-
         if self.data_collector is not None:
             additional_exports = {}
             for key, callback in self.data_collector.items():
@@ -923,6 +920,9 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
                         f"An error was encountered running 'data_collector' callback {key}. "
                     ) from e
             outputs_dict = outputs_dict | additional_exports
+
+        # After the collectors, so one cannot take the row's own number.
+        outputs_dict["index"] = sim_idx
 
         return (
             json.dumps(outputs_dict, cls=RocketPyEncoder, **self._export_config) + "\n"
@@ -1899,13 +1899,20 @@ class _SimMonitor:
         self.n_simulations = n_simulations
         self.start_time = start_time
         self.completed_count = 0
+        self._claim = threading.Lock()  # proxy calls run in the manager
 
-    def keep_simulating(self):
-        return self.count < self.n_simulations
+    def claim_next_index(self):
+        """The next index to run, or None once every one has been claimed.
 
-    def increment(self):
-        self.count += 1
-        return self.count
+        One call, because a separate check and increment let two workers both
+        see the last slot free and then claim an index each past the end.
+        """
+        with self._claim:
+            if self.count >= self.n_simulations:
+                return None
+            claimed = self.count
+            self.count += 1
+            return claimed
 
     def print_update_status(self):
         """Prints a message on the same line as the previous one and replaces

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -413,14 +413,18 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
             n_simulations=self.number_of_simulations,
             start_time=time(),
         )
+        sim_idx = sim_monitor.count
         try:
             while sim_monitor.keep_simulating():
-                sim_monitor.increment()
+                # Counted from zero, as the parallel path already does. The two
+                # named the same simulation differently: three of them wrote
+                # 1, 2, 3 here and 0, 1, 2 there.
+                sim_idx = sim_monitor.increment() - 1
                 inputs_json, outputs_json = "", ""
 
                 flight = self.__run_single_simulation()
-                inputs_json = self.__evaluate_flight_inputs(sim_monitor.count)
-                outputs_json = self.__evaluate_flight_outputs(flight, sim_monitor.count)
+                inputs_json = self.__evaluate_flight_inputs(sim_idx)
+                outputs_json = self.__evaluate_flight_outputs(flight, sim_idx)
 
                 self._append_simulation_record(inputs_json, outputs_json)
 
@@ -434,7 +438,7 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
                 f.write(inputs_json)
 
         except Exception as error:
-            print(f"Error on iteration {sim_monitor.count}: {error}")
+            print(f"Error on iteration {sim_idx}: {error}")
             with open(self._error_file, "a", encoding="utf-8") as f:
                 f.write(inputs_json)
             raise error

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -339,6 +339,20 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
             number of workers will be equal to the number of CPUs available.
             A minimum of 2 workers is required for parallel mode.
             Default is None.
+        random_seed : int, sequence of int or numpy.random.SeedSequence, optional
+            Fixes what every simulation draws. Simulation ``i`` takes the same
+            inputs whichever way the run was split up, so serial and parallel
+            results agree and the number of workers does not reach the
+            sampling. Keyword-only. Default is None, which draws fresh entropy
+            and reproduces nothing.
+
+            Appending continues the same stream when the same seed is given
+            again, since an index maps to a seed and to nothing else. Nothing
+            here records the seed, so nothing here can tell you that a later
+            append was given the same one; that is #1075.
+
+            A ``Generator`` or ``BitGenerator`` is refused rather than read.
+            Pass the seed it was built from.
         kwargs : dict
             Custom arguments for simulation export of the ``inputs`` file. Options
             are:

--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -18,6 +18,7 @@ import json
 import os
 import traceback
 import warnings
+from copy import deepcopy
 from numbers import Real
 from pathlib import Path
 from time import time
@@ -31,6 +32,7 @@ from rocketpy.plots.monte_carlo_plots import _MonteCarloPlots
 from rocketpy.prints.monte_carlo_prints import _MonteCarloPrints
 from rocketpy.simulation.flight import Flight
 from rocketpy.tools import (
+    _seed_sequence_to_int,
     generate_monte_carlo_ellipses,
     generate_monte_carlo_ellipses_coordinates,
     import_optional_dependency,
@@ -42,6 +44,57 @@ from rocketpy.tools import (
 # simulate() writes one JSON object per line and reads that same shape back, so
 # this is the only format it can both resume from and overwrite safely.
 _SIMULATION_LOG_SUFFIX = ".txt"
+
+
+def _root_seed_sequence(random_seed):
+    """The immutable root a run derives every simulation's seed from.
+
+    A ``SeedSequence`` is rebuilt from its full state rather than used as
+    given, since ``spawn`` advances a counter the caller still holds. A
+    ``Generator`` is refused rather than read, because using a consume-on-use
+    object as an immutable seed cannot mean what it says.
+    """
+    if isinstance(random_seed, np.random.SeedSequence):
+        return np.random.SeedSequence(**random_seed.state)
+    if isinstance(random_seed, (np.random.Generator, np.random.BitGenerator)):
+        raise TypeError(
+            f"random_seed must be an int, a sequence of non-negative integers, "
+            f"or a numpy.random.SeedSequence, not a "
+            f"{type(random_seed).__name__}. Pass the seed the generator was "
+            f"built from."
+        )
+    return np.random.SeedSequence(random_seed)
+
+
+def _root_state_of(root):
+    """A root as the four picklable values a worker can rebuild it from.
+
+    Sent to each worker instead of the object, and instead of the list of
+    children, so a run of a million simulations costs four values. The entropy
+    is copied because a sequence one is kept by reference all the way from the
+    caller, who could otherwise still move every child by editing their list.
+    """
+    return (
+        deepcopy(root.entropy),
+        tuple(root.spawn_key),
+        root.pool_size,
+        root.n_children_spawned,
+    )
+
+
+def _seed_of_simulation(root_state, sim_idx):
+    """The seed for one simulation index, without spawning the ones before it.
+
+    ``spawn`` derives child ``i`` by appending ``n_children_spawned + i`` to
+    the parent spawn key, so rebuilding that one child directly reproduces it
+    and any index can be reached from the four values above alone.
+    """
+    entropy, spawn_key, pool_size, base = root_state
+    return np.random.SeedSequence(
+        entropy=entropy,
+        spawn_key=(*spawn_key, base + sim_idx),
+        pool_size=pool_size,
+    )
 
 
 def _refuse_logs_this_run_cannot_write(
@@ -265,6 +318,8 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
         append=False,
         parallel=False,
         n_workers=None,
+        *,
+        random_seed=None,
         **kwargs,
     ):
         """
@@ -317,6 +372,11 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
         self._export_config = kwargs
         self.number_of_simulations = number_of_simulations
         self._initial_sim_idx = self.num_of_loaded_sims if append else 0
+        # Validated here, before __setup_files truncates anything, so an
+        # unusable seed cannot cost a previous run its results. Kept as four
+        # picklable values rather than as the object, since a worker rebuilds
+        # any index from them.
+        self.__root_state = _root_state_of(_root_seed_sequence(random_seed))
 
         # Before anything is opened: __setup_files truncates for append=False.
         _refuse_logs_this_run_cannot_write(
@@ -422,6 +482,7 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
                 sim_idx = sim_monitor.increment() - 1
                 inputs_json, outputs_json = "", ""
 
+                self.__seed_this_simulation(sim_idx)
                 flight = self.__run_single_simulation()
                 inputs_json = self.__evaluate_flight_inputs(sim_idx)
                 outputs_json = self.__evaluate_flight_outputs(flight, sim_idx)
@@ -473,13 +534,14 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
             )
 
             processes = []
-            seeds = np.random.SeedSequence().spawn(n_workers)
 
-            for seed in seeds:
+            # No seed per worker any more: every simulation takes its own from
+            # its index, so the workers are interchangeable and how many there
+            # are does not reach the sampling.
+            for _ in range(n_workers):
                 sim_producer = multiprocess.Process(
                     target=self.__sim_producer,
                     args=(
-                        seed,
                         sim_monitor,
                         mutex,
                         simulation_error_event,
@@ -521,13 +583,11 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
             raise ValueError("Number of workers must be at least 2 for parallel mode.")
         return n_workers
 
-    def __sim_producer(self, seed, sim_monitor, mutex, error_event):  # pylint: disable=too-many-statements
+    def __sim_producer(self, sim_monitor, mutex, error_event):
         """Simulation producer to be used in parallel by multiprocessing.
 
         Parameters
         ----------
-        seed : int
-            The seed to set the random number generator.
         sim_monitor : _SimMonitor
             The simulation monitor object to keep track of the simulations.
         mutex : multiprocess.Lock
@@ -536,15 +596,11 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
             Event signaling an error occurred during the simulation.
         """
         try:
-            # Ensure Processes generate different random numbers
-            self.environment._set_stochastic(seed)
-            self.rocket._set_stochastic(seed)
-            self.flight._set_stochastic(seed)
-
             while sim_monitor.keep_simulating():
                 sim_idx = sim_monitor.increment() - 1
                 inputs_json, outputs_json = "", ""
 
+                self.__seed_this_simulation(sim_idx)
                 flight = self.__run_single_simulation()
                 inputs_json = self.__evaluate_flight_inputs(sim_idx)
                 outputs_json = self.__evaluate_flight_outputs(flight, sim_idx)
@@ -583,6 +639,20 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
             )
             error_event.set()
             mutex.release()
+
+    def __seed_this_simulation(self, sim_idx):
+        """Reseed the three models from this index's own child of the root.
+
+        Per index rather than per worker, which is what makes a simulation's
+        inputs the same however the run was split up. The child is split three
+        ways so the environment, rocket and flight draw independently instead
+        of sharing one stream.
+        """
+        child = _seed_of_simulation(self.__root_state, sim_idx)
+        environment, rocket, flight = child.spawn(3)
+        self.environment._set_stochastic(_seed_sequence_to_int(environment))
+        self.rocket._set_stochastic(_seed_sequence_to_int(rocket))
+        self.flight._set_stochastic(_seed_sequence_to_int(flight))
 
     def __run_single_simulation(self):
         """Runs a single simulation and returns the inputs and outputs.

--- a/rocketpy/stochastic/stochastic_model.py
+++ b/rocketpy/stochastic/stochastic_model.py
@@ -8,7 +8,7 @@ import numpy as np
 from rocketpy.mathutils.function import Function
 from rocketpy.stochastic.custom_sampler import CustomSampler
 
-from ..tools import get_distribution
+from ..tools import _seed_sequence_to_int, get_distribution
 
 
 def _names_as_spawn_key(input_names):
@@ -41,6 +41,18 @@ def _format_number(value):
     return f"array of shape {np.shape(value)}"
 
 
+def _seed_as_entropy(seed):
+    """A seed as something ``SeedSequence`` will take as entropy.
+
+    A parallel run is handed a ``SeedSequence``, which it will not take. Any
+    other seed goes through untouched, so the stream an int reaches stays where
+    it was.
+    """
+    if not isinstance(seed, np.random.SeedSequence):
+        return seed
+    return _seed_sequence_to_int(seed)
+
+
 def _sampler_seed(seed, input_names):
     """Derive a seed for one sampler, or for one group that shares a generator.
 
@@ -54,10 +66,10 @@ def _sampler_seed(seed, input_names):
     # Sorted here rather than trusting the caller, so a future call site cannot
     # give one group two different seeds by listing its members another way.
     root = np.random.SeedSequence(
-        entropy=seed, spawn_key=_names_as_spawn_key(tuple(sorted(input_names)))
+        entropy=_seed_as_entropy(seed),
+        spawn_key=_names_as_spawn_key(tuple(sorted(input_names))),
     )
-    words = root.generate_state(4, dtype=np.uint32)
-    return sum(int(word) << (32 * position) for position, word in enumerate(words))
+    return _seed_sequence_to_int(root)
 
 
 # TODO: Stop using assert in production code. Use exceptions instead.

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -1377,6 +1377,17 @@ def euler313_to_quaternions(phi, theta, psi):
     return e0, e1, e2, e3
 
 
+def _seed_sequence_to_int(seed_sequence):
+    """Returns a ``SeedSequence`` as the 128-bit ``int`` it can be rebuilt from.
+
+    Folded through ``generate_state`` rather than read off ``entropy``, since
+    the children of one root differ only by ``spawn_key``, and combined by
+    value so it does not depend on byte order.
+    """
+    words = seed_sequence.generate_state(4, dtype=np.uint32)
+    return sum(int(word) << (32 * position) for position, word in enumerate(words))
+
+
 def get_matplotlib_supported_file_endings():
     """Gets the file endings supported by matplotlib.
 

--- a/tests/unit/simulation/test_monte_carlo_parallel_runs.py
+++ b/tests/unit/simulation/test_monte_carlo_parallel_runs.py
@@ -1,0 +1,32 @@
+import pytest
+
+from rocketpy.simulation.monte_carlo import MonteCarlo
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_a_monte_carlo_run_finishes(
+    stochastic_environment, stochastic_calisto, stochastic_flight, tmp_path, parallel
+):
+    # The parallel path hands each worker a SeedSequence rather than an int, and
+    # nothing else in the suite exercises that. A worker that dies on it is not
+    # reported, so this reads as a hang rather than as a failure.
+    #
+    # Built here rather than taken from the monte_carlo_calisto fixture, whose
+    # own filename is fixed, since `filename` is a plain attribute and the three
+    # working paths are settled when the object is constructed.
+    analysis = MonteCarlo(
+        filename=str(tmp_path / "study"),
+        environment=stochastic_environment,
+        rocket=stochastic_calisto,
+        flight=stochastic_flight,
+    )
+
+    analysis.simulate(
+        number_of_simulations=2,
+        append=False,
+        parallel=parallel,
+        n_workers=2 if parallel else None,
+    )
+
+    assert analysis.num_of_loaded_sims == 2
+    assert str(tmp_path) in str(analysis.output_file)

--- a/tests/unit/simulation/test_monte_carlo_seeding.py
+++ b/tests/unit/simulation/test_monte_carlo_seeding.py
@@ -12,10 +12,30 @@ from rocketpy.simulation.monte_carlo import (
 )
 
 
+def _without_object_identity(value):
+    """The same record with every ``hash`` dropped, at any depth.
+
+    ``RocketPyEncoder`` records ``hash(obj)`` beside a serialized ``Function``,
+    and that is the object's identity in the process that wrote it, not
+    anything that was drawn. It agrees between two runs that share memory and
+    differs between two that do not, which is a property of the start method
+    rather than of the seed.
+    """
+    if isinstance(value, dict):
+        return {
+            key: _without_object_identity(item)
+            for key, item in value.items()
+            if key != "hash"
+        }
+    if isinstance(value, list):
+        return [_without_object_identity(item) for item in value]
+    return value
+
+
 def _sampled_inputs(analysis):
     with open(analysis.input_file, "r", encoding="utf-8") as written:
         rows = [json.loads(line) for line in written if line.strip()]
-    return {row["index"]: row for row in rows}
+    return {row["index"]: _without_object_identity(row) for row in rows}
 
 
 def _a_run(tmp_path, stem, models, *, parallel=False, workers=None, seed=None, count=4):

--- a/tests/unit/simulation/test_monte_carlo_seeding.py
+++ b/tests/unit/simulation/test_monte_carlo_seeding.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+import multiprocess
 import numpy as np
 import pytest
 
@@ -12,30 +13,32 @@ from rocketpy.simulation.monte_carlo import (
 )
 
 
-def _without_object_identity(value):
-    """The same record with every ``hash`` dropped, at any depth.
+def _what_was_drawn(value):
+    """The same record without the parts that say which process wrote it.
 
-    ``RocketPyEncoder`` records ``hash(obj)`` beside a serialized ``Function``,
-    and that is the object's identity in the process that wrote it, not
-    anything that was drawn. It agrees between two runs that share memory and
-    differs between two that do not, which is a property of the start method
-    rather than of the seed.
+    Two of the fields a serialized ``Function`` carries are properties of the
+    writer rather than of the draw. ``hash`` is the object's identity in that
+    process. A callable ``source`` is its pickle, and the same callable pickles
+    to different bytes under ``spawn``: measured on one drag curve, the parent
+    and a forked child agree and a spawned child does not, for a value the
+    fixture does not vary at all. Everything a run actually draws is numeric
+    and stays.
     """
     if isinstance(value, dict):
         return {
-            key: _without_object_identity(item)
+            key: _what_was_drawn(item)
             for key, item in value.items()
-            if key != "hash"
+            if key != "hash" and not (key == "source" and isinstance(item, str))
         }
     if isinstance(value, list):
-        return [_without_object_identity(item) for item in value]
+        return [_what_was_drawn(item) for item in value]
     return value
 
 
 def _sampled_inputs(analysis):
     with open(analysis.input_file, "r", encoding="utf-8") as written:
         rows = [json.loads(line) for line in written if line.strip()]
-    return {row["index"]: _without_object_identity(row) for row in rows}
+    return {row["index"]: _what_was_drawn(row) for row in rows}
 
 
 def _a_run(tmp_path, stem, models, *, parallel=False, workers=None, seed=None, count=4):
@@ -175,3 +178,30 @@ def test_an_appended_run_carries_the_same_stream_on(models, tmp_path):
     part.simulate(4, append=True, random_seed=42)
 
     assert _sampled_inputs(part) == _sampled_inputs(whole)
+
+
+@pytest.fixture(name="spawned_workers")
+def _spawned_workers():
+    """Start workers the way Windows does, wherever the test happens to run."""
+    was = multiprocess.get_start_method()
+    multiprocess.set_start_method("spawn", force=True)
+    yield
+    multiprocess.set_start_method(was, force=True)
+
+
+@pytest.mark.usefixtures("spawned_workers")
+@pytest.mark.skipif(os.cpu_count() < 4, reason="needs four workers to be four")
+def test_an_index_keeps_its_inputs_when_the_workers_are_spawned(models, tmp_path):
+    """The same guarantee on the start method Windows uses.
+
+    A spawned child rebuilds the models by unpickling rather than inheriting
+    them, so this is a different question from the one above and was worth
+    asking separately: the first version of these tests compared serialized
+    callables, which differ between processes for a value nothing varies.
+    """
+    serial = _a_run(tmp_path, "serial", models, seed=42)
+    two = _a_run(tmp_path, "two", models, parallel=True, workers=2, seed=42)
+    four = _a_run(tmp_path, "four", models, parallel=True, workers=4, seed=42)
+
+    assert _sampled_inputs(serial) == _sampled_inputs(two)
+    assert _sampled_inputs(serial) == _sampled_inputs(four)

--- a/tests/unit/simulation/test_monte_carlo_seeding.py
+++ b/tests/unit/simulation/test_monte_carlo_seeding.py
@@ -1,5 +1,6 @@
 import json
 import os
+from time import time
 
 import multiprocess
 import numpy as np
@@ -10,6 +11,7 @@ from rocketpy.simulation.monte_carlo import (
     _root_seed_sequence,
     _root_state_of,
     _seed_of_simulation,
+    _SimMonitor,
 )
 
 
@@ -205,3 +207,46 @@ def test_an_index_keeps_its_inputs_when_the_workers_are_spawned(models, tmp_path
 
     assert _sampled_inputs(serial) == _sampled_inputs(two)
     assert _sampled_inputs(serial) == _sampled_inputs(four)
+
+
+class _ALockNobodyContends:
+    """The manager's mutex, with only this process to hand it to."""
+
+    def acquire(self):
+        pass
+
+    def release(self):
+        pass
+
+
+class _AnEventNobodySet:
+    """The failure event, which nothing in a clean run reaches for."""
+
+    def is_set(self):
+        return False
+
+    def set(self):
+        raise AssertionError("the producer reported a failure")
+
+
+def test_a_worker_loop_draws_the_study_serial_draws(models, tmp_path):
+    """The loop a worker runs, driven here, produces the run serial produces."""
+    # Every other check of this starts a child process, where the same code
+    # runs and nothing in the test can watch it.
+    serial = _a_run(tmp_path, "serial", models, seed=42, count=4)
+    environment, rocket, flight = models
+    worker = MonteCarlo(
+        filename=str(tmp_path / "worker"),
+        environment=environment,
+        rocket=rocket,
+        flight=flight,
+    )
+    worker.simulate(number_of_simulations=0, append=False, random_seed=42)
+
+    worker._MonteCarlo__sim_producer(
+        _SimMonitor(initial_count=0, n_simulations=4, start_time=time()),
+        _ALockNobodyContends(),
+        _AnEventNobodySet(),
+    )
+
+    assert _sampled_inputs(worker) == _sampled_inputs(serial)

--- a/tests/unit/simulation/test_monte_carlo_seeding.py
+++ b/tests/unit/simulation/test_monte_carlo_seeding.py
@@ -1,0 +1,157 @@
+import json
+import os
+
+import numpy as np
+import pytest
+
+from rocketpy.simulation.monte_carlo import (
+    MonteCarlo,
+    _root_seed_sequence,
+    _root_state_of,
+    _seed_of_simulation,
+)
+
+
+def _sampled_inputs(analysis):
+    with open(analysis.input_file, "r", encoding="utf-8") as written:
+        rows = [json.loads(line) for line in written if line.strip()]
+    return {row["index"]: row for row in rows}
+
+
+def _a_run(tmp_path, stem, models, *, parallel=False, workers=None, seed=None, count=4):
+    environment, rocket, flight = models
+    analysis = MonteCarlo(
+        filename=str(tmp_path / stem),
+        environment=environment,
+        rocket=rocket,
+        flight=flight,
+    )
+    analysis.simulate(
+        number_of_simulations=count,
+        append=False,
+        parallel=parallel,
+        n_workers=workers,
+        random_seed=seed,
+    )
+    return analysis
+
+
+@pytest.fixture(name="models")
+def _models(stochastic_environment, stochastic_calisto, stochastic_flight):
+    return stochastic_environment, stochastic_calisto, stochastic_flight
+
+
+# --------------------------------------------------------------- the derivation
+
+
+@pytest.mark.parametrize("seed", [42, None, [1, 2, 3], np.random.SeedSequence(7)])
+def test_a_simulation_gets_the_child_spawn_would_have_given_it(seed):
+    # The whole point of deriving one index directly: it has to be the same
+    # child, bit for bit, as spawning every index before it would produce.
+    root = _root_seed_sequence(seed)
+    state = _root_state_of(root)
+    spawned = np.random.SeedSequence(**root.state).spawn(6)
+
+    for index, expected in enumerate(spawned):
+        assert np.array_equal(
+            expected.generate_state(4),
+            _seed_of_simulation(state, index).generate_state(4),
+        )
+
+
+def test_deriving_an_index_costs_nothing_for_the_ones_before_it():
+    state = _root_state_of(_root_seed_sequence(42))
+
+    far = _seed_of_simulation(state, 1_000_000)
+
+    assert far.spawn_key == (1_000_000,)
+
+
+def test_two_indices_do_not_share_a_stream():
+    state = _root_state_of(_root_seed_sequence(42))
+
+    first = _seed_of_simulation(state, 0).generate_state(4)
+    second = _seed_of_simulation(state, 1).generate_state(4)
+
+    assert not np.array_equal(first, second)
+
+
+# ------------------------------------------------------------------- the root
+
+
+def test_a_caller_seed_sequence_is_not_consumed():
+    given = np.random.SeedSequence(42)
+
+    _root_seed_sequence(given).spawn(5)
+
+    assert given.n_children_spawned == 0
+
+
+def test_a_caller_cannot_move_the_run_by_editing_the_list_it_passed():
+    # SeedSequence keeps a sequence entropy by reference, so without a copy of
+    # its own the run would follow whatever the caller did to that list next.
+    given = [1, 2, 3]
+    state = _root_state_of(_root_seed_sequence(given))
+
+    before = _seed_of_simulation(state, 0).generate_state(4)
+    given[0] = 999
+
+    assert np.array_equal(_seed_of_simulation(state, 0).generate_state(4), before)
+
+
+@pytest.mark.parametrize("given", [np.random.default_rng(42), np.random.PCG64(42)])
+def test_a_generator_is_refused_rather_than_read(given):
+    # Using a consume-on-use object as an immutable seed cannot mean what it
+    # says, so it is refused instead of quietly meaning something else.
+    with pytest.raises(TypeError, match="random_seed must be"):
+        _root_seed_sequence(given)
+
+
+def test_an_unusable_seed_costs_the_previous_run_nothing(models, tmp_path):
+    analysis = _a_run(tmp_path, "study", models, seed=42, count=2)
+    kept = _sampled_inputs(analysis)
+
+    with pytest.raises(TypeError):
+        analysis.simulate(2, append=False, random_seed=np.random.default_rng(1))
+
+    assert _sampled_inputs(analysis) == kept
+
+
+# ------------------------------------------------------------- what a run gives
+
+
+def test_one_seed_gives_one_set_of_inputs(models, tmp_path):
+    first = _a_run(tmp_path, "first", models, seed=42)
+    again = _a_run(tmp_path, "again", models, seed=42)
+
+    assert _sampled_inputs(first) == _sampled_inputs(again)
+
+
+def test_another_seed_gives_another_set(models, tmp_path):
+    # The control. Without this the test above passes on a run that ignores
+    # the seed entirely.
+    first = _a_run(tmp_path, "first", models, seed=42)
+    other = _a_run(tmp_path, "other", models, seed=7)
+
+    assert _sampled_inputs(first) != _sampled_inputs(other)
+
+
+@pytest.mark.skipif(os.cpu_count() < 4, reason="needs four workers to be four")
+def test_an_index_gets_the_same_inputs_however_the_run_was_split(models, tmp_path):
+    # This is the guarantee. Splitting the work differently must not change
+    # what any one simulation drew.
+    serial = _a_run(tmp_path, "serial", models, seed=42)
+    two = _a_run(tmp_path, "two", models, parallel=True, workers=2, seed=42)
+    four = _a_run(tmp_path, "four", models, parallel=True, workers=4, seed=42)
+
+    assert _sampled_inputs(serial) == _sampled_inputs(two)
+    assert _sampled_inputs(serial) == _sampled_inputs(four)
+
+
+def test_an_appended_run_carries_the_same_stream_on(models, tmp_path):
+    whole = _a_run(tmp_path, "whole", models, seed=42, count=4)
+
+    part = _a_run(tmp_path, "part", models, seed=42, count=2)
+    part.simulate(4, append=True, random_seed=42)
+
+    assert _sampled_inputs(part) == _sampled_inputs(whole)

--- a/tests/unit/simulation/test_monte_carlo_simulation_index.py
+++ b/tests/unit/simulation/test_monte_carlo_simulation_index.py
@@ -1,8 +1,10 @@
 import json
+import threading
+from time import time
 
 import pytest
 
-from rocketpy.simulation.monte_carlo import MonteCarlo
+from rocketpy.simulation.monte_carlo import MonteCarlo, _SimMonitor
 
 
 def _indices(analysis):
@@ -111,3 +113,56 @@ def test_a_serial_failure_names_the_simulation_the_way_parallel_would(
         analysis.simulate(number_of_simulations=3, append=False)
 
     assert "Error on iteration 1:" in capsys.readouterr().out
+
+
+def test_claim_next_index_hands_out_each_index_once():
+    """Claimers racing each other get range(n) between them and nothing past it."""
+    n_simulations, n_claimers = 200, 8
+    monitor = _SimMonitor(0, n_simulations, time())
+    ready = threading.Barrier(n_claimers)
+    guard = threading.Lock()
+    claimed = []
+
+    def claim_until_empty():
+        ready.wait()
+        mine = []
+        while (index := monitor.claim_next_index()) is not None:
+            mine.append(index)
+        with guard:
+            claimed.extend(mine)
+
+    workers = [threading.Thread(target=claim_until_empty) for _ in range(n_claimers)]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join()
+
+    assert len(claimed) == n_simulations
+    assert len(set(claimed)) == n_simulations
+    assert sorted(claimed) == list(range(n_simulations))
+    assert max(claimed) < n_simulations
+
+
+def test_claim_next_index_is_empty_once_the_target_is_reached():
+    """The control: a checkpoint that already holds the target claims nothing."""
+    monitor = _SimMonitor(3, 3, time())
+
+    assert monitor.claim_next_index() is None
+    assert monitor.count == 3
+
+
+def test_a_collector_cannot_take_over_the_simulation_index(
+    stochastic_environment, stochastic_calisto, stochastic_flight, tmp_path
+):
+    """The index names the seed a row was drawn with, so nothing else sets it."""
+    # Set past the constructor, so this pins the row and not the validation.
+    analysis = _a_study(
+        tmp_path, "study", stochastic_environment, stochastic_calisto, stochastic_flight
+    )
+    analysis.export_list = []
+    analysis._export_config = {}
+    analysis.data_collector = {"index": lambda _flight: 999}
+
+    row = json.loads(analysis._MonteCarlo__evaluate_flight_outputs(None, 7))
+
+    assert row["index"] == 7

--- a/tests/unit/simulation/test_monte_carlo_simulation_index.py
+++ b/tests/unit/simulation/test_monte_carlo_simulation_index.py
@@ -161,6 +161,8 @@ def test_a_collector_cannot_take_over_the_simulation_index(
     )
     analysis.export_list = []
     analysis._export_config = {}
+    # The row also carries which root drew it, which simulate() would have set.
+    analysis._MonteCarlo__root_state = (42, (), 4, 0)
     analysis.data_collector = {"index": lambda _flight: 999}
 
     row = json.loads(analysis._MonteCarlo__evaluate_flight_outputs(None, 7))

--- a/tests/unit/simulation/test_monte_carlo_simulation_index.py
+++ b/tests/unit/simulation/test_monte_carlo_simulation_index.py
@@ -1,0 +1,76 @@
+import json
+
+import pytest
+
+from rocketpy.simulation.monte_carlo import MonteCarlo
+
+
+def _indices(analysis):
+    with open(analysis.output_file, "r", encoding="utf-8") as written:
+        return sorted(json.loads(line)["index"] for line in written if line.strip())
+
+
+def _a_study(tmp_path, stem, environment, rocket, flight):
+    return MonteCarlo(
+        filename=str(tmp_path / stem),
+        environment=environment,
+        rocket=rocket,
+        flight=flight,
+    )
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_a_run_numbers_its_simulations_from_zero(
+    stochastic_environment, stochastic_calisto, stochastic_flight, tmp_path, parallel
+):
+    # Serial used to write 1, 2, 3 while parallel wrote 0, 1, 2, so the same
+    # simulation had two names depending on how the run was started.
+    analysis = _a_study(
+        tmp_path,
+        f"study-{parallel}",
+        stochastic_environment,
+        stochastic_calisto,
+        stochastic_flight,
+    )
+
+    analysis.simulate(
+        number_of_simulations=3,
+        append=False,
+        parallel=parallel,
+        n_workers=2 if parallel else None,
+    )
+
+    assert _indices(analysis) == [0, 1, 2]
+
+
+def test_both_modes_agree_on_what_a_simulation_is_called(
+    stochastic_environment, stochastic_calisto, stochastic_flight, tmp_path
+):
+    one = _a_study(
+        tmp_path,
+        "serial",
+        stochastic_environment,
+        stochastic_calisto,
+        stochastic_flight,
+    )
+    other = _a_study(
+        tmp_path, "para", stochastic_environment, stochastic_calisto, stochastic_flight
+    )
+
+    one.simulate(number_of_simulations=3, append=False, parallel=False)
+    other.simulate(number_of_simulations=3, append=False, parallel=True, n_workers=2)
+
+    assert _indices(one) == _indices(other)
+
+
+def test_an_appended_run_carries_on_from_the_last_index(
+    stochastic_environment, stochastic_calisto, stochastic_flight, tmp_path
+):
+    analysis = _a_study(
+        tmp_path, "study", stochastic_environment, stochastic_calisto, stochastic_flight
+    )
+
+    analysis.simulate(number_of_simulations=2, append=False)
+    analysis.simulate(number_of_simulations=4, append=True)
+
+    assert _indices(analysis) == [0, 1, 2, 3]

--- a/tests/unit/simulation/test_monte_carlo_simulation_index.py
+++ b/tests/unit/simulation/test_monte_carlo_simulation_index.py
@@ -74,3 +74,40 @@ def test_an_appended_run_carries_on_from_the_last_index(
     analysis.simulate(number_of_simulations=4, append=True)
 
     assert _indices(analysis) == [0, 1, 2, 3]
+
+
+def test_a_serial_failure_names_the_simulation_the_way_parallel_would(
+    stochastic_environment,
+    stochastic_calisto,
+    stochastic_flight,
+    tmp_path,
+    monkeypatch,
+    capsys,
+):
+    """A run that fails reports the index the other mode would have used."""
+    # The message is the only place the numbering reaches whoever ran it, so
+    # it can disagree with the logs without anything else noticing.
+    analysis = _a_study(
+        tmp_path,
+        "failing",
+        stochastic_environment,
+        stochastic_calisto,
+        stochastic_flight,
+    )
+    attempts = []
+    ran = MonteCarlo._MonteCarlo__run_single_simulation
+
+    def fails_on_the_second(self):
+        attempts.append(None)
+        if len(attempts) == 2:
+            raise RuntimeError("the flight would not run")
+        return ran(self)
+
+    monkeypatch.setattr(
+        MonteCarlo, "_MonteCarlo__run_single_simulation", fails_on_the_second
+    )
+
+    with pytest.raises(RuntimeError, match="the flight would not run"):
+        analysis.simulate(number_of_simulations=3, append=False)
+
+    assert "Error on iteration 1:" in capsys.readouterr().out

--- a/tests/unit/stochastic/test_seed_types.py
+++ b/tests/unit/stochastic/test_seed_types.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+
+from rocketpy.stochastic.stochastic_model import (
+    _names_as_spawn_key,
+    _sampler_seed,
+)
+from rocketpy.tools import _seed_sequence_to_int
+
+
+def _a_worker_seed(index=0, workers=2):
+    # What MonteCarlo.__run_in_parallel spawns and hands to each worker, which
+    # passes it straight to environment/rocket/flight._set_stochastic.
+    return np.random.SeedSequence().spawn(workers)[index]
+
+
+def test_the_seed_type_a_worker_is_handed_is_accepted(stochastic_calisto):
+    stochastic_calisto._set_stochastic(_a_worker_seed())
+
+    stochastic_calisto.create_object()
+
+
+def test_a_parachute_derives_its_noise_seed_from_a_worker_seed(
+    stochastic_main_parachute,
+):
+    stochastic_main_parachute._set_stochastic(_a_worker_seed())
+
+    assert stochastic_main_parachute.create_object().noise[2] is not None
+
+
+def test_two_workers_do_not_share_a_sampler_stream():
+    first, second = np.random.SeedSequence(7).spawn(2)
+    # They come off one root, so they carry the same entropy and differ only in
+    # spawn_key. Reading the entropy alone would put both on one stream.
+    assert first.entropy == second.entropy
+
+    assert _sampler_seed(first, ("__list_choice__",)) != _sampler_seed(
+        second, ("__list_choice__",)
+    )
+
+
+def test_a_caller_seed_sequence_is_not_consumed():
+    root = np.random.SeedSequence(42)
+
+    _sampler_seed(root, ("__list_choice__",))
+
+    assert root.n_children_spawned == 0
+    assert root.spawn(1)[0].spawn_key == (0,)
+
+
+def test_the_same_seed_sequence_twice_gives_the_same_sampler_seed():
+    root = np.random.SeedSequence(42)
+
+    first = _sampler_seed(root, ("pressure_noise", "main"))
+    second = _sampler_seed(root, ("pressure_noise", "main"))
+
+    assert first == second
+
+
+@pytest.mark.parametrize("seed", [42, 7, [1, 2, 3]])
+@pytest.mark.parametrize("names", [("__list_choice__",), ("pressure_noise", "main")])
+def test_a_seed_that_is_not_a_sequence_reaches_numpy_untouched(seed, names):
+    # The control. Every fixed-seed baseline in the suite was recorded through
+    # this path, so anything but a SeedSequence has to arrive as it always did.
+    # Compared with the expression rather than with a recorded number, which
+    # would go red on a NumPy release instead of on a change of ours.
+    unchanged = np.random.SeedSequence(
+        entropy=seed, spawn_key=_names_as_spawn_key(tuple(sorted(names)))
+    )
+
+    assert _sampler_seed(seed, names) == _seed_sequence_to_int(unchanged)
+
+
+def test_no_seed_still_means_no_seed():
+    # None is left out above on purpose: it asks NumPy for fresh entropy, so
+    # two calls must not agree, and comparing one against another would be
+    # asserting the opposite of what an unseeded run promises.
+    first = _sampler_seed(None, ("__list_choice__",))
+    second = _sampler_seed(None, ("__list_choice__",))
+
+    assert first != second


### PR DESCRIPTION
Rewritten from current `develop`. The old head is not replayed: it is kept at `thc1006/RocketPy@backup/pr-1054-cf99e872`, and what came out of it went up separately as #1169, #1170, #1181 and #1182.

What is left here is the thing #1053 asked for and nothing else.

```
                  production files   production   new functions
old head cf99e872               15   +1544/-1091             49
this                             1      +120/-25             5
```

The other three files are the two test files and a paragraph in `docs/user/stochastic.rst`.

**Stacked on #1181.** This branch carries that commit, so the diff shown here includes it. Happy to rebase once it lands.

## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`ruff check` / `ruff format --check`, `pylint`) has passed locally
- [x] All tests have passed locally
- `CHANGELOG.md`: one line, written by hand. The workflow that would have written it has not run since #1112, which is #1173.

## Current behavior

`simulate()` has no seed at all. The two run paths seed differently, and one of them does not seed:

```
monte_carlo.py:472   seeds = np.random.SeedSequence().spawn(n_workers)   # fresh entropy, one per worker
__run_in_serial                                                          # never reseeds anything
```

So a study gives different results run to run, different results in the two modes, and different results again when the worker count changes. That is #1053.

Underneath it, the two paths do not even agree on what a simulation is called. Three simulations, measured:

```
serial   indices written: [1, 2, 3]
parallel indices written: [0, 1, 2]
```

An index therefore meant nothing on its own, and no index-keyed guarantee was possible before that was settled. It is the first commit here, separately revertible.

## New behavior

`simulate(..., random_seed=None)`, keyword-only. Every simulation takes the child of that root belonging to its index.

The child is derived directly rather than by spawning the ones before it. `spawn` appends `n_children_spawned + i` to the parent key, so rebuilding that one child reproduces it bit for bit and a worker reaches any index from four picklable values instead of a list a million long. There is a test comparing it against `spawn(n)[i]`, for every index, for each of `int`, `None`, a sequence, and a `SeedSequence`.

Measured over real flights, four simulations:

```
serial(42)  == serial(42)               True
serial(42)  == parallel(2 workers, 42)  True
serial(42)  == parallel(4 workers, 42)  True
serial(42)  == serial(7)                False
```

The last line is the control. Without it the first three pass on a run that ignores the seed.

The per-worker seed is gone rather than kept alongside. A worker decides nothing about sampling now, so `__sim_producer` no longer takes a seed and `__run_in_parallel` no longer spawns one per worker. `pylint` finding the argument unused is what made that obvious.

An index is claimed in one operation. `keep_simulating()` and `increment()` were two calls on a manager proxy, so two workers could both see the last slot free and then claim one index each, the second past the end. `claim_next_index()` does both under a lock in the manager's own process, and the two methods it replaces are gone, so the pair cannot be written again by accident. The index is also written after the data collectors now, so one named `index` cannot take the number the row's seed was derived from.

Addresses #1053. Not `Closes`, because the default branch is `master` and a closing keyword only fires into it.

It also addresses the spawn half of #1076. `test_an_index_keeps_its_inputs_when_the_workers_are_spawned` runs a real `simulate()` on two and four workers under `spawn` and compares the sampled inputs against serial. The forkserver half is still only the derivation helpers, so that issue stays open.

## Breaking change

- [x] Yes

Two, both worth stating plainly.

Fixed-seed results change, because there were none: nothing in `simulate()` was reproducible before, so nothing that was reproducible stops being so. Every study is now sampled from a different place than it would have been.

Serial results are numbered one lower. A three-simulation serial run wrote indices 1, 2, 3 and now writes 0, 1, 2. Anything reading those indices back sees the shift. Append already assumed zero-based, since `num_of_loaded_sims` counts rows and a two-row checkpoint resumes at index 2, which the serial path never used.

## What this does not do

Appending continues the same stream when the same seed is given again, since an index maps to a seed and to nothing else. Nothing here records the seed, so nothing here can tell you whether a later append was given the same one. Persisting the root so that can be checked is #1075, and the docstring says so rather than implying more.

Not in here, and each already has its own place: the nominal lifetime (#1169), component streams (#1170), worker failure reporting (#1182), checkpoint and manifest work (#1075). The old branch had all of them at once, which is what made it unreviewable.

## Additional information

Verification, on a clean tree:

```
pytest tests/unit                     2202 passed
pytest rocketpy --doctest-modules       48 passed
pytest tests/acceptance                 18 passed
ruff check . / ruff format --check .   clean
pylint rocketpy/ tests/ docs/          10.00/10, exit 0
```

Seven `tests/unit` failures on my machine are optional dependencies it does not have: four in `test_sensitivity.py` for `statsmodels`, three in `test_environment_analysis.py` for `windrose` and `ipywidgets`. All seven are `ImportError` before any assertion.

Each mechanism is pinned by a mutation, and each leaves a control standing:

| undone | goes red | still passes |
|---|---|---|
| serial numbering back to one-based | three | the parallel case, which was already right |
| the per-index seeding, in both loops | three: reproducibility, split independence, append | the twelve derivation tests |
| every index reuses the root's own key | all six derivation tests | the rest |
| the caller's `SeedSequence` used as given | the consumption test | the rest |
| the entropy copy dropped | the aliasing test | the consumption test |
| the off-by-one put back in the failure message | the serial failure test | the numbering tests |
| the worker stops seeding the index it claimed | the worker-loop test, and the split-independence test with it | the two single-run seed tests |
| the index written before the collectors instead of after | the collector test | the numbering tests |
| the claim split back into a check and an increment | nothing | everything, which is the second finding below |

The last two rows are new. The patch had two lines uncovered, both reachable only when something goes wrong or when the worker loop runs in another process, so each now has a test that reaches it here: the failure message names the index the parallel path would, and the loop a worker runs, driven in this process, produces the run serial produces.

**One mutation survived, and finding that was the point.** I had written the entropy copy twice, once in `_root_seed_sequence` and once in `_root_state_of`. Removing either alone changed nothing, because the other still did the job; only removing both turned a test red. So one of them could not be distinguished from its own absence. Kept the one at the boundary where the value stops being the caller's, deleted the other.

**A second mutation survives, and I would rather say so than imply a test I do not have.** Putting the two-call claim back leaves everything green. A thread-level test does not reproduce the race even at `setswitchinterval(1e-9)` with eight claimers over five thousand slots, and the existing parallel test stayed green over five runs with the old loop restored. The window is one IPC round trip and two workers have to arrive inside it. The two tests I added pin the claim contract and both die to a boundary mutation, but the fix rests on construction rather than on a failing test.

The copy is not decoration. `SeedSequence` keeps a sequence entropy by reference:

```
caller passes [1, 2, 3], then sets caller[0] = 999
without the copy   the children move
with it            they do not
```

Merged with #1169, #1170, #1182 and #1171's follow-up into a throwaway tree on `develop` and run there. That found two things no branch shows on its own: `pylint` R0915 on `__sim_producer`, which is under the limit on each branch and over it once both grew, and ten of #1182's tests calling the producer with the seed argument this branch removes, which git merged without a conflict marker. Both are noted for whichever lands second.


