### PR TITLE
BUG: apply wind factors to the ensemble member that was selected

### DIFF
--- a/rocketpy/stochastic/stochastic_environment.py
+++ b/rocketpy/stochastic/stochastic_environment.py
@@ -182,16 +182,29 @@ class StochasticEnvironment(StochasticModel):
         member attribute.
         """
         generated_dict = next(self.dict_generator())
+        factors = {}
+        member_selected = False
         for key, value in generated_dict.items():
             # special case for ensemble member
             # TODO: Generalize create_object() with a env.ensemble_member setter
             if key == "ensemble_member":
                 self.obj.select_ensemble_member(value)
+                member_selected = True
+            elif "factor" in key:
+                factors[key.replace("_factor", "")] = value
             else:
-                if "factor" in key:
-                    # get original attribute value and multiply by factor
-                    attribute_name = f"_{key.replace('_factor', '')}"
-                    value = getattr(self, attribute_name) * value
-                    key = f"{key.replace('_factor', '')}"
                 setattr(self.obj, key, value)
+
+        # Applied last, and not where the loop met them: select_ensemble_member
+        # rebuilds the wind from the member's own profile, so a factor scaled in
+        # earlier is discarded. Which one runs first is only __dict__ order.
+        for attribute_name, factor in factors.items():
+            if member_selected:
+                # The member just loaded is the baseline. The construction-time
+                # one belongs to whichever member was active back then.
+                baseline = getattr(self.obj, attribute_name)
+            else:
+                # Construction-time value, so repeated calls do not compound.
+                baseline = getattr(self, f"_{attribute_name}")
+            setattr(self.obj, attribute_name, baseline * factor)
         return self.obj

--- a/tests/unit/stochastic/test_stochastic_environment.py
+++ b/tests/unit/stochastic/test_stochastic_environment.py
@@ -1,4 +1,8 @@
+import numpy as np
+import pytest
+
 from rocketpy.environment.environment import Environment
+from rocketpy.stochastic import StochasticEnvironment
 
 
 def test_str(stochastic_environment):
@@ -41,3 +45,82 @@ def test_create_object(stochastic_environment):
     """
     obj = stochastic_environment.create_object()
     assert isinstance(obj, Environment)
