### PR TITLE
TST: use UTC for the HRRR forecast date

### DIFF
--- a/tests/integration/environment/test_environment.py
+++ b/tests/integration/environment/test_environment.py
@@ -321,7 +321,7 @@ def test_hrrr_atmosphere(mock_show, example_spaceport_env):  # pylint: disable=u
     # Sometimes the HRRR latest-model can fail due to not having at least 24
     # hours in the future in the forecast, so we try with 12 hours in the future
     # only.
-    example_spaceport_env.set_date(datetime.now() + timedelta(hours=12))
+    example_spaceport_env.set_date(datetime.now(timezone.utc) + timedelta(hours=12))
     example_spaceport_env.set_atmospheric_model(type="Forecast", file="HRRR")
     assert example_spaceport_env.all_info() is None
 


### PR DESCRIPTION
## Summary

Make the live HRRR slow test construct its forecast date in UTC. `Environment.set_date()` treats a naive `datetime` according to its default `timezone="UTC"`, so using the host-local result of `datetime.now()` shifts the requested forecast window on non-UTC systems.

This is a test-only reliability fix that supports the slow-suite measurements in #709.

## Before and after

Both runs used the same host in `Asia/Taipei` and the same live HRRR source.

| Revision | Requested/selected time | Result |
| --- | --- | --- |
| Base `cb6106a717207dd8fc2dfe1446d80ff75022f21b` | Requested `2026-08-14 22:58 UTC`; source ended at `19:00 UTC` | `ValueError` |
| Head `4ec030f27f4d772d5108709914ed853dca826a11` | Source selected `2026-08-14 15:00 UTC` | Passed |

The change uses `datetime.now(timezone.utc)`; `timezone` was already imported by the test module.

## Verification

```console
$ pytest tests/integration/environment/test_environment.py::test_hrrr_atmosphere \
    --runslow -q
1 passed, 1 warning in 4.12s

$ ruff check tests/integration/environment/test_environment.py
All checks passed!

$ ruff format --check tests/integration/environment/test_environment.py
1 file already formatted
```

The warning reports that the exact requested instant was rounded to the available `15:00 UTC` forecast step. The test still depends on the live HRRR service and its published forecast range; this change only removes the host-timezone offset.

## Environment

- macOS 26.5.2, arm64, `Asia/Taipei`
- Python 3.12.6
- RocketPy 1.13.0
- NumPy 2.5.2
- SciPy 1.18.0
- pytest 9.1.1
- Ruff 0.16.3
