### PR TITLE
BUG: avoid scalar statistics for structured Monte Carlo results

### DIFF
--- a/rocketpy/simulation/monte_carlo.py
+++ b/rocketpy/simulation/monte_carlo.py
@@ -18,6 +18,7 @@ import json
 import os
 import traceback
 import warnings
+from numbers import Real
 from pathlib import Path
 from time import time
 
@@ -1170,8 +1171,12 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
 
     def set_processed_results(self):
         """
-        Creates a dictionary with the mean and standard deviation of each
-        parameter available in the results.
+        Create summary statistics for scalar, real-valued results.
+
+        Structured and non-numeric results remain available in ``results``.
+        Their entry in ``processed_results`` contains five ``None`` values
+        because a scalar mean, median, standard deviation, and prediction
+        interval are not defined for those values.
 
         Returns
         -------
@@ -1179,19 +1184,18 @@ class MonteCarlo:  # pylint: disable=too-many-public-methods
         """
         self.processed_results = {}
         for result, values in self.results.items():
-            try:
-                mean = np.mean(values)
-                stdev = np.std(values)
-                self.processed_results[result] = (mean, stdev)
-                pi_low = np.quantile(values, 0.025)
-                pi_high = np.quantile(values, 0.975)
-                median = np.median(values)
-            except TypeError:
-                mean = None
-                stdev = None
-                pi_low = None
-                pi_high = None
-                median = None
+            if not values or not all(
+                isinstance(value, Real) and not isinstance(value, (bool, np.bool_))
+                for value in values
+            ):
+                self.processed_results[result] = (None, None, None, None, None)
+                continue
+
+            mean = np.mean(values)
+            stdev = np.std(values)
+            pi_low = np.quantile(values, 0.025)
+            pi_high = np.quantile(values, 0.975)
+            median = np.median(values)
             self.processed_results[result] = (mean, median, stdev, pi_low, pi_high)
 
     # Import methods

--- a/tests/unit/simulation/test_monte_carlo.py
+++ b/tests/unit/simulation/test_monte_carlo.py
@@ -252,6 +252,43 @@ class MockMonteCarloWithLogs(MonteCarlo):
         self.num_of_loaded_sims = 3
 
 
+def test_set_processed_results_summarizes_real_scalars():
+    mc = MockMonteCarloWithLogs()
+    mc.results = {"value": [1, np.int64(2), np.float32(3)]}
+
+    mc.set_processed_results()
+
+    mean, median, stdev, pi_low, pi_high = mc.processed_results["value"]
+    assert mean == pytest.approx(2)
+    assert median == pytest.approx(2)
+    assert stdev == pytest.approx(np.std([1, 2, 3]))
+    assert pi_low == pytest.approx(np.quantile([1, 2, 3], 0.025))
+    assert pi_high == pytest.approx(np.quantile([1, 2, 3], 0.975))
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        ["ascent", "descent"],
+        [[1, 2], [3, 4]],
+        [[1], [2, 3]],
+        [{"x": 1}, {"x": 2}],
+        [np.array([1, 2]), np.array([3, 4])],
+        [1, "two"],
+        [True, False],
+        [],
+    ],
+)
+def test_set_processed_results_preserves_structured_results(values):
+    mc = MockMonteCarloWithLogs()
+    mc.results = {"structured": values}
+
+    mc.set_processed_results()
+
+    assert mc.results["structured"] is values
+    assert mc.processed_results["structured"] == (None, None, None, None, None)
+
+
 def test_export_outputs_to_csv(tmp_path):
     """Tests that outputs are correctly exported to CSV."""
     mc = MockMonteCarloWithLogs()


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix)
- [ ] Code maintenance
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other

Closes #1145.

## Current behavior

`MonteCarlo.set_processed_results()` sends all collected output values to NumPy's scalar aggregation functions. Equal-shaped lists and arrays are flattened into a single distribution, while ragged or empty values raise before results can finish loading.

At merge base `cb6106a717207dd8fc2dfe1446d80ff75022f21b`:

| Input observations | Result |
| --- | --- |
| `[[1, 2], [3, 4]]` | scalar statistics with mean `2.5` |
| two `np.array([1, 2])` values | scalar statistics with mean `2.5` |
| `[[1], [2, 3]]` | `ValueError` |
| `[]` | `IndexError` |

## New behavior

Summary statistics are calculated only when every observation is a real-valued scalar. Structured, non-numeric, boolean, mixed, and empty results remain unchanged in `results`; their existing five-element `processed_results` tuple is `(None, None, None, None, None)`.

The tuple shape and scalar result behavior remain unchanged.

At head `0c93bf7058222e4997df52981d45a9da4ad25e17`, all four inputs above return the five-`None` tuple without changing their raw values.

## Verification

- `.venv/bin/python -m pytest tests/unit/simulation/test_monte_carlo.py -k set_processed_results -q`: 9 passed
- `.venv/bin/python -m pytest tests/unit/simulation/test_monte_carlo.py tests/integration/simulation/test_monte_carlo.py -m 'not slow' -q`: 50 passed, 5 deselected
- `.venv/bin/ruff check rocketpy/simulation/monte_carlo.py tests/unit/simulation/test_monte_carlo.py`: passed
- `.venv/bin/ruff format --check rocketpy/simulation/monte_carlo.py tests/unit/simulation/test_monte_carlo.py`: passed
- `git diff --check`: passed

The slow Monte Carlo simulation matrix was not run locally.

Environment: RocketPy 1.13.0; Python 3.12.6; NumPy 2.5.2; SciPy 1.18.0; pytest 9.1.1; Ruff 0.16.3; macOS 26.5.2 arm64.

## Breaking change

- [x] No
