### PR TITLE
CI: build the docs for pull requests into develop as well

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,6 @@
 name: Documentation
 
 on:
-  # PRs into either long-lived branch, and pushes to master. `branches` filters
-  # on the PR's base, and almost every PR is opened against develop, so master
-  # alone meant the build first saw a docs change in the release batch.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [master, develop]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,12 @@
 name: Documentation
 
 on:
-  # Only PRs targeting master (base branch = master) and pushes to master.
+  # PRs into either long-lived branch, and pushes to master. `branches` filters
+  # on the PR's base, and almost every PR is opened against develop, so master
+  # alone meant the build first saw a docs change in the release batch.
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    branches: [master]
+    branches: [master, develop]
     paths:
       - "docs/**"
       - "rocketpy/**" # docstrings feed the autodoc API reference


### PR DESCRIPTION
Addresses #1099. Not `Closes`, because the closing keyword only fires when the pull request targets the default branch, and this one targets `develop`. #1094 and #1096 are both still open for exactly that reason.

## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)

## Checklist

- [x] Docs have been reviewed and added / updated

One workflow file changes and nothing under `rocketpy/` or `tests/` does, so no code test was added. The Tests, Linters and Documentation workflows all pass on the current head.

## Current behavior

```yaml
  pull_request:
    branches: [master]
```

`branches` filters on the pull request's base, and almost nothing here targets `master`. Of the last 30 pull requests, 25 went to `develop` and 3 to `master`. So the build that runs with `-W --keep-going` first sees a docs change when `develop` is promoted, in a batch, a long way from whatever caused it.

#1097 is the case that prompted this. It changed `docs/user/custom_sampler.rst`, targeted `develop`, and its only check was the auto-assign workflow. My local `sphinx-build` was the only thing standing behind the reStructuredText, which is not where that check belongs.

The path filter includes `rocketpy/**`, because docstrings feed the autodoc reference, so this is not only about `docs/`. A docstring edit merged into `develop` can break the API pages with nothing to say so.

## New behavior

```yaml
    branches: [master, develop]
```

`push` is deliberately left on `master` alone. The pull request check is where the feedback is useful, and running both would pay twice for a second opinion on the same commit.

## Breaking change

- [x] No

## Additional information

Two things worth knowing before adding a `-W` build to every docs-affecting pull request. A check rather than a gate: whether it can block a merge is a branch-rule decision, not this file's, and a workflow with top-level `paths` filters is the wrong shape to make required as it stands.

**It is not slow.** The job sets `DOCS_SKIP_EXECUTE: "1"`, so notebooks are not executed and `jupyter-execute` cells render as static blocks. The documentation examples therefore make no live weather or external-data calls, which is the expensive and flaky part; the job still installs pandoc and the Python dependencies like any other. The run on this pull request took 2m27s.

**`develop` builds clean today**, so this does not switch on a check that is already red. This pull request proves it rather than arguing it: `.github/workflows/docs.yml` is inside the workflow's own `paths` list, so the change triggered itself. `Documentation / build-docs (3.12)` ran against the merge ref and the warnings-as-errors build finished clean.

The workflow asks for `contents: read` and uses no repository or organization secrets, so a fork pull request runs it with a read-only token, subject to whatever approval policy the repository applies to outside contributors. That is where it is needed most.

It has to stay on `pull_request` rather than `pull_request_target`: it checks out the merge tree and then installs and imports the package, `docs/conf.py` and the Sphinx extensions from it, all of which the pull request controls.

