### PR TITLE
BUG: report missing impact roots explicitly

### DIFF
--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -1225,6 +1225,8 @@ class Flight:
         ]
         if len(valid_t_root) > 1:  # pragma: no cover
             raise ValueError("Multiple roots found when solving for impact time.")
+        if len(valid_t_root) == 0:
+            raise ValueError("No valid roots found when solving for impact time.")
         # Determine impact state at t_root
         self.t = self.t_final = valid_t_root[0] + self.solution[-2][0]
         interpolator = phase.solver.dense_output()

--- a/tests/unit/simulation/test_flight.py
+++ b/tests/unit/simulation/test_flight.py
@@ -1,6 +1,7 @@
 import json
 import os
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import matplotlib as plt
 import numpy as np
@@ -82,6 +83,65 @@ def setup_rocket_with_given_static_margin(rocket, static_margin):
 
 
 # Tests
+
+
+def _make_impact_event_state():
+    flight = object.__new__(Flight)
+    flight.env = SimpleNamespace(elevation=0)
+    flight.solution = [
+        [10.0, 0, 0, 1, 0, 0, -1],
+        [11.0, 0, 0, -1, 0, 0, -1],
+    ]
+    flight.flight_phases = SimpleNamespace(
+        flush_after=MagicMock(), add_phase=MagicMock()
+    )
+
+    solver = SimpleNamespace(
+        step_size=1.0,
+        dense_output=lambda: lambda _: np.array([2, 3, 0, 4, 5, -6]),
+        status="running",
+    )
+    time_nodes = SimpleNamespace(flush_after=MagicMock(), add_node=MagicMock())
+    phase = SimpleNamespace(solver=solver, time_nodes=time_nodes)
+    return flight, phase
+
+
+@pytest.mark.parametrize(
+    "roots, match",
+    [
+        ([-1 + 0j, 2 + 0j], "No valid roots found"),
+        ([0.25 + 0j, 0.75 + 0j], "Multiple roots found"),
+    ],
+)
+def test_handle_impact_event_reports_invalid_root_counts(roots, match):
+    flight, phase = _make_impact_event_state()
+
+    with patch(
+        "rocketpy.simulation.flight.find_roots_cubic_function", return_value=roots
+    ):
+        with pytest.raises(ValueError, match=match):
+            flight._Flight__handle_impact_event(phase, phase_index=1, node_index=2)
+
+
+def test_handle_impact_event_uses_single_valid_root():
+    flight, phase = _make_impact_event_state()
+
+    with patch(
+        "rocketpy.simulation.flight.find_roots_cubic_function",
+        return_value=[0.5 + 0j],
+    ):
+        handled = flight._Flight__handle_impact_event(
+            phase, phase_index=1, node_index=2
+        )
+
+    assert handled is True
+    assert flight.t == flight.t_final == pytest.approx(10.5)
+    assert flight.impact_velocity == -6
+    assert phase.solver.status == "finished"
+    flight.flight_phases.flush_after.assert_called_once_with(1)
+    flight.flight_phases.add_phase.assert_called_once_with(10.5)
+    phase.time_nodes.flush_after.assert_called_once_with(2)
+    phase.time_nodes.add_node.assert_called_once_with(10.5, [], [], [])
 
 
 def test_get_solution_at_time(flight_calisto):


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix)
- [ ] Code maintenance
- [ ] ReadMe, Docs and GitHub updates
- [ ] Other

Closes #1147.

## Current behavior

`Flight.__handle_impact_event()` reports multiple valid interpolation roots explicitly, but assumes the list is non-empty before reading its first element.

At merge base `cb6106a717207dd8fc2dfe1446d80ff75022f21b`, a one-second step whose cubic roots are `[-1 + 0j, 2 + 0j]` produces:

```text
IndexError: list index out of range
```

## New behavior

The impact handler checks the zero-root case before indexing and reports:

```text
ValueError: No valid roots found when solving for impact time.
```

This matches the existing rail-exit error style. The single-root path is unchanged, and multiple valid roots retain their existing `ValueError`.

At head `e511a80b2cb0c8140db6818af0dcff2245e217b0`, focused tests exercise all three root counts. The single-root case also verifies impact time, velocity, phase updates, time-node updates, and solver termination.

## Verification

- `.venv/bin/python -m pytest tests/unit/simulation/test_flight.py -k handle_impact_event -q`: 3 passed, 60 deselected
- `.venv/bin/python -m pytest tests/unit/simulation/test_flight.py -q`: 59 passed, 4 skipped
- `.venv/bin/ruff check rocketpy/simulation/flight.py tests/unit/simulation/test_flight.py`: passed
- `.venv/bin/ruff format --check rocketpy/simulation/flight.py tests/unit/simulation/test_flight.py`: passed
- `git diff --check`: passed

The full integration and slow test suites were not run locally.

Environment: RocketPy 1.13.0; Python 3.12.6; NumPy 2.5.2; SciPy 1.18.0; pytest 9.1.1; Ruff 0.16.3; macOS 26.5.2 arm64.

## Breaking change

- [x] No
