### PR TITLE
CI: write the changelog entry for pull requests from forks too

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,6 +1,10 @@
 name: Populate Changelog
 on:
-  pull_request:
+  # `pull_request_target`, not `pull_request`: secrets are withheld from a
+  # `pull_request` run whose head is a fork, so RELEASE_TOKEN arrived empty and
+  # the checkout below failed for every outside contribution. Nothing here runs
+  # code from the pull request, only the trusted tree checked out below.
+  pull_request_target:
     types: [closed]
     branches:
       - develop


### PR DESCRIPTION
Addresses #1101. Not `Closes`, since the keyword only fires on a pull request into the default branch and this one targets `develop`.

## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)

## Current behavior

`Populate Changelog` fails for every pull request opened from a fork, and only for those. GitHub withholds secrets from a `pull_request` run whose head is a fork, so `secrets.RELEASE_TOKEN` is empty and the first step stops after about five seconds:

```
##[error]Input required and not supplied: token
```

Nothing else refers to the changelog, so the merge completes and the entry is absent. The split is clean in both directions across every run still on record:

```
#1097  fork (thc1006)      failure
#1070  fork (zuorenchen)   failure
#1052  fork (thc1006)      failure

#1079  RocketPy-Team       success
#1082  RocketPy-Team       success
#1056  RocketPy-Team       success
```

This is not losing history, and I would rather be accurate about the size of it. Both older cases were caught by hand: #1052 merged on 07-11 and its entry was added on 07-12 in `ba9d130`; #1070 merged on 07-19 and was picked up the same day in `d31822d`, under "changelog consolidation" while v1.13.0 was being prepared. What it costs is somebody noticing, once per outside contribution, often not until a release is being assembled.

## New behavior

```yaml
  pull_request_target:
    types: [closed]
    branches:
      - develop
```

`pull_request_target` runs in the base repository's context and does receive the secrets.

## Why that trigger is safe here

It is usually the one to avoid, so it is worth being specific rather than asserting it.

The job never touches the pull request. It checks out `RocketPy-Team/RocketPy` at `ref: develop` and runs `.github/scripts/update_changelog.py` from that same trusted tree. There is no `head.sha`, `head.ref` or `head.repo` anywhere in the file, so nothing from the contributor's branch is fetched or executed.

The contributor-controlled values are the title, body and labels, and they were already being treated as untrusted, by the workflow's own comment:

> PR title/body are untrusted input, so they are passed via the environment and consumed inside Python (never interpolated into the shell).

The one interpolation into a shell is `github.event.pull_request.number` in the commit message, which is an integer GitHub assigns.

What changes is who can supply that title and body: today only people with write access, afterwards any contributor. The handling was built for untrusted input either way, and the script validates the model's output and falls back to a deterministic insert when it is rejected, so the worst case stays inside `CHANGELOG.md`. `RELEASE_TOKEN` is used only by `actions/checkout` and is not in the script step's environment.

`github.event.pull_request` keeps the same shape under either trigger, so the `merged == true` guard and `PR_NUMBER` carry over unchanged.

If you would rather not use that trigger at all, `on: push: branches: [develop]` also receives secrets, at the cost of working out which pull request a push came from.

## Breaking change

- [x] No

## Additional information

Worth saying that this lands on outside contributions specifically, which are the ones where a changelog line does the most good and where the contributor is least likely to notice it went missing.

`7f85c07` from April is titled "DEV: correct auto-changelog access token", so the token has had attention before. This looks like a different failure, but I have not gone back to check what that one was.

I have not run this. A workflow trigger only proves itself once it is on the default path, and the failing half is by definition not reachable from a fork branch.

