### PR TITLE
CI: pin the linters, so a release cannot turn a branch red

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,7 +28,12 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[all]
         pip install .[tests]
-        pip install pylint ruff
+        # Pinned, because both decide whether this job passes and both change
+        # what they report between releases. Unpinned, the formatter widening
+        # its scope or pylint adding a check turns a branch red with no commit
+        # to explain it. Bumping these is a deliberate change, made when the
+        # tree is ready for what the new version says.
+        pip install "pylint==4.0.6" "ruff==0.16.2"
     - name: Ruff (lint)
       run: ruff check --output-format=github .
     - name: Ruff (format)


### PR DESCRIPTION
`pip install pylint ruff` takes whatever is newest, and both tools decide whether this job passes.

This is not hypothetical. Recent ruff formats Python code blocks inside Markdown, which it did not use to, so `master`'s README stopped matching `ruff format --check` without anyone touching the file:

```
master   9bd6ad3a   1 file would be reformatted, 297 files already formatted   (README.md)
develop             307 files already formatted
```

Any pull request into `master` now shows a red `lint (3.10)` for a reason unrelated to it. #1114 fixes the content; this stops the next one.

**pylint has the same shape and a wider blast radius.** `.pylintrc` uses `disable=` with named messages rather than enabling named ones, so a new release's new checks are on by default. And CI reads the exit code, not the score, so a single new convention message fails the job at 10.00/10.

Pinned to what CI installs today, verified against `develop` before pinning rather than after:

```
ruff 0.16.2     All checks passed!
                307 files already formatted
pylint 4.0.6    exit 0
```

**One thing I could not make true, so I am not claiming it.** My first draft of the comment said Renovate would raise the bump. It manages the dependencies declared in `pyproject.toml` and the requirements files, and I found no pull request from it for a pinned version inside a workflow, so I do not think its pip manager reads these. That leaves bumping them a manual step, or a Renovate rule that would need adding. I would rather say that plainly than pin behind a promise that does not hold.

If you would rather not carry the maintenance, `ruff~=0.16.0` narrows the window without closing it, though a patch release can still change formatting. Exact is what I would choose for a formatter, and it is what BalloonPoppingChallenge does for the same reason.
