### PR TITLE
MNT: declare dependency floors the package can actually run on

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.13
-scipy>=1.0
+numpy>=1.23  # matplotlib 3.9 requires it
+scipy>=1.8  # first to allow numpy 1.23; bootstrap needs 1.7
 matplotlib>=3.9.0  # Released May 15th 2024
 netCDF4>=1.6.4
 requests


### PR DESCRIPTION
Addresses #1107. Not `Closes`, since the keyword only fires when a pull request targets the default branch and this targets `develop`.

## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)

## Current behavior

```
numpy>=1.13
scipy>=1.0
```

Neither is true, and `pyproject.toml` reads this file through `dynamic = ["dependencies"]`, so it is what an installer is told.

**SciPy.** `rocketpy/simulation/monte_carlo.py` imports `scipy.stats.bootstrap` at module level, and the package `__init__` reaches that module. The SciPy 1.7.0 release notes are where the function arrives:

> `scipy.stats.bootstrap` has been added to allow estimation of the confidence interval and standard error of a statistic.

So 1.0 through 1.6 satisfy the floor and then fail on `import rocketpy`, before anything runs.

**NumPy.** The binding constraint here is a sibling rather than NumPy itself. `matplotlib>=3.9.0` is in this same file and requires `numpy>=1.23`, which I found the direct way:

```
ImportError: Matplotlib requires numpy>=1.23; you have 1.21.3
```

That is at 1.21.3, which is where NumPy's own Python 3.10 wheels begin, so the wheel-availability answer is not far enough either.

## New behavior

```
numpy>=1.23  # matplotlib 3.9 requires it
scipy>=1.8   # first to allow numpy 1.23; bootstrap needs 1.7
```

SciPy is 1.8 rather than 1.7 because the two have to compose: `scipy==1.7.2` declares `numpy<1.23.0`, so pinning 1.7 and asking for numpy 1.23 is unsatisfiable. 1.8.0 raised its cap to `<1.25.0`.

Both are old. SciPy 1.8.0 is February 2022 and NumPy 1.23.0 June 2022, against a package that already requires Python 3.10.

## Breaking change

- [x] No

It refuses installs that would have failed anyway, earlier and with a message about versions rather than an ImportError.

## How this was checked

Installed rather than reasoned about, since the constraint that decided the NumPy floor was not the one I expected:

```
python 3.10, numpy 1.23.0, scipy 1.8.0 pinned, everything else current

import rocketpy                                   works
tests/unit/simulation + tests/unit/stochastic     162 passed, 5 skipped
```

And resolved from the file itself, taking the lowest each declaration allows:

```
uv pip install --resolution=lowest-direct -r requirements.txt
-> numpy 1.23.0, scipy 1.8.0, matplotlib 3.9.0
```

## One thing I found and deliberately left alone

`requests`, `pytz`, `simplekml` and `dill` carry no floor at all, and under a lowest-version resolution they pick releases that cannot run on Python 3.10:

```
pytz 2018.3       from collections import Mapping
requests (old)    from collections import MutableMapping
```

`pytz>=2018.4` is the first that imports, if anyone wants the number.

I have not touched them, because that is a different defect. These two lines make a claim that is false; those four make no claim at all, and deciding what they should claim is a policy call rather than a correction. It is also not reachable the way the SciPy one is: an ordinary install takes the newest of an unfloored dependency, whereas a deliberate `scipy==1.6` is a thing someone might really have.
