### PR TITLE
TST: cover attitude conversion helpers

### DIFF
--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -13,6 +13,10 @@ from rocketpy.tools import (
     haversine,
     inverted_haversine,
     mercator_to_wgs84,
+    normalize_quaternions,
+    quaternions_to_nutation,
+    quaternions_to_precession,
+    quaternions_to_spin,
     tuple_handler,
 )
 
@@ -39,6 +43,28 @@ def test_euler_to_quaternions(angles, expected_quaternions):
     assert round(q1, 7) == expected_quaternions[1]
     assert round(q2, 7) == expected_quaternions[2]
     assert round(q3, 7) == expected_quaternions[3]
+
+
+def test_quaternions_to_euler_angles_support_flight_arrays():
+    quaternions = np.array(
+        [
+            (0.5, -(0.5**0.5), 0.0, 0.5),
+            (0.5, -0.5, -0.5, 0.5),
+        ]
+    )
+    e0, e1, e2, e3 = quaternions.T
+
+    assert quaternions_to_precession(e0, e1, e2, e3) == pytest.approx([45, 90])
+    assert quaternions_to_nutation(e1, e2) == pytest.approx([-90, -90])
+    assert quaternions_to_spin(e0, e1, e2, e3) == pytest.approx([45, 0])
+
+
+def test_normalize_quaternions_handles_scaled_and_zero_inputs():
+    normalized = normalize_quaternions((1, 2, 3, 4))
+
+    assert normalized == pytest.approx(np.array([1, 2, 3, 4]) / np.sqrt(30))
+    assert np.linalg.norm(normalized) == pytest.approx(1)
+    assert normalize_quaternions((0, 0, 0, 0)) == (1, 0, 0, 0)
 
 
 def test_calculate_cubic_hermite_coefficients():


### PR DESCRIPTION
## Summary

- add direct coverage for quaternion-to-precession, nutation, and spin conversions using array inputs, matching how `Flight` evaluates recorded quaternion data
- cover normalization for both scaled and zero-magnitude quaternions
- leave production code unchanged

This is one focused coverage slice for #709.

## Before and after

| | Merge base | Head |
| --- | --- | --- |
| Full SHA | `1d04bcc3b6339bc16f3daf34195943cf9a73f2fa` | `cb11b9e280fe4dc374df0cd46f8090c4a8706c63` |
| `tests/unit/test_tools.py` | 28 passed | 30 passed |
| `rocketpy/tools.py` coverage | 48% (149/313 statements) | 50% (157/313 statements) |
| Missed statements | 164 | 156 |

Both measurements used:

```console
python -m coverage erase
python -m coverage run --source=rocketpy -m pytest tests/unit/test_tools.py -q
python -m coverage report -m rocketpy/tools.py
```

The angle and normalization assertions use `pytest.approx` defaults (`rel=1e-6`, `abs=1e-12`). The five existing weather-data warnings were unchanged between the base and head runs.

## Validation

```console
python -m coverage run --source=rocketpy -m pytest tests/unit/test_tools.py -q
# 30 passed, 5 warnings

python -m ruff check tests/unit/test_tools.py
# All checks passed!

python -m ruff format --check tests/unit/test_tools.py
# 1 file already formatted
```

## Environment

- Python 3.12.6
- RocketPy 1.13.0
- NumPy 2.5.2
- SciPy 1.18.0
- pytest 9.1.1
- macOS 26.5.2 (arm64)
