### PR TITLE
TST: harden flaky VTK flight animation tests (#1078)

### DIFF
--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -65,24 +65,21 @@ jobs:
           pip install numpy --upgrade
           pytest rocketpy --doctest-modules --cov=rocketpy --cov-append
 
+      # Isolate flaky_vtk (#1078): native VTK/OpenGL crashes (SIGBUS/SIGSEGV)
+      # kill the pytest process, so keep them out of the main integration job
+      # and retry them in the dedicated step below.
       - name: Run Integration Tests
         run: |
           pytest tests/integration \
-            --deselect tests/integration/test_plots.py::test_flight_animations_run_off_screen \
-            --deselect tests/integration/test_plots.py::test_flight_animations_render_all_scene_options \
-            --deselect tests/integration/test_plots.py::test_flight_animation_export_gif \
+            -m "not flaky_vtk" \
             --cov=rocketpy --cov-append
 
       - name: Run VTK animation tests
         run: |
-          tests=(
-            tests/integration/test_plots.py::test_flight_animations_run_off_screen
-            tests/integration/test_plots.py::test_flight_animations_render_all_scene_options
-            tests/integration/test_plots.py::test_flight_animation_export_gif
-          )
-          attempts=3
+          # flaky_vtk marker selects the three PyVista flight animation tests.
+          attempts=5
           for attempt in $(seq 1 "$attempts"); do
-            if pytest "${tests[@]}" --cov=rocketpy --cov-append; then
+            if pytest tests/integration -m flaky_vtk --cov=rocketpy --cov-append; then
               exit 0
             else
               status=$?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,13 @@ exclude_also = [
 ]
 
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: mark test as slow to run",
+    "flaky_vtk: VTK/PyVista off-screen animation tests that can SIGBUS/SIGSEGV on headless CI (#1078)",
+]
+
+
 [tool.ruff]
 target-version = "py310"
 line-length = 88

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,11 @@ def pytest_configure(config):
         Config object to which the marker is added.
     """
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line(
+        "markers",
+        "flaky_vtk: VTK/PyVista off-screen animation tests that can "
+        "SIGBUS/SIGSEGV on headless CI (#1078)",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/integration/test_plots.py
+++ b/tests/integration/test_plots.py
@@ -9,6 +9,7 @@ from rocketpy import Flight
 from rocketpy.plots.compare import CompareFlights
 
 
+@pytest.mark.flaky_vtk
 def test_flight_animations_run_off_screen(flight_calisto):
     """Ensure both PyVista flight animations render successfully off screen."""
 
@@ -33,6 +34,7 @@ def test_flight_animations_run_off_screen(flight_calisto):
     assert rotation_result is None
 
 
+@pytest.mark.flaky_vtk
 def test_flight_animations_render_all_scene_options(flight_calisto):
     """Exercise the animation scene builders with the full set of overlays.
 
@@ -70,21 +72,27 @@ def test_flight_animations_render_all_scene_options(flight_calisto):
     assert rotation_result is None
 
 
+@pytest.mark.flaky_vtk
 def test_flight_animation_export_gif(flight_calisto, tmp_path):
     """Cover the deterministic GIF export path of ``_run_animation``."""
     pytest.importorskip("pyvista")
     pytest.importorskip("imageio")
     export_file = tmp_path / "trajectory.gif"
 
-    result = flight_calisto.plots.animate_trajectory(
-        start=0,
-        stop=0.3,
-        time_step=0.1,
-        backend="none",
-        window_size=(240, 180),
-        color_by="speed",
-        export_file=str(export_file),
-    )
+    try:
+        result = flight_calisto.plots.animate_trajectory(
+            start=0,
+            stop=0.3,
+            time_step=0.1,
+            backend="none",
+            window_size=(240, 180),
+            color_by="speed",
+            export_file=str(export_file),
+        )
+    except OSError as exc:
+        # EnvironmentError is an alias of OSError. Skip only when the off-screen
+        # renderer is unavailable; assertion failures below still fail the test.
+        pytest.skip(f"Off-screen VTK rendering unavailable: {exc}")
 
     assert result == str(export_file)
     assert export_file.is_file()


### PR DESCRIPTION
## Summary
- Mark the three PyVista/VTK flight animation tests with `flaky_vtk` and register the marker in `pyproject.toml` / `tests/conftest.py`.
- Drive CI isolation with `-m "not flaky_vtk"` / `-m flaky_vtk` instead of hard-coded `--deselect` paths; bump native-crash retries from 3 to 5.
- Soft-skip `test_flight_animation_export_gif` only on `OSError` when off-screen rendering is unavailable; assertion failures still fail the test.

`develop` already isolates these tests from the main integration job and retries SIGBUS/SIGSEGV (135/138/139). This PR makes that flake explicit via a marker and a slightly safer export path.

Fixes #1078

## Test plan
- [x] `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/integration/test_plots.py -m flaky_vtk --collect-only` collects exactly the three animation tests
- [x] `-m "not flaky_vtk"` deselects those three and keeps the compare tests
- [ ] CI `Pytest` matrix: integration step skips `flaky_vtk`; VTK step retries up to 5 times on 135/138/139