### PR TITLE
BUG: accept the callable parachute triggers the docstring promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
+- BUG: Accept the callable parachute triggers `StochasticParachute` documents, and reject the ones it cannot mean. An invalid string, an empty list or a boolean now fails during validation instead of reaching `Parachute` or becoming a one-metre height trigger. [#1103](https://github.com/RocketPy-Team/RocketPy/pull/1103)
 - BUG: rocket with a late-starting thrust curve never leaves the rail [#1085](https://github.com/RocketPy-Team/RocketPy/pull/1085)
 
 ## [v1.13.0] - 2026-07-21

--- a/rocketpy/stochastic/stochastic_parachute.py
+++ b/rocketpy/stochastic/stochastic_parachute.py
@@ -120,8 +120,11 @@ class StochasticParachute(StochasticModel):
         - a tuple that will be further validated in the StochasticModel class
         """
         if trigger is not None:
+            # The `or` belongs beside the isinstance, not inside it. A non-empty
+            # type tuple is truthy, so `X or callable(member)` short-circuited to
+            # X and the callables this docstring promises were refused.
             assert isinstance(trigger, list) and all(
-                isinstance(member, (str, int, float) or callable(member))
+                isinstance(member, (str, int, float)) or callable(member)
                 for member in trigger
             ), "`trigger` must be a list of callables, string 'apogee' or ints/floats"
 

--- a/rocketpy/stochastic/stochastic_parachute.py
+++ b/rocketpy/stochastic/stochastic_parachute.py
@@ -1,8 +1,24 @@
 """Defines the StochasticParachute class."""
 
+from numbers import Real
+
 from rocketpy.rocket import Parachute
 
 from .stochastic_model import StochasticModel
+
+
+def _is_a_trigger(member):
+    """One of the three forms ``Parachute`` accepts.
+
+    ``Real`` rather than ``(int, float)``, which took ``numpy.float64`` but not
+    ``numpy.int64``. ``bool`` is excluded because it is an ``int``, and
+    ``Parachute`` would read ``True`` as a height of one metre.
+    """
+    if callable(member):
+        return True
+    if isinstance(member, str):
+        return member.lower() == "apogee"
+    return isinstance(member, Real) and not isinstance(member, bool)
 
 
 class StochasticParachute(StochasticModel):
@@ -114,19 +130,26 @@ class StochasticParachute(StochasticModel):
         )
 
     def _validate_trigger(self, trigger):
-        """Validates the trigger input. If the trigger input argument is not
-        None, it must be:
-        - a list of callables, string "apogee" or ints/floats
-        - a tuple that will be further validated in the StochasticModel class
+        """Validates the trigger input. If not None, it must be a non-empty
+        list whose members are each a callable, the string "apogee", or a
+        height. One of those is chosen per simulation.
         """
-        if trigger is not None:
-            # The `or` belongs beside the isinstance, not inside it. A non-empty
-            # type tuple is truthy, so `X or callable(member)` short-circuited to
-            # X and the callables this docstring promises were refused.
-            assert isinstance(trigger, list) and all(
-                isinstance(member, (str, int, float)) or callable(member)
-                for member in trigger
-            ), "`trigger` must be a list of callables, string 'apogee' or ints/floats"
+        if trigger is None:
+            return
+
+        valid = (
+            isinstance(trigger, list)
+            and bool(trigger)
+            and all(_is_a_trigger(member) for member in trigger)
+        )
+        # Raised rather than asserted: `python -O` strips an assert, and this
+        # is the only thing standing between a bad trigger and a Parachute
+        # that either refuses it much later or reads True as a height of 1.
+        if not valid:
+            raise AssertionError(
+                "`trigger` must be a non-empty list whose members are "
+                "callables, the string 'apogee', or heights"
+            )
 
     def _validate_noise(self, noise):
         """Validates the noise input. If the noise input argument is not

--- a/rocketpy/stochastic/stochastic_parachute.py
+++ b/rocketpy/stochastic/stochastic_parachute.py
@@ -1,24 +1,23 @@
 """Defines the StochasticParachute class."""
 
-from numbers import Real
-
 from rocketpy.rocket import Parachute
 
 from .stochastic_model import StochasticModel
 
 
 def _is_a_trigger(member):
-    """One of the three forms ``Parachute`` accepts.
+    """One of the three forms ``Parachute`` accepts, and no more.
 
-    ``Real`` rather than ``(int, float)``, which took ``numpy.float64`` but not
-    ``numpy.int64``. ``bool`` is excluded because it is an ``int``, and
-    ``Parachute`` would read ``True`` as a height of one metre.
+    ``(int, float)`` deliberately, matching ``Parachute``'s own check rather
+    than ``numbers.Real``: that would take ``numpy.int64``, which ``Parachute``
+    refuses, so widening here only moves the failure to create time. ``bool``
+    is excluded because it is an ``int``, and would arrive as a height of one.
     """
     if callable(member):
         return True
     if isinstance(member, str):
         return member.lower() == "apogee"
-    return isinstance(member, Real) and not isinstance(member, bool)
+    return isinstance(member, (int, float)) and not isinstance(member, bool)
 
 
 class StochasticParachute(StochasticModel):

--- a/tests/unit/stochastic/test_stochastic_parachute.py
+++ b/tests/unit/stochastic/test_stochastic_parachute.py
@@ -78,14 +78,34 @@ def test_a_trigger_that_is_not_a_list_of_those_is_refused(calisto_main_chute, tr
 
 
 @pytest.mark.parametrize(
-    "member", [800, 800.0, np.float64(800), np.int64(800)], ids=str
+    "member",
+    [_at_apogee, "apogee", "APOGEE", 800, 800.0, np.float64(800)],
+    ids=str,
 )
-def test_a_height_is_a_height_whatever_numeric_type_it_arrives_as(
+def test_what_this_accepts_is_what_a_parachute_accepts(calisto_main_chute, member):
+    """The property, rather than a list of types. Anything this lets through
+    has to survive `Parachute`, or the check has only moved the failure."""
+    StochasticParachute(calisto_main_chute, trigger=[member])
+
+    Parachute("probe", 10.0, member, 105, 1.5)
+
+
+@pytest.mark.parametrize("member", [np.int64(800), np.int32(800)], ids=str)
+def test_a_numpy_integer_is_refused_here_because_parachute_refuses_it(
     calisto_main_chute, member
 ):
-    """`(int, float)` accepted `numpy.float64`, which subclasses `float`, and
-    refused `numpy.int64`, which subclasses neither."""
-    StochasticParachute(calisto_main_chute, trigger=[member])
+    """`Parachute` checks `isinstance(trigger, (int, float))`. `numpy.float64`
+    subclasses `float` and passes; `numpy.int64` subclasses neither and raises.
+
+    So this check matches that one rather than `numbers.Real`, which would be
+    the wider and more natural spelling but would let these through to fail at
+    create time. The asymmetry is `Parachute`'s and is worth fixing there.
+    """
+    with pytest.raises(ValueError, match="Unable to set the trigger"):
+        Parachute("probe", 10.0, member, 105, 1.5)
+
+    with pytest.raises(AssertionError, match="must be a non-empty list"):
+        StochasticParachute(calisto_main_chute, trigger=[member])
 
 
 def test_the_check_is_not_stripped_by_python_dash_o():

--- a/tests/unit/stochastic/test_stochastic_parachute.py
+++ b/tests/unit/stochastic/test_stochastic_parachute.py
@@ -129,7 +129,8 @@ def test_a_callable_trigger_reaches_the_parachute_and_gets_called(
     built = stochastic.create_object()
 
     assert built.trigger is _at_apogee
-    descending = [0.0] * 5 + [-5.0] + [0.0] * 8
-    ascending = [0.0] * 5 + [5.0] + [0.0] * 8
+    # 13, matching the state Flight passes: x y z vx vy vz e0 e1 e2 e3 wx wy wz
+    descending = [0.0] * 5 + [-5.0] + [0.0] * 7
+    ascending = [0.0] * 5 + [5.0] + [0.0] * 7
     assert built.triggerfunc(0.0, 100.0, descending, [], [])
     assert not built.triggerfunc(0.0, 100.0, ascending, [], [])

--- a/tests/unit/stochastic/test_stochastic_parachute.py
+++ b/tests/unit/stochastic/test_stochastic_parachute.py
@@ -1,3 +1,6 @@
+import pytest
+
+from rocketpy.stochastic import StochasticParachute
 from rocketpy.rocket.parachute import Parachute
 
 
@@ -19,3 +22,36 @@ def test_stochastic_parachute_create_object(stochastic_main_parachute):
     """
     obj = stochastic_main_parachute.create_object()
     assert isinstance(obj, Parachute)
+
+
+def _at_apogee(pressure, height, state):  # pylint: disable=unused-argument
+    """A trigger of the kind `Parachute` and `Flight` already accept.
+
+    Keeps the full signature rather than underscoring the unused two, since the
+    signature is the contract being tested."""
+    return state[5] < 0
+
+
+@pytest.mark.parametrize(
+    "trigger",
+    [[_at_apogee], ["apogee"], [800], [_at_apogee, "apogee", 800]],
+    ids=["callable", "apogee", "height", "mixed"],
+)
+def test_every_documented_trigger_form_is_accepted(calisto_main_chute, trigger):
+    """The docstring promises callables, "apogee" and numbers. The check read
+    `isinstance(member, (str, int, float) or callable(member))`, and a non-empty
+    type tuple is truthy, so the `or` short-circuited and callables were
+    refused. The two non-callable forms passed throughout, which is why it went
+    unnoticed."""
+    StochasticParachute(calisto_main_chute, trigger=trigger)
+
+
+@pytest.mark.parametrize("trigger", [_at_apogee, "apogee", 800, [None], [{}]], ids=str)
+def test_a_trigger_that_is_not_a_list_of_those_is_still_refused(
+    calisto_main_chute, trigger
+):
+    """The control. Moving the `or` must not turn the check into one that
+    accepts anything: a bare callable is not a list, and None is none of the
+    three."""
+    with pytest.raises(AssertionError, match="must be a list"):
+        StochasticParachute(calisto_main_chute, trigger=trigger)

--- a/tests/unit/stochastic/test_stochastic_parachute.py
+++ b/tests/unit/stochastic/test_stochastic_parachute.py
@@ -1,3 +1,6 @@
+import inspect
+
+import numpy as np
 import pytest
 
 from rocketpy.stochastic import StochasticParachute
@@ -46,12 +49,67 @@ def test_every_documented_trigger_form_is_accepted(calisto_main_chute, trigger):
     StochasticParachute(calisto_main_chute, trigger=trigger)
 
 
-@pytest.mark.parametrize("trigger", [_at_apogee, "apogee", 800, [None], [{}]], ids=str)
-def test_a_trigger_that_is_not_a_list_of_those_is_still_refused(
-    calisto_main_chute, trigger
-):
-    """The control. Moving the `or` must not turn the check into one that
-    accepts anything: a bare callable is not a list, and None is none of the
-    three."""
-    with pytest.raises(AssertionError, match="must be a list"):
+@pytest.mark.parametrize(
+    "trigger",
+    [
+        _at_apogee,
+        "apogee",
+        800,
+        (800,),
+        [],
+        [None],
+        [{}],
+        ["banana"],
+        [True],
+        [_at_apogee, None],
+    ],
+    ids=str,
+)
+def test_a_trigger_that_is_not_a_list_of_those_is_refused(calisto_main_chute, trigger):
+    """The control, and four that the check used to wave through.
+
+    `Parachute` refuses "banana" with a ValueError, so accepting it here only
+    moved the failure to create time. `True` is worse: it is an `int`, so it
+    was taken as a height of one metre. An empty list passed because `all([])`
+    is True. And the docstring's tuple form was never implemented.
+    """
+    with pytest.raises(AssertionError, match="must be a non-empty list"):
         StochasticParachute(calisto_main_chute, trigger=trigger)
+
+
+@pytest.mark.parametrize(
+    "member", [800, 800.0, np.float64(800), np.int64(800)], ids=str
+)
+def test_a_height_is_a_height_whatever_numeric_type_it_arrives_as(
+    calisto_main_chute, member
+):
+    """`(int, float)` accepted `numpy.float64`, which subclasses `float`, and
+    refused `numpy.int64`, which subclasses neither."""
+    StochasticParachute(calisto_main_chute, trigger=[member])
+
+
+def test_the_check_is_not_stripped_by_python_dash_o():
+    """`python -O` removes an `assert` outright, and this check is the only
+    thing between a bad trigger and a `Parachute` that either refuses it much
+    later or reads `True` as a height."""
+    source = inspect.getsource(StochasticParachute._validate_trigger)
+
+    assert "raise AssertionError" in source
+    assert not any(line.strip().startswith("assert ") for line in source.splitlines())
+
+
+def test_a_callable_trigger_reaches_the_parachute_and_gets_called(
+    calisto_main_chute,
+):
+    """Constructing the wrapper is not the property that matters. The callable
+    has to survive `create_object` and be what `Flight` ends up calling."""
+    stochastic = StochasticParachute(calisto_main_chute, trigger=[_at_apogee])
+    stochastic._set_stochastic(42)
+
+    built = stochastic.create_object()
+
+    assert built.trigger is _at_apogee
+    descending = [0.0] * 5 + [-5.0] + [0.0] * 8
+    ascending = [0.0] * 5 + [5.0] + [0.0] * 8
+    assert built.triggerfunc(0.0, 100.0, descending, [], [])
+    assert not built.triggerfunc(0.0, 100.0, ascending, [], [])


### PR DESCRIPTION
Addresses #1095. Not `Closes`, because the keyword only fires when a pull request targets the default branch and this targets `develop`.

## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added
- [x] Lint (`ruff check` / `ruff format --check` / `pylint rocketpy/ tests/ docs/`) has passed locally
- [x] All tests have passed locally

`pylint` exits 0, `pytest tests/unit tests/integration` is 2058 passed, 44 skipped.

## Current behavior

`StochasticParachute._validate_trigger` refused the callable triggers its own docstring promised:

```python
isinstance(member, (str, int, float) or callable(member))
```

The `or` sat inside the `isinstance` call. `(str, int, float)` is a non-empty tuple and therefore truthy, so the expression short-circuited to the tuple and `callable(member)` was never evaluated. The check reduced to `isinstance(member, (str, int, float))`, and a callable is none of those.

Fixing that turned up four more things the check should never have accepted:

```
["banana"]   passed here, then Parachute raised ValueError at create time
[True]       passed as a height of one metre, since bool is an int
[]           passed, because all([]) is True
numpy.int64  refused, while numpy.float64 was accepted
```

## New behavior

The check now accepts exactly what `Parachute` accepts, and nothing else:

```python
def _is_a_trigger(member):
    if callable(member):
        return True
    if isinstance(member, str):
        return member.lower() == "apogee"
    return isinstance(member, (int, float)) and not isinstance(member, bool)
```

`(int, float)` rather than `numbers.Real`, deliberately. `Parachute` uses that exact check, so widening here would let `numpy.int64` past validation and into `create_object`, which is the same defect as accepting `"banana"`: not permissiveness, but moving the failure somewhere less obvious. `bool` is excluded because `Parachute` would otherwise read `True` as one metre without complaint.

The whole contract, checked against both sides in one test:

```
value              Parachute   this check
callable           accepts     accepts
"apogee"/"APOGEE"  accepts     accepts
"banana"           refuses     refuses
800 / 800.0        accepts     accepts
numpy.float64      accepts     accepts
numpy.float32      refuses     refuses
numpy.int64        refuses     refuses
None / {} / ()     refuses     refuses
True / False       accepts     refuses
```

The last row is the one deliberate gap, in the safe direction.

The check is also raised from an `if` rather than asserted. It stays an `AssertionError`, so nothing catching it has to change, but `python -O` strips an `assert` outright and this is the only thing between those triggers and a `Parachute` that either refuses them later or misreads them.

The docstring promised a tuple form that was never implemented, and now describes what the code does.

## Tests

Twenty-five. Five mutations, one per rule, each taking only its own case:

| mutation | fails |
|---|---|
| callable branch removed | the callable and mixed cases |
| accept any string | `["banana"]` |
| drop the bool exclusion | `[True]` |
| drop the non-empty check | `[]` |
| `(int, float)` widened to `numbers.Real` | `numpy.int64` |
| `raise` back to `assert` | the `-O` test |

There is also the end-to-end case that was missing: a callable has to survive `create_object` and be what gets called, rather than merely be accepted by the constructor.

```
built.trigger is _at_apogee
triggerfunc(0.0, 100.0, descending, [], [])  -> True
triggerfunc(0.0, 100.0, ascending,  [], [])  -> False
```

## Breaking change

- [x] No

It accepts callables, which the docstring already promised, and refuses four forms that either failed later or were silently misread.

## Additional information

`Parachute`'s own numeric check is asymmetric: `numpy.float64` passes because it subclasses `float`, `numpy.int64` does not because it subclasses neither, and `True` is taken as a height. This follows that contract rather than trying to improve on it, and the asymmetry is filed separately as #1106, where widening would not strand anything downstream.

Found while reviewing #1054, and unrelated to it.
