### PR TITLE
TST: cover Monte Carlo confidence ellipse helpers

### DIFF
--- a/tests/unit/test_tools.py
+++ b/tests/unit/test_tools.py
@@ -5,11 +5,13 @@ import pytest
 
 from rocketpy import Environment
 from rocketpy.tools import (
+    calculate_confidence_ellipse,
     calculate_cubic_hermite_coefficients,
     convert_local_extent_to_wgs84,
     convert_mercator_extent_to_local,
     euler313_to_quaternions,
     find_roots_cubic_function,
+    generate_monte_carlo_ellipses,
     haversine,
     inverted_haversine,
     mercator_to_wgs84,
@@ -65,6 +67,45 @@ def test_normalize_quaternions_handles_scaled_and_zero_inputs():
     assert normalized == pytest.approx(np.array([1, 2, 3, 4]) / np.sqrt(30))
     assert np.linalg.norm(normalized) == pytest.approx(1)
     assert normalize_quaternions((0, 0, 0, 0)) == (1, 0, 0, 0)
+
+
+def test_calculate_confidence_ellipse_axes():
+    x = np.array([-2.0, -2.0, 2.0, 2.0])
+    y = np.array([-1.0, 1.0, -1.0, 1.0])
+
+    theta, width, height = calculate_confidence_ellipse(x, y, n_std=2)
+
+    assert abs(np.cos(np.deg2rad(theta))) == pytest.approx(1)
+    assert width == pytest.approx(4 * np.sqrt(16 / 3))
+    assert height == pytest.approx(4 * np.sqrt(4 / 3))
+
+
+def test_generate_monte_carlo_ellipses_builds_scaled_patches():
+    apogee_x = np.array([8.0, 8.0, 12.0, 12.0])
+    apogee_y = np.array([19.0, 21.0, 19.0, 21.0])
+    impact_x = np.array([-8.0, -8.0, -2.0, -2.0])
+    impact_y = np.array([2.5, 5.5, 2.5, 5.5])
+
+    impact_ellipses, apogee_ellipses = generate_monte_carlo_ellipses(
+        apogee_x,
+        apogee_y,
+        impact_x,
+        impact_y,
+        n_apogee=[1, 2],
+        n_impact=[1],
+        apogee_rgb=(0.2, 0.6, 0.4),
+        impact_rgb=(0.8, 0.1, 0.3),
+        opacity=0.35,
+    )
+
+    assert len(apogee_ellipses) == 2
+    assert len(impact_ellipses) == 1
+    assert apogee_ellipses[0].center == pytest.approx((10, 20))
+    assert impact_ellipses[0].center == pytest.approx((-5, 4))
+    assert apogee_ellipses[1].width == pytest.approx(2 * apogee_ellipses[0].width)
+    assert apogee_ellipses[1].height == pytest.approx(2 * apogee_ellipses[0].height)
+    assert apogee_ellipses[0].get_facecolor() == pytest.approx((0.2, 0.6, 0.4, 0.35))
+    assert impact_ellipses[0].get_facecolor() == pytest.approx((0.8, 0.1, 0.3, 0.35))
 
 
 def test_calculate_cubic_hermite_coefficients():


### PR DESCRIPTION
## Summary

- add deterministic unit coverage for confidence-ellipse axis calculations using a known covariance matrix
- verify generated apogee and impact ellipse patches preserve centers, standard-deviation scaling, colors, and opacity
- keep the slice limited to tests; production behavior is unchanged

## Coverage

Using `tests/unit/test_tools.py` with `rocketpy/tools.py` as the measured source:

- merge base `6c156490`: 50% (157/313 statements)
- this branch: 57% (178/313 statements)

That covers 21 additional statements in the confidence-ellipse helpers.

## Validation

- `.venv/bin/python -m pytest tests/unit/test_tools.py -q -p no:cacheprovider` — 32 passed
- `.venv/bin/ruff check tests/unit/test_tools.py`
- `.venv/bin/ruff format --check tests/unit/test_tools.py`

Relates to #709.
