### PR TITLE
TST: cover Function unit conversions

### DIFF
--- a/tests/unit/test_units.py
+++ b/tests/unit/test_units.py
@@ -1,5 +1,7 @@
+import numpy as np
 import pytest
 
+from rocketpy import Function
 from rocketpy.units import conversion_factor, convert_temperature, convert_units
 
 
@@ -82,3 +84,41 @@ class TestConvertUnits:
 
     def test_convert_units_kilometer_to_mile(self):
         assert convert_units(1, "km", "mi") == pytest.approx(0.621371, rel=1e-2)
+
+    def test_convert_units_function_input_axis(self):
+        function = Function(
+            np.array([[0.0, 0.0], [60.0, 100.0]]),
+            inputs="Time (s)",
+            outputs="Distance (m)",
+            interpolation="linear",
+            extrapolation="zero",
+        )
+
+        converted = convert_units(function, "s", "min", axis=0)
+
+        np.testing.assert_allclose(
+            converted.get_source(), np.array([[0.0, 0.0], [1.0, 100.0]])
+        )
+        assert converted.__inputs__ == ["Time (min)"]
+        assert converted.__outputs__ == ["Distance (m)"]
+        assert converted.__interpolation__ == "linear"
+        assert converted.__extrapolation__ == "zero"
+
+    def test_convert_units_function_temperature_output(self):
+        function = Function(
+            np.array([[0.0, 273.15], [1.0, 373.15]]),
+            inputs="Time (s)",
+            outputs="Temperature (K)",
+            interpolation="linear",
+            extrapolation="constant",
+        )
+
+        converted = convert_units(function, "K", "degC")
+
+        np.testing.assert_allclose(
+            converted.get_source(), np.array([[0.0, 0.0], [1.0, 100.0]])
+        )
+        assert converted.__inputs__ == ["Time (s)"]
+        assert converted.__outputs__ == ["Temperature (degC)"]
+        assert converted.__interpolation__ == "linear"
+        assert converted.__extrapolation__ == "constant"


### PR DESCRIPTION
## Summary

Add two behavior tests for the `Function` branch of `convert_units()`:

- convert an input axis from seconds to minutes and verify the source data, axis labels, interpolation, and extrapolation metadata;
- convert a temperature output from kelvin to degrees Celsius and verify the same returned-`Function` contract.

This changes tests only. It does not modify unit-conversion behavior.

Refs #709.

## Revisions

- Base: `62aa0f9be32eeccafbc1aefd6ac3d90306b257ce`
- Head: `2bd510ac7a5b93b10b8b03ca117feb75c6597380`

## Before and after

The same targeted test and coverage command was run at the base and head revisions.

| Measurement | Base | Head |
| --- | ---: | ---: |
| `rocketpy/units.py` statements | 48 | 48 |
| Covered statements | 37 | 48 |
| Missed statements | 11 | 0 |
| Coverage | 77% | 100% |
| `tests/unit/test_units.py` | 19 passed | 21 passed |

## Validation

```console
$ python -m pytest tests/unit/test_units.py -q
21 passed in 0.02s

$ python -m pytest tests/unit/test_units.py -q --cov=rocketpy --cov-report=term-missing
21 passed in 1.32s
rocketpy/units.py  48  0  100%

$ python -m ruff check tests/unit/test_units.py
All checks passed!

$ python -m ruff format --check tests/unit/test_units.py
1 file already formatted
```

The array assertions use NumPy's `assert_allclose` defaults: `rtol=1e-7` and `atol=0`.

## Environment

- Python 3.12.6
- RocketPy 1.13.0
- NumPy 2.5.2
- SciPy 1.18.0
- pytest 9.1.1
- macOS 26.5.2, arm64

## Scope

The coverage comparison is limited to the targeted units test file. I did not use this focused run to claim a full non-slow-suite coverage increase.
