### PR TITLE
DOC: make the CustomSampler examples answer to their seed

### DIFF
--- a/docs/user/custom_sampler.rst
+++ b/docs/user/custom_sampler.rst
@@ -52,7 +52,7 @@ distributions.
                 2-Tuple that contains the probability of each normal distribution 
                 of the mixture. Its entries should be non-negative and sum up to 1.
             """
-            np.random.default_rng(seed)
+            self.reset_seed(seed)
             self.means_tuple = means_tuple
             self.sd_tuple = sd_tuple
             self.prob_tuple = prob_tuple
@@ -71,12 +71,12 @@ distributions.
                 List containing n_samples samples
             """
             samples_list = [0] * n_samples
-            mixture_id_list = np.random.binomial(1, self.prob_tuple[0], n_samples)
+            mixture_id_list = self.rng.binomial(1, self.prob_tuple[0], n_samples)
             for i, mixture_id in enumerate(mixture_id_list):
                 if mixture_id:
-                    samples_list[i] = np.random.normal(self.means_tuple[0], self.sd_tuple[0])
+                    samples_list[i] = self.rng.normal(self.means_tuple[0], self.sd_tuple[0])
                 else:
-                    samples_list[i] = np.random.normal(self.means_tuple[1], self.sd_tuple[1])
+                    samples_list[i] = self.rng.normal(self.means_tuple[1], self.sd_tuple[1])
 
             return samples_list
 
@@ -88,7 +88,14 @@ distributions.
             seed : int, optional
                 Seed for the random number generator.
             """
-            np.random.default_rng(seed)
+            self.rng = np.random.default_rng(seed)
+
+.. warning::
+    Keep the generator on the instance and draw from it in *sample*. Calling
+    ``np.random.default_rng(seed)`` and discarding the result is a no-op, and
+    *sample* then draws from the process-global ``np.random`` instead, which
+    ``random_seed`` does not reach. The study still runs; it is simply not
+    reproducible, and nothing says so.
 
 This is an example of a distribution that is not implemented in numpy. Note that it is
 a general distribution, so we can use it for many different variables.
@@ -216,14 +223,9 @@ below implements an example of such a generator
             seed : int, optional
                 Number to seed random generator, by default None
             """
-            np.random.default_rng(seed)
-            self.samples_list = []
-            self.samples_generated = 0
-            self.used_samples_x = 0
-            self.used_samples_y = 0
             self.mean = mean
             self.cov = cov
-            self.generate_samples(1000)
+            self.reset_seed(seed)
 
         def generate_samples(self, n_samples = 1):
             """Generate samples from bivariate Gaussian and append to sample list
@@ -233,23 +235,37 @@ below implements an example of such a generator
             n_samples : int, optional
                 Number of samples to be generated, by default 1
             """
-            samples_generated = np.random.multivariate_normal(self.mean, self.cov, n_samples)
+            samples_generated = self.rng.multivariate_normal(self.mean, self.cov, n_samples)
             self.samples_generated += n_samples
             self.samples_list += list(samples_generated)
 
         def reset_seed(self, seed=None):
-            np.random.default_rng(seed)
+            """Reseeds the generator and discards the samples drawn before it
+
+            The cached samples came from the previous generator, so keeping them
+            would let the first 1000 draws after a reseed ignore the new seed.
+            """
+            self.rng = np.random.default_rng(seed)
+            self.samples_list = []
+            self.samples_generated = 0
+            self.used_samples_x = 0
+            self.used_samples_y = 0
+            self.generate_samples(1000)
+
+        def top_up(self, used_samples, n_samples):
+            """Generates enough samples to cover the request, if it is short"""
+            shortfall = used_samples + n_samples - self.samples_generated
+            if shortfall > 0:
+                self.generate_samples(shortfall)
 
         def get_samples(self, n_samples, axis):
             if axis == "x":
-                if self.samples_generated < self.used_samples_x:
-                    self.generate_samples(n_samples)
+                self.top_up(self.used_samples_x, n_samples)
                 samples_list = [
                     sample[0] for sample in self.samples_list[self.used_samples_x:(self.used_samples_x + n_samples)]
                 ]
             if axis == "y":
-                if self.samples_generated < self.used_samples_y:
-                    self.generate_samples(n_samples)
+                self.top_up(self.used_samples_y, n_samples)
                 samples_list = [
                     sample[1] for sample in self.samples_list[self.used_samples_y:(self.used_samples_y + n_samples)]
                 ]


### PR DESCRIPTION
Closes #1096.

## Pull request type

- [x] ReadMe, Docs and GitHub updates

## Checklist

- [x] Docs have been reviewed and added / updated

The other three items are removed rather than ticked. Nothing under `rocketpy/` or `tests/` changes, so the suite and the linters have nothing to say about this branch and I did not run them on it. What I did run is the documentation build and the code the page contains, both below.

## Current behavior

Both `CustomSampler` examples build a generator and discard it:

```python
def reset_seed(self, seed=None):
    np.random.default_rng(seed)
```

Nothing is assigned, so the call has no effect, and `sample` goes on drawing from the process-global `np.random`. A sampler written by following this page ignores `random_seed` entirely. The failure is quiet: the study runs, the numbers look reasonable, and only a second run with the same seed shows they were never reproducible. Nothing in RocketPy seeds the global RNG, so there is no accident that would rescue it.

The bivariate generator has two further defects, found while fixing the first.

It caches 1000 samples up front. Even with `reset_seed` corrected, those samples came from the generator that was replaced, so the first 1000 draws after a reseed would still ignore the new seed.

Its refill test is

```python
if self.samples_generated < self.used_samples_x:
    self.generate_samples(n_samples)
```

which only becomes true once the cache has already run out, and the slice that follows is not bounded either. A study longer than the cache silently receives short lists:

```
draw 1..1000   sample(n_samples=1) -> 1 value
draw 1001      sample(n_samples=1) -> []
               dict_generator does sample(...)[0] -> IndexError
```

## New behavior

`reset_seed` keeps the generator, `sample` draws from it, and `__init__` routes through `reset_seed` so construction and reseeding agree. For the bivariate generator, `reset_seed` also drops the cache, and the refill covers the shortfall rather than reacting after the fact.

Executing the code blocks straight out of the page, before and after:

```
                                          before        after
mixture, same seed twice                  differs       same
bivariate, same seed twice                differs       same
1501 draws of one sample, short returns   501           0
wind X against wind Y                     IndexError    0.6986
```

The last row is the property the shared generator exists for. The measured correlation matches 0.171/sqrt(0.2*0.3) = 0.6981, so splitting the seeding did not split the two wind components.

I ran those checks by parsing the `jupyter-execute` blocks out of the `.rst` and executing them, rather than retyping the classes, so what passed is what the page says.

The added `.. warning::` is there because the mistake is easy to repeat and produces no error when repeated.

## Breaking change

- [x] No

Documentation only. No module in `rocketpy/` is touched.

## Additional information

The same mistake was in `tests/fixtures/monte_carlo/custom_sampler_fixtures.py` and is fixed in #1054. This uses the same corrected shape so the two do not drift apart. It is independent of that PR and can go in first or second.

Sphinx built clean with the CI settings (`-W --keep-going`, `DOCS_SKIP_EXECUTE=1`): no warning from `custom_sampler.rst`, and the rendered page contains the corrected code with no global draws left.

Related: #1093, #1094, #1095, filed from the same review.
