### PR TITLE
MNT: let pylint use every core it is given

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -72,7 +72,7 @@ ignored-modules=
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use, and will cap the count on Windows to
 # avoid hangs.
-jobs=1
+jobs=0
 
 # Control the amount of potential inferred values when inferring a single
 # object. This can help the performance when dealing with large functions or


### PR DESCRIPTION
## Pull request type

- [x] Code maintenance (refactoring, formatting, tests)

## Checklist

- [x] Lint (`pylint rocketpy/ tests/ docs/`) has passed locally
- [x] All tests have passed locally

## Current behavior

`.pylintrc` sets `jobs=1`, so the lint runs in one process no matter what the machine has. The comment directly above it already describes `0` as the auto-detecting value, including the Windows cap, so the setting reads as a leftover rather than a decision.

## New behavior

`jobs=0`. Measured over `rocketpy/`, `tests/` and `docs/` on eight cores:

| setting | wall clock | exit code |
| --- | --- | --- |
| `jobs=1` | 36.4s | 0 |
| `jobs=0` | 14.0s | 0 |

I diffed the two message sets rather than trusting the exit code, since some checkers behave differently when the files are split across processes. They are identical, so the gate is the same one and only the wait is shorter.

This reaches CI, the `Makefile` target and a plain local `pylint` at once, because all three read this file rather than passing `-j`.

## Breaking change

- [x] No

## Additional information

Windows is the usual worry with `-j`. pylint caps the process count there itself, which is what the comment in the file says, and the linters workflow runs on `ubuntu-latest` in any case.
