### PR TITLE
CI: measure coverage on develop, not only on pull requests

### DIFF
--- a/.github/workflows/test_pytest.yaml
+++ b/.github/workflows/test_pytest.yaml
@@ -8,6 +8,17 @@ on:
       - ".github/**"
       - "pyproject.toml"
       - "requirements*"
+  # Codecov compares a pull request against the report it holds for the base
+  # commit. Without this, nothing ever uploads one for a commit on develop, so
+  # every pull request is measured against whichever old report is nearest and
+  # says how far behind it has fallen.
+  push:
+    branches: [master, develop]
+    paths:
+      - "**.py"
+      - ".github/**"
+      - "pyproject.toml"
+      - "requirements*"
 
 defaults:
   run:


### PR DESCRIPTION
## Pull request type

- [x] ReadMe, Docs and GitHub updates

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint has passed locally
- [x] All tests have passed locally

## Current behavior

`test_pytest.yaml` is the only workflow that uploads to Codecov, and it runs on `pull_request` alone. No commit on `develop` ever gets a coverage report.

Codecov falls back to the nearest older report it holds and says how far behind that is. The banner on my open pull requests read:

- 2026-08-14: `Report is 53 commits behind head on develop.`
- 2026-08-15: `Report is 61 commits behind head on develop.`

It grows with every merge, and the comparison is against whatever `develop` looked like whenever that stale report was uploaded rather than against the base the pull request is actually built on.

`.codecov.yml` already names `master` and `develop` under `branches:` for both the project and the patch status, so the configuration expects both to be measured. It is only the trigger that never produces the reports.

## New behavior

The same matrix also runs on a push to `master` or `develop`, under the same `paths:` filter the pull request trigger uses. Each merge leaves a report at the commit the next pull request will be compared against.

`docs.yml` pairs `pull_request` with `push` in the same shape, so this is the existing idiom in this repository rather than a new one.

## Breaking change

- [x] No

## Additional information

Nothing in either job reads `pull_request` context: the only mention of the event in the file is the trigger itself, so the matrix and the `CodecovUpload` guard behave the same on a push. Forks still get an empty `CODECOV_TOKEN` and `fail_ci_if_error` still stays off for them; a push to `develop` runs in this repository, so it has the token.

Two things worth weighing:

- This roughly doubles the matrix runs, once for the pull request and once for the merge. The alternative, a single cheap leg on push, would report lower coverage than the six-leg pull request reports and read as a drop.
- A merge that touches no `.py` file still uploads nothing, so the banner can still show a small number. That one is accurate: coverage did not change, and Codecov walking back one commit is the right answer. What this fixes is never getting a report at all.
