### PR TITLE
TST: cover controller behavior and reporting

### DIFF
--- a/tests/unit/control/test_controller.py
+++ b/tests/unit/control/test_controller.py
@@ -1,0 +1,158 @@
+from dataclasses import dataclass
+
+from rocketpy.control.controller import _Controller
+
+
+@dataclass(frozen=True)
+class InteractiveObject:
+    name: str
+
+
+def controller_function(
+    time,
+    sampling_rate,
+    state_vector,
+    state_history,
+    observed_variables,
+    interactive_objects,
+    sensors,
+    environment,
+):
+    return {
+        "time": time,
+        "sampling_rate": sampling_rate,
+        "state": state_vector,
+        "history": state_history,
+        "previous": observed_variables[-1],
+        "objects": interactive_objects,
+        "sensors": sensors,
+        "environment": environment,
+    }
+
+
+def test_controller_preserves_initial_observation_and_appends_return_value():
+    initial_observation = {"deployment": 0.0}
+    interactive_object = InteractiveObject("Air brakes")
+    controller = _Controller(
+        interactive_objects=[interactive_object],
+        controller_function=controller_function,
+        sampling_rate=20,
+        initial_observed_variables=initial_observation,
+        name="Air-brake controller",
+    )
+
+    state = [0.0] * 13
+    history = [[0.0] + state]
+    sensors = [object()]
+    environment = object()
+    controller(0.25, state, history, sensors, environment)
+
+    assert controller.observed_variables == [
+        initial_observation,
+        {
+            "time": 0.25,
+            "sampling_rate": 20,
+            "state": state,
+            "history": history,
+            "previous": initial_observation,
+            "objects": [interactive_object],
+            "sensors": sensors,
+            "environment": environment,
+        },
+    ]
+
+
+def test_controller_info_reports_discrete_rate_and_each_interactive_object(capsys):
+    controller = _Controller(
+        interactive_objects=[
+            InteractiveObject("Left air brake"),
+            InteractiveObject("Right air brake"),
+        ],
+        controller_function=controller_function,
+        sampling_rate=4,
+        name="Roll controller",
+    )
+
+    controller.all_info()
+
+    assert capsys.readouterr().out == (
+        "\nController Details\n\n"
+        "Controller 'Roll controller' with sampling rate 4 Hz.\n"
+        "Controller function: controller_function\n"
+        "Controller refresh rate: 4.000 Hz\n"
+        "interactive Objects\n"
+        "Left air brake\n"
+        "Right air brake\n"
+    )
+
+
+def test_controller_info_reports_continuous_rate_and_single_object(capsys):
+    controller = _Controller(
+        interactive_objects=InteractiveObject("Thrust vector actuator"),
+        controller_function=controller_function,
+        sampling_rate=None,
+        name="Pitch controller",
+    )
+
+    controller.info()
+
+    assert capsys.readouterr().out == (
+        "\nController Details\n\n"
+        "Controller 'Pitch controller' with continuous sampling.\n"
+        "Controller function: controller_function\n"
+        "Controller refresh rate: continuous (every solver step)\n"
+        "interactive Objects\n"
+        "Thrust vector actuator\n"
+    )
+
+
+def test_controller_to_dict_without_pickle_uses_function_name_and_object_hashes():
+    interactive_objects = [InteractiveObject("A"), InteractiveObject("B")]
+    controller = _Controller(
+        interactive_objects=interactive_objects,
+        controller_function=controller_function,
+        sampling_rate=8,
+        initial_observed_variables=[0.0],
+        name="Test controller",
+    )
+
+    data = controller.to_dict(allow_pickle=False)
+
+    assert data == {
+        "controller_function": "controller_function",
+        "sampling_rate": 8,
+        "initial_observed_variables": [0.0],
+        "name": "Test controller",
+        "_interactive_objects_hash": [hash(obj) for obj in interactive_objects],
+    }
+
+
+def test_controller_to_dict_hashes_a_single_interactive_object():
+    interactive_object = InteractiveObject("Actuator")
+    controller = _Controller(
+        interactive_objects=interactive_object,
+        controller_function=controller_function,
+    )
+
+    assert controller.to_dict(allow_pickle=False)["_interactive_objects_hash"] == hash(
+        interactive_object
+    )
+
+
+def test_controller_from_dict_accepts_an_existing_callable():
+    data = {
+        "interactive_objects": [InteractiveObject("Actuator")],
+        "controller_function": controller_function,
+        "sampling_rate": 5,
+        "initial_observed_variables": [1.0],
+        "name": "Restored controller",
+        "_interactive_objects_hash": [1234],
+    }
+
+    restored = _Controller.from_dict(data)
+
+    assert restored.base_controller_function is controller_function
+    assert restored.sampling_rate == 5
+    assert restored.initial_observed_variables == [1.0]
+    assert restored.name == "Restored controller"
+    assert restored._interactive_objects_hash == [1234]


### PR DESCRIPTION
## Summary

Add focused unit coverage for controller state handling, reporting, and non-pickle serialization. The tests exercise observable behavior and complement the existing Flight integration coverage; they do not change production code.

This is a small contribution toward #709.

## Coverage

Both measurements used the same non-slow unit, integration, and acceptance suite, followed by the RocketPy doctests.

| Scope | Base `cb6106a717207dd8fc2dfe1446d80ff75022f21b` | Head `5a205109a6989a569d20e8ec448eba8c71c6ae1e` |
| --- | ---: | ---: |
| `rocketpy/control/controller.py` | 54/63 (85.71%) | 63/63 (100.00%) |
| `rocketpy/prints/controller_prints.py` | 7/24 (29.17%) | 22/24 (91.67%) |
| Entire `rocketpy` package | 13,810/17,080 (80.8548%) | 13,834/17,080 (80.9953%) |

The new tests cover 24 previously missed statements. They verify:

- preservation of the initial observation and appending of each controller return value;
- discrete and continuous controller descriptions;
- reporting for one and multiple interactive objects;
- non-pickle serialization of the function name and interactive-object hashes; and
- restoration when `from_dict()` receives an existing callable.

## Verification

```console
$ pytest tests \
    --deselect tests/integration/test_plots.py::test_flight_animations_run_off_screen \
    --deselect tests/integration/test_plots.py::test_flight_animations_render_all_scene_options \
    --deselect tests/integration/test_plots.py::test_flight_animation_export_gif \
    --cov=rocketpy --cov-report=
2193 passed, 53 skipped, 3 deselected

$ pytest rocketpy --doctest-modules --cov=rocketpy --cov-append --cov-report=
48 passed

$ pytest tests/unit/control/test_controller.py \
    tests/unit/simulation/test_flight_time_nodes.py \
    tests/integration/simulation/test_flight.py -k controller
13 passed, 34 deselected

$ ruff check tests/unit/control/test_controller.py
All checks passed!

$ ruff format --check tests/unit/control/test_controller.py
1 file already formatted
```

The three PyVista animation tests were excluded locally because the first off-screen render terminated the local VTK process with a segmentation fault. The repository workflow already runs those three tests as a separate retrying step; the PR does not modify animation code.

## Environment

- macOS 26.5.2, arm64
- Python 3.12.6
- RocketPy 1.13.0
- NumPy 2.5.2
- SciPy 1.18.0
- pytest 9.1.1
- Ruff 0.16.3
