### PR TITLE
BUG: accept numpy integer parachute height triggers (#1106)

### DIFF
--- a/rocketpy/rocket/parachute.py
+++ b/rocketpy/rocket/parachute.py
@@ -1,4 +1,5 @@
 from inspect import Parameter, signature
+from numbers import Real
 
 import numpy as np
 
@@ -350,8 +351,8 @@ class Parachute:
             self.triggerfunc = _make_wrapper(trigger)
             return
 
-        # Numeric altitude trigger
-        if isinstance(trigger, (int, float)):
+        # Numeric altitude trigger (accept numpy integers/floats; reject bool)
+        if isinstance(trigger, Real) and not isinstance(trigger, bool):
             self._trigger_falling_only = True
 
             def triggerfunc(p, h, y, sensors, u_dot):  # pylint: disable=unused-argument
@@ -379,8 +380,8 @@ class Parachute:
         # If we reach this point, the trigger is invalid
         raise ValueError(
             f"Unable to set the trigger function for parachute '{self.name}'. "
-            + "Trigger must be a callable, a float value or one of the strings "
-            + "('apogee'). "
+            + "Trigger must be a callable, a real number (height in meters), "
+            + "or one of the strings ('apogee'). "
             + "See the Parachute class documentation for more information."
         )
 

--- a/tests/unit/rocket/test_parachute.py
+++ b/tests/unit/rocket/test_parachute.py
@@ -130,3 +130,32 @@ def test_callable_trigger_arities_route_arguments(trigger, expects_udot):
     result = parachute.triggerfunc(800.0, 500.0, [0.0] * 6, [], [1.0] * 6)
     assert result is True
     assert parachute.triggerfunc._expects_udot is expects_udot
+
+
+class TestParachuteNumericTrigger:
+    """Numeric height triggers must accept numpy scalar integers/floats and
+    reject bool (which is a Real subclass in Python)."""
+
+    @pytest.mark.parametrize(
+        "trigger",
+        [
+            800,
+            800.0,
+            np.int32(800),
+            np.int64(800),
+            np.float64(800.0),
+        ],
+    )
+    def test_numeric_height_trigger_accepted(self, trigger):
+        parachute = _make_parachute(trigger=trigger)
+        assert callable(parachute.triggerfunc)
+        # Falling below trigger height should fire
+        y = np.zeros(13)
+        y[5] = -1.0
+        assert bool(parachute.triggerfunc(101325.0, 799.0, y, [], None)) is True
+        assert bool(parachute.triggerfunc(101325.0, 801.0, y, [], None)) is False
+
+    @pytest.mark.parametrize("trigger", [True, False])
+    def test_bool_trigger_rejected(self, trigger):
+        with pytest.raises(ValueError, match="real number"):
+            _make_parachute(trigger=trigger)


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bug fix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/` / `make lint`) has passed locally
- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
- `CHANGELOG.md` — no action needed; an LLM workflow auto-updates it after merge

## Current behavior

`isinstance(trigger, (int, float))` rejects `numpy.int32` / `numpy.int64` height triggers while accepting `numpy.float64` (which subclasses `float`).

Fixes #1106

## New behavior

Numeric altitude triggers use `numbers.Real` excluding `bool`, so numpy integer/float scalars are accepted. Bools still raise `ValueError`.

## Breaking change

- [x] No

## Additional information

Focused unit tests added/extended; full slow suite not run in this contribution pass.