### PR TITLE
CI: run the changelog job for pull requests from forks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,12 +1,21 @@
 name: Populate Changelog
 on:
-  pull_request:
+  # `pull_request_target`, not `pull_request`. Secrets are withheld from a
+  # `pull_request` run whose head is a fork, so RELEASE_TOKEN arrived empty and
+  # the checkout below failed for every outside contribution.
+  #
+  # Nothing from the pull request is executed. The checkout is `ref: develop`,
+  # and the updater is inline below, which under this trigger is read from the
+  # default branch rather than from the merged head.
+  pull_request_target:
     types: [closed]
     branches:
       - develop
 
+# Read, because the job's own writes go through RELEASE_TOKEN. This trigger runs
+# with secrets available, so GITHUB_TOKEN should not also carry write.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   Changelog:


### PR DESCRIPTION
Replaces #1105, which targets `develop` and therefore cannot take effect. Addresses #1101.

`Populate Changelog` fails for every pull request opened from a fork, and only those:

```
2026-08-08T02:31  success  enh/add-pr-agent-gemini             branch on the repo
2026-08-08T02:22  failure  mnt/pytest-matrix-fail-fast         fork
2026-08-08T02:22  failure  bug/sampled-parachute-geometry      fork
2026-08-08T02:09  failure  bug/rail-takeoff-delayed-thrust     fork
2026-08-08T01:51  failure  ci/software-render-animation-tests  fork
2026-08-08T01:08  failure  doc/custom-sampler-seed             fork
```

The split is exactly fork versus not. GitHub withholds secrets from a `pull_request` run whose head is a fork, so `secrets.RELEASE_TOKEN` is empty and the checkout stops after a few seconds with `Input required and not supplied: token`.

The effect showed up today: #1102, #1103 and #1108 all merged without a changelog entry, and the lines had to be written by hand.

**Why this targets `master`.** A `pull_request_target` workflow is read from the repository's default branch, so the copy that decides whether the event fires is the one on `master`. #1105 changes `develop`'s copy, which means merging it changes nothing at all. I would rather close that one than leave it looking like a fix.

**On the trigger.** `pull_request_target` receives secrets because it runs in the base repository's context, which is also what makes it worth reading carefully. Nothing from the pull request is executed here:

- the checkout is `ref: develop`, not the pull request's head
- the updater is inline in the workflow, so under this trigger it comes from `master` rather than from whatever was just merged
- the title and labels reach Python through the environment, never interpolated into a shell

That last one was already true and already commented; I have not changed it.

**One thing beyond the trigger.** `permissions` drops from `contents: write` to `contents: read`. The job's writes go through `RELEASE_TOKEN`, which the checkout persists for the push step, so `GITHUB_TOKEN` never needed write. Under `pull_request` from a fork that grant was moot because the token was read-only anyway. Under this trigger it would be real, so it seemed the wrong moment to leave it.

Two things I did not do, and would rather you decide:

- pinning `actions/checkout@v4` to a full commit SHA, which GitHub recommends for privileged workflows. Nothing else in the repository pins that way, so it felt like a separate conversation.
- anything about `develop`'s copy of this file, which has since diverged considerably. Once this is on `master`, the two will want reconciling, and the Gemini path there raises its own questions that are not mine to settle.
