### PR TITLE
BUG: draw the eccentricities again, whichever way they were added

### DIFF
--- a/rocketpy/stochastic/stochastic_model.py
+++ b/rocketpy/stochastic/stochastic_model.py
@@ -124,6 +124,22 @@ class StochasticModel:
         self.__stochastic_dict = kwargs
         self._set_stochastic(seed)
 
+    def _declare_stochastic_input(self, input_name, input_value):
+        """Declare an input that an ``add_*`` method installs after ``__init__``.
+
+        ``dict_generator`` walks the inputs a model declared rather than every
+        attribute on it (#1109), and that list is built in ``__init__``. Anything
+        added afterwards is set on the instance and never drawn from unless it
+        says so here.
+
+        The value is the argument as given, not the validated form, because
+        ``_set_stochastic`` validates it again on every reseed and binds the
+        distribution to the generator that is live then.
+        """
+        if input_value is None:
+            return
+        self.__stochastic_dict[input_name] = input_value
+
     def _set_stochastic(self, seed=None):
         """Set the stochastic attributes from the input dictionary.
         This method is useful to reset or reseed the attributes of the instance.

--- a/rocketpy/stochastic/stochastic_rocket.py
+++ b/rocketpy/stochastic/stochastic_rocket.py
@@ -457,7 +457,9 @@ class StochasticRocket(StochasticModel):
             Object of the StochasticRocket class.
         """
         self.cp_eccentricity_x = self._validate_eccentricity("cp_eccentricity_x", x)
+        self._declare_stochastic_input("cp_eccentricity_x", x)
         self.cp_eccentricity_y = self._validate_eccentricity("cp_eccentricity_y", y)
+        self._declare_stochastic_input("cp_eccentricity_y", y)
         return self
 
     def add_thrust_eccentricity(self, x=None, y=None):
@@ -485,9 +487,11 @@ class StochasticRocket(StochasticModel):
         self.thrust_eccentricity_x = self._validate_eccentricity(
             "thrust_eccentricity_x", x
         )
+        self._declare_stochastic_input("thrust_eccentricity_x", x)
         self.thrust_eccentricity_y = self._validate_eccentricity(
             "thrust_eccentricity_y", y
         )
+        self._declare_stochastic_input("thrust_eccentricity_y", y)
         return self
 
     def _validate_eccentricity(self, eccentricity, position):

--- a/tests/unit/stochastic/test_stochastic_rocket.py
+++ b/tests/unit/stochastic/test_stochastic_rocket.py
@@ -1,3 +1,5 @@
+from numbers import Real
+
 import numpy as np
 import pytest
 
@@ -191,3 +193,46 @@ def test_add_free_form_fins_wraps_a_deterministic_fin_set(calisto_robust):
     added = stochastic.aerodynamic_surfaces.get_tuple_by_type(StochasticFreeFormFins)
     assert len(added) == 1
     assert added[0].component.obj is fins
+
+
+@pytest.mark.parametrize(
+    "add_them, names",
+    [
+        (
+            "add_cp_eccentricity",
+            ("cp_eccentricity_x", "cp_eccentricity_y"),
+        ),
+        (
+            "add_thrust_eccentricity",
+            ("thrust_eccentricity_x", "thrust_eccentricity_y"),
+        ),
+    ],
+)
+def test_an_eccentricity_added_after_init_is_still_drawn(calisto, add_them, names):
+    """``dict_generator`` walks the declared inputs, and these arrive later.
+
+    The list is built in ``__init__``, so a distribution installed by an
+    ``add_*`` method afterwards was set on the instance and never drawn from:
+    every simulation used the same value, with nothing to say so.
+    """
+    stochastic = StochasticRocket(rocket=calisto, radius=0.0127 / 2)
+    getattr(stochastic, add_them)(x=(0.0, 0.001), y=(0.0, 0.001))
+    stochastic._set_stochastic(42)
+
+    generated = next(stochastic.dict_generator())
+
+    assert set(names) <= set(generated), f"{add_them} was set but never sampled"
+    assert all(isinstance(generated[name], Real) for name in names)
+
+
+def test_two_seeds_move_an_eccentricity_that_was_added_late(calisto):
+    """Being present is not enough; it has to follow the seed."""
+    stochastic = StochasticRocket(rocket=calisto, radius=0.0127 / 2)
+    stochastic.add_cp_eccentricity(x=(0.0, 0.01), y=(0.0, 0.01))
+
+    def drawn(seed):
+        stochastic._set_stochastic(seed)
+        return next(stochastic.dict_generator())["cp_eccentricity_x"]
+
+    assert drawn(7) == drawn(7)
+    assert drawn(7) != drawn(8)


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`ruff check` / `ruff format --check`, `pylint`) has passed locally
- [x] All tests (`pytest tests/unit tests/integration`) have passed locally