+
+
+def _two_member_ensemble(first=10.0, second=30.0):
+    """An Environment with two ensemble members whose winds differ.
+
+    Built here rather than read from a NetCDF file so the two winds are known
+    exactly and a factor applied to the wrong one is visible in the result.
+    """
+    levels = np.array([100000.0, 90000.0, 80000.0])
+    height = np.array([0.0, 1000.0, 2000.0])
+    temperature = np.array([288.0, 282.0, 275.0])
+    winds = (first, second)
+
+    environment = Environment()
+    environment.set_atmospheric_model(type="custom_atmosphere", wind_u=0, wind_v=0)
+    environment.atmospheric_model_type = "Ensemble"
+    environment.num_ensemble_members = 2
+    environment.level_ensemble = levels
+    environment.height_ensemble = np.tile(height, (2, 1))
+    environment.temperature_ensemble = np.tile(temperature, (2, 1))
+    environment.wind_u_ensemble = np.array([np.full(3, wind) for wind in winds])
+    environment.wind_v_ensemble = np.zeros((2, 3))
+    environment.wind_speed_ensemble = np.array([np.full(3, wind) for wind in winds])
+    environment.wind_heading_ensemble = np.full((2, 3), 90.0)
+    environment.wind_direction_ensemble = np.full((2, 3), 270.0)
+    environment.ensemble_member = 0
+    environment.select_ensemble_member(0)
+    return environment
+
+
+def test_create_object_scales_the_wind_of_the_member_it_selected():
+    """A wind factor must multiply the selected member's own wind.
+
+    ``select_ensemble_member`` rebuilds the wind from that member's profile, so
+    a factor applied before it used to be discarded and the run flew the raw
+    member wind while the input record still reported the factor.
+    """
+    environment = _two_member_ensemble(first=10.0, second=30.0)
+    stochastic = StochasticEnvironment(
+        environment=environment,
+        ensemble_member=[1],
+        wind_velocity_x_factor=(2.0, 0),
+    )
+    stochastic._set_stochastic(7)
+
+    wind = float(stochastic.create_object().wind_velocity_x(500))
+
+    assert wind == pytest.approx(60.0, rel=1e-9)
+    assert wind != pytest.approx(30.0, rel=1e-9)  # factor dropped
+    assert wind != pytest.approx(20.0, rel=1e-9)  # member 0's cached wind
+
+
+def test_create_object_does_not_compound_the_factor_across_calls():
+    """Each call scales the member's profile once, not the previous result."""
+    environment = _two_member_ensemble(first=10.0, second=30.0)
+    stochastic = StochasticEnvironment(
+        environment=environment,
+        ensemble_member=[1],
+        wind_velocity_x_factor=(2.0, 0),
+    )
+    stochastic._set_stochastic(7)
+
+    winds = [float(stochastic.create_object().wind_velocity_x(500)) for _ in range(3)]
+
+    assert winds == pytest.approx([60.0, 60.0, 60.0], rel=1e-9)
+
+
+def test_create_object_without_a_member_still_scales_the_construction_value():
+    """Without ensemble members the factor keeps multiplying the original wind."""
+    environment = Environment()
+    environment.set_atmospheric_model(type="custom_atmosphere", wind_u=10, wind_v=0)
+    stochastic = StochasticEnvironment(
+        environment=environment, wind_velocity_x_factor=(2.0, 0)
+    )
+    stochastic._set_stochastic(7)
+
+    winds = [float(stochastic.create_object().wind_velocity_x(500)) for _ in range(3)]
+
+    assert winds == pytest.approx([20.0, 20.0, 20.0], rel=1e-9)


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`ruff check` / `ruff format --check`) has passed locally
- [x] All tests (`pytest tests/unit tests/integration`) have passed locally

## Current behavior

`StochasticEnvironment.create_object()` walks the generated dictionary and, when it meets `ensemble_member`, calls `select_ensemble_member()`. That call rebuilds the wind functions from the chosen member's own profile.

`ensemble_member` sits in `exception_list`, so `_set_stochastic()` skips it and `_validate_ensemble()` sets it after the base constructor has already put the wind factors in `__dict__`. The factors are therefore reached first, scaled into whichever member was loaded at construction, and then overwritten.

With two members whose winds are 10 and 30, member 1 selected and a factor of 2, the flight gets 30. The input record still says the factor was applied.

```python
StochasticEnvironment(
    environment=ensemble_env,
    ensemble_member=[1],
    wind_velocity_x_factor=(2.0, 0),
)
```

A determinism test would not catch this: the same seed is consistently wrong.

## New behavior

Factors are collected during the loop and applied after it, so which entry `__dict__` happens to hold first no longer decides the result. When a member was selected, the baseline is the profile that member just loaded; otherwise it is the construction-time value, so repeated calls still do not compound.

The example above now gives 60.

## Breaking change

- [x] No

Runs that combined an ensemble with a wind factor were silently ignoring the factor, so their results change. That was the bug.

## Additional information

Three tests, filling the `test_validate_ensemble` gap that was commented out in `tests/unit/stochastic/test_stochastic_environment.py`:

- the selected member's wind is scaled, rejecting both 30 (factor dropped) and 20 (member 0's cached wind)
- repeated `create_object()` calls stay at 60 rather than compounding
- without ensemble members the factor still multiplies the construction value

Reverting the fix turns the first two red; so does keeping the construction-time baseline after a member switch. The third stays green under both, which is what tells them apart.

Local run against `develop` at 1d04bcc3: ruff clean, pylint exit 0, `pytest tests/unit tests/integration` 2216 passed, 51 skipped.
