### PR TITLE
BUG: Restore UTC fallback without timezonefinder

### DIFF
--- a/rocketpy/environment/environment_analysis.py
+++ b/rocketpy/environment/environment_analysis.py
@@ -450,7 +450,7 @@ class EnvironmentAnalysis:  # pylint: disable=too-many-public-methods
                     tf.timezone_at(lng=self.longitude, lat=self.latitude)
                 )
             except ImportError:
-                warnings.warning(  # pragma: no cover
+                warnings.warn(
                     "'timezonefinder' not installed, defaulting to UTC."
                     + " Install timezonefinder to get local time zone."
                     + " To do so, run 'pip install timezonefinder'"

--- a/tests/unit/environment/test_environment_analysis.py
+++ b/tests/unit/environment/test_environment_analysis.py
@@ -1,12 +1,51 @@
 import os
+from datetime import datetime
 from unittest.mock import patch
 
 import matplotlib as plt
 import pytest
 
+from rocketpy import EnvironmentAnalysis
 from rocketpy.tools import import_optional_dependency
 
 plt.rcParams.update({"figure.max_open_warning": 0})
+
+
+@patch("rocketpy.environment.environment_analysis._EnvironmentAnalysisPlots")
+@patch("rocketpy.environment.environment_analysis._EnvironmentAnalysisPrints")
+@patch.object(
+    EnvironmentAnalysis,
+    "_EnvironmentAnalysis__check_requirements",
+)
+@patch(
+    "rocketpy.environment.environment_analysis.import_optional_dependency",
+    side_effect=ImportError("timezonefinder is not installed"),
+)
+def test_missing_timezonefinder_defaults_to_utc(
+    _mock_import_optional_dependency,
+    _mock_check_requirements,
+    _mock_prints,
+    _mock_plots,
+):
+    """Use UTC when automatic timezone detection is unavailable."""
+    # Arrange
+    start_date = datetime(2026, 1, 1)
+    end_date = datetime(2026, 1, 2)
+
+    # Act
+    with pytest.warns(UserWarning, match="defaulting to UTC"):
+        analysis = EnvironmentAnalysis(
+            start_date=start_date,
+            end_date=end_date,
+            latitude=0,
+            longitude=0,
+            timezone=None,
+        )
+
+    # Assert
+    assert analysis.preferred_timezone.zone == "UTC"
+    assert analysis.start_date.tzinfo is not None
+    assert analysis.end_date.tzinfo is not None
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix)
- [x] Code maintenance (tests)

## Checklist

- [x] A regression test covers the missing optional dependency
- [x] Docs were reviewed; no update is needed because the intended UTC fallback is unchanged
- [x] Ruff formatting and lint checks pass
- [x] Pylint reports 10.00/10 for the changed files
- `CHANGELOG.md` — no action needed; an LLM workflow auto-updates it after merge

## Current behavior

When `EnvironmentAnalysis` receives no explicit timezone, it uses the optional
`timezonefinder` dependency to select one from the launch coordinates. If that
dependency is unavailable, the fallback handler calls `warnings.warning`, which
does not exist. Construction stops with `AttributeError` before UTC can be
selected.

## New behavior

The fallback now calls `warnings.warn`, emits the existing message, selects UTC,
and localizes naive input dates. The regression test exercises the public
constructor while forcing the optional import to fail.

## Breaking change

- [x] No

## Verification

- `pytest tests/unit/environment/test_environment_analysis.py::test_missing_timezonefinder_defaults_to_utc -q` — 1 passed
- `pytest tests/unit/environment -m "not slow" -q` — 159 passed, 6 deselected
- `ruff check rocketpy/environment/environment_analysis.py tests/unit/environment/test_environment_analysis.py`
- `ruff format --check rocketpy/environment/environment_analysis.py tests/unit/environment/test_environment_analysis.py`
- `pylint rocketpy/environment/environment_analysis.py tests/unit/environment/test_environment_analysis.py` — 10.00/10
