### PR TITLE
MNT: remove duplicate and merge-sync entries from Unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,9 @@ Attention: The newest changes should be on top -->
 
 ### Added
 
-- ENH: Updates develop with master [#1058](https://github.com/RocketPy-Team/RocketPy/pull/1058)
 ### Changed
 
 ### Fixed
-
-- BUG: BUG: Environment not Encoding Necessary Parameters for Decode [#1059](https://github.com/RocketPy-Team/RocketPy/pull/1059)
 
 ## [v1.13.0] - 2026-07-04
 


### PR DESCRIPTION
## Summary

Cleans up the `Unreleased` section of the changelog:

- Removes the duplicated #1059 entry (with the "BUG: BUG:" typo) — it is already recorded under the v1.13.0 section.
- Removes the #1058 develop/master sync entry, which the changelog header explicitly excludes (merge commits).

Best merged before #1060 so `master` receives a clean changelog ahead of the v1.13.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)