## Current behavior

#1122 made `dict_generator` walk the inputs a model declared rather than every attribute on it. That is the right shape for #1109, and `initial_solution` is correctly out of the draw now.

The declared list is built in `__init__`. `add_cp_eccentricity` and `add_thrust_eccentricity` run after that, so what they install is never declared, and `_set_stochastic(seed)` does not re-validate it.

That matters because validation is what binds a distribution to a generator. An undeclared eccentricity keeps the one built in `__init__`, which no seed reaches, so **a fixed seed does not reproduce a run whose eccentricities were added through `add_*`**. The values are not frozen: `create_object` reaches them through `_create_eccentricities` and `_randomize_position`, which draws afresh every simulation. They simply do not answer to `random_seed`.

Four `create_object()` calls with `add_cp_eccentricity(x=(0.0, 0.01), y=(0.0, 0.01))`, reading `cp_eccentricity_x`:

```
develop    seed=42, run 1:  -0.002798  -0.005315   0.003486  -0.012569
develop    seed=42, run 2:   0.002131   0.009386   0.014345  -0.001072   <- same seed, different draws
this PR    seed=42, run 1:  -0.013022   0.000660  -0.000499   0.005323
this PR    seed=42, run 2:  -0.013022   0.000660  -0.000499   0.005323   <- reproducible
```

Thanks to @Gui-FernandesBR for catching that my first description had the symptom wrong. I had read the eccentricities out of `dict_generator`, seen them absent and concluded the value was stuck, without checking what `create_object` actually does with them.

Bisected on `develop` by reading the generated dictionary, which is where the declaration went missing:

```
3e16c9fc  (before #1122)  cp_eccentricity_x, cp_eccentricity_y,
                          thrust_eccentricity_x, thrust_eccentricity_y
5a71eb93  (#1122)         none of them
```

`ensemble_member` was fine either way: `StochasticEnvironment` passes it through the constructor, so it is declared, and the `hasattr` guard #1122 added covers `_validate_ensemble` not having set it yet. It is the fields no constructor declares that fall out.

## New behavior

An `add_*` method that installs a distribution declares it, so the draw reaches it again.

What is declared is the argument as given, not the validated form. `_set_stochastic` validates every declared input again on each reseed, and validation binds a distribution to the generator that is live at the time, so handing it the raw argument is what ties the draw to the reseed rather than to whichever one happened to come first. `_validate_eccentricity` dispatches to the same `_validate_tuple` / `_validate_scalar` / `_validate_list` that `_set_stochastic` uses, so the two agree on what a spec means.

`None` is not declared, since there is nothing to draw.

## Breaking change

- [x] No

Runs that set an eccentricity spread were not reproducible from their seed. Their values change, which is the bug being fixed.

## Additional information

Three tests: the four names appear in the generated dictionary for each `add_*` method, the values are numbers, and the same seed twice gives the same eccentricity while a different seed moves it. Dropping any one of the four declarations turns them red.

Local run against `develop` at be195d40: ruff clean, pylint exit 0, `pytest tests/unit tests/integration` 2261 passed, 51 skipped.

Found while rebasing #1054, which has an eccentricity regression test of its own that went red on the same change.

