### PR TITLE
DOC: correct Flight aerodynamic moment units

### DIFF
--- a/rocketpy/simulation/flight.py
+++ b/rocketpy/simulation/flight.py
@@ -3007,19 +3007,19 @@ class Flight:
     @funcify_method("Time (s)", "M1 (Nm)", "linear", "zero")
     def M1(self):
         """Aerodynamic moment acting along the x-axis of the rocket's body
-        frame as a function of time. Expressed in Newtons (N)."""
+        frame as a function of time. Expressed in Newton-metres (N·m)."""
         return self.__evaluate_post_process[:, [0, 10]]
 
     @funcify_method("Time (s)", "M2 (Nm)", "linear", "zero")
     def M2(self):
         """Aerodynamic moment acting along the y-axis of the rocket's body
-        frame as a function of time. Expressed in Newtons (N)."""
+        frame as a function of time. Expressed in Newton-metres (N·m)."""
         return self.__evaluate_post_process[:, [0, 11]]
 
     @funcify_method("Time (s)", "M3 (Nm)", "linear", "zero")
     def M3(self):
         """Aerodynamic moment acting along the z-axis of the rocket's body
-        frame as a function of time. Expressed in Newtons (N)."""
+        frame as a function of time. Expressed in Newton-metres (N·m)."""
         return self.__evaluate_post_process[:, [0, 12]]
 
     @funcify_method("Time (s)", "Net Thrust (N)", "linear", "zero")


### PR DESCRIPTION
## Pull request type

- [ ] Code changes
- [ ] Code maintenance
- [x] ReadMe, Docs and GitHub updates
- [ ] Other

## Current behavior

The `Flight.M1`, `Flight.M2`, and `Flight.M3` docstrings describe aerodynamic moments as Newtons (N), which is a force unit. Their `Function` output labels and the surrounding Flight documentation already identify these values as moments.

At merge base `cb6106a717207dd8fc2dfe1446d80ff75022f21b`, all three docstrings say:

```text
Expressed in Newtons (N).
```

## New behavior

At head `3ac68cdf16e65bd070c608d8b672dced429dbec6`, the three docstrings say:

```text
Expressed in Newton-metres (N·m).
```

No executable behavior changes.

## Verification

- Searched the source and user documentation for M1, M2, and M3 unit descriptions; these were the three force-unit references.
- `.venv/bin/ruff check rocketpy/simulation/flight.py`: passed
- `.venv/bin/ruff format --check rocketpy/simulation/flight.py`: passed
- `git diff --check`: passed
- Sphinx 8.1.3 started with `-W --keep-going` and read the documentation until the first notebook conversion. The local build could not continue because Pandoc is not installed; no Sphinx warning from this change was reported before that external-tool failure.

The GitHub documentation job remains the complete Sphinx verification.

Environment: RocketPy 1.13.0; Python 3.12.6; Ruff 0.16.3; macOS 26.5.2 arm64.

## Breaking change

- [x] No
