### PR TITLE
Bring master's README in line with develop's

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,10 @@ env = Environment(
 tomorrow = datetime.date.today() + datetime.timedelta(days=1)
 
 env.set_date(
-  (tomorrow.year, tomorrow.month, tomorrow.day, 12), timezone="America/Denver"
-) # Tomorrow's date in year, month, day, hour UTC format
+    (tomorrow.year, tomorrow.month, tomorrow.day, 12), timezone="America/Denver"
+)  # Tomorrow's date in year, month, day, hour UTC format
 
-env.set_atmospheric_model(type='Forecast', file='GFS')
+env.set_atmospheric_model(type="Forecast", file="GFS")
 ```
 
 This can be followed up by starting a Solid Motor object. To get help on it, just use:
@@ -233,9 +233,7 @@ buttons = calisto.set_rail_buttons(
 
 calisto.add_motor(Pro75M1670, position=-1.255)
 
-nose = calisto.add_nose(
-    length=0.55829, kind="vonKarman", position=1.278
-)
+nose = calisto.add_nose(length=0.55829, kind="vonKarman", position=1.278)
 
 fins = calisto.add_trapezoidal_fins(
     n=4,
@@ -290,7 +288,7 @@ To actually create a Flight object, use:
 
 ```python
 test_flight = Flight(
-  rocket=calisto, environment=env, rail_length=5.2, inclination=85, heading=0
+    rocket=calisto, environment=env, rail_length=5.2, inclination=85, heading=0
 )
 ```
 


### PR DESCRIPTION
Reopening #1113 against `master`, which is the only branch it applies to. Retargeting it to `develop` left nothing to apply, and I did not say why clearly enough at the time.

`Ruff (format)` fails on `master` right now, and any pull request into `master` shows a red `lint (3.10)` for a reason that has nothing to do with it. Checked against both branches with the ruff CI installs:

```
master   9bd6ad3a   1 file would be reformatted, 297 files already formatted   (README.md)
develop             307 files already formatted
```

**`develop`'s README is already formatted this way.** The diff between the two READMEs is exactly this change, which is why moving the pull request across made it a no-op.

So this takes develop's file rather than running the formatter again. The result is byte for byte identical to `develop`, which means the next release sync has nothing to reconcile here instead of carrying a conflict.

Whitespace and quotes only: single quotes in one call, a call split across three lines that fits on one, and two blocks indented two spaces rather than four. No snippet behaves differently when run.

**Why it drifted.** The linters job installs ruff unpinned, and recent versions format Python code blocks inside Markdown. That will happen again on whatever the formatter widens to next, on a branch that was green and without a commit to explain it. Pinning ruff in `linters.yml` is the durable fix and is its own change; happy to send it if you want it.

One thing to expect: this pull request will show a single check. The `paths` filters mean a README-only change runs the docs build and nothing else, so the linters job that would confirm the fix does not run on the change that makes it. It runs on the next thing to touch `master`, which is #1112.
