### PR TITLE
BUG: write MonteCarlo input and output rows atomically (#1110)

### DIFF
--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -268,6 +268,39 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
         except OSError as error:
             raise OSError(f"Error creating files: {error}") from error
 
+    def _append_simulation_record(self, inputs_json, outputs_json):
+        """Append one simulation's inputs and outputs as a paired record.
+
+        Writes the inputs row first, then the outputs row. If the outputs write
+        fails, the inputs file is truncated back to its size before this call so
+        the two files do not drift out of alignment.
+
+        Parameters
+        ----------
+        inputs_json : str
+            Serialized inputs row, including its trailing newline.
+        outputs_json : str
+            Serialized outputs row, including its trailing newline.
+        """
+        input_path = self.input_file
+        output_path = self.output_file
+
+        try:
+            previous_input_size = os.path.getsize(input_path)
+        except OSError:
+            previous_input_size = 0
+
+        with open(input_path, "a", encoding="utf-8") as f:
+            f.write(inputs_json)
+
+        try:
+            with open(output_path, "a", encoding="utf-8") as f:
+                f.write(outputs_json)
+        except Exception:
+            with open(input_path, "rb+") as f:
+                f.truncate(previous_input_size)
+            raise
+
     def __run_in_serial(self):
         """
         Runs the monte carlo simulation in serial mode.
@@ -290,10 +323,7 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
                 inputs_json = self.__evaluate_flight_inputs(sim_monitor.count)
                 outputs_json = self.__evaluate_flight_outputs(flight, sim_monitor.count)
 
-                with open(self.input_file, "a", encoding="utf-8") as f:
-                    f.write(inputs_json)
-                with open(self.output_file, "a", encoding="utf-8") as f:
-                    f.write(outputs_json)
+                self._append_simulation_record(inputs_json, outputs_json)
 
                 sim_monitor.print_update_status()
 
@@ -432,10 +462,7 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
 
                         break
 
-                    with open(self.input_file, "a", encoding="utf-8") as f:
-                        f.write(inputs_json)
-                    with open(self.output_file, "a", encoding="utf-8") as f:
-                        f.write(outputs_json)
+                    self._append_simulation_record(inputs_json, outputs_json)
 
                     sim_monitor.print_update_status()
                 finally:

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -105,10 +105,13 @@ def test_append_simulation_record_rolls_back_inputs_on_output_failure(tmp_path):
     original_open = builtins.open
     output_path = os.fspath(output_file)
 
-    def failing_output_open(file, mode="r", *args, **kwargs):
+    def failing_output_open(*args, **kwargs):
+        # Match builtins.open call shapes without keyword-before-vararg (W1113).
+        file = args[0] if args else kwargs["file"]
+        mode = args[1] if len(args) > 1 else kwargs.get("mode", "r")
         if os.fspath(file) == output_path and "a" in mode:
             raise OSError("no space left on device")
-        return original_open(file, mode, *args, **kwargs)
+        return original_open(*args, **kwargs)
 
     with pytest.raises(OSError, match="no space left on device"):
         with patch("builtins.open", side_effect=failing_output_open):

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -1,8 +1,11 @@
+import builtins
 import csv
 import json
+import os
 import pathlib
 import types
 from collections import namedtuple
+from unittest.mock import patch
 
 import matplotlib as plt
 import numpy as np
@@ -85,6 +88,34 @@ class MockMonteCarlo(MonteCarlo):
             "single_point": [100],
             "empty_attribute": [],
         }
+
+
+def test_append_simulation_record_rolls_back_inputs_on_output_failure(tmp_path):
+    """If the outputs append fails, the inputs row must not remain on disk."""
+    mc = MockMonteCarlo()
+    input_file = tmp_path / "inputs.json"
+    output_file = tmp_path / "outputs.json"
+    input_file.write_text('{"index": 0}\n', encoding="utf-8")
+    output_file.write_text('{"index": 0}\n', encoding="utf-8")
+    mc._input_file = str(input_file)
+    mc._output_file = str(output_file)
+
+    mc._append_simulation_record('{"index": 1}\n', '{"index": 1}\n')
+
+    original_open = builtins.open
+    output_path = os.fspath(output_file)
+
+    def failing_output_open(file, mode="r", *args, **kwargs):
+        if os.fspath(file) == output_path and "a" in mode:
+            raise OSError("no space left on device")
+        return original_open(file, mode, *args, **kwargs)
+
+    with pytest.raises(OSError, match="no space left on device"):
+        with patch("builtins.open", side_effect=failing_output_open):
+            mc._append_simulation_record('{"index": 2}\n', '{"index": 2}\n')
+
+    assert input_file.read_text(encoding="utf-8") == '{"index": 0}\n{"index": 1}\n'
+    assert output_file.read_text(encoding="utf-8") == '{"index": 0}\n{"index": 1}\n'
 
 
 def test_estimate_confidence_interval_contains_known_mean():


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bug fix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`black rocketpy/ tests/` / `make lint`) has passed locally
- [ ] All tests (`pytest tests -m slow --runslow`) have passed locally
- `CHANGELOG.md` — no action needed; an LLM workflow auto-updates it after merge

## Current behavior

MonteCarlo appends inputs then outputs in two separate `open(..., "a")` blocks (serial and parallel). If the second write fails, the inputs file keeps an orphan row and the files no longer line up by index.

Fixes #1110

## New behavior

`_append_simulation_record` records the inputs file size, writes inputs then outputs, and truncates inputs back on outputs failure so either both rows land or neither does. Serial and parallel paths both use the helper.

## Breaking change

- [x] No

## Additional information

Focused unit test mocks a failing outputs append and asserts the inputs file was rolled back. Full slow suite not run in this contribution pass.