### PR TITLE
BUG: draw each declared eccentricity once per simulation

### DIFF
--- a/rocketpy/stochastic/stochastic_rocket.py
+++ b/rocketpy/stochastic/stochastic_rocket.py
@@ -734,10 +734,16 @@ class StochasticRocket(StochasticModel):
         return parachute
 
     def _create_eccentricities(self, stochastic_x, stochastic_y, eccentricity):
-        x_rnd = self._randomize_position(stochastic_x)
-        self.last_rnd_dict[eccentricity + "_x"] = x_rnd
-        y_rnd = self._randomize_position(stochastic_y)
-        self.last_rnd_dict[eccentricity + "_y"] = y_rnd
+        # A half that was given is a declared input, so dict_generator has drawn
+        # it already; drawing again would spend a second value out of the same
+        # stream and move every component position that follows.
+        def drawn_once(name, stochastic):
+            if name not in self.last_rnd_dict:
+                self.last_rnd_dict[name] = self._randomize_position(stochastic)
+            return self.last_rnd_dict[name]
+
+        x_rnd = drawn_once(eccentricity + "_x", stochastic_x)
+        y_rnd = drawn_once(eccentricity + "_y", stochastic_y)
         return x_rnd, y_rnd
 
     def create_object(self):

--- a/tests/unit/stochastic/test_stochastic_rocket.py
+++ b/tests/unit/stochastic/test_stochastic_rocket.py
@@ -212,8 +212,8 @@ def test_an_eccentricity_added_after_init_is_still_drawn(calisto, add_them, name
     """``dict_generator`` walks the declared inputs, and these arrive later.
 
     The list is built in ``__init__``, so a distribution installed by an
-    ``add_*`` method afterwards was set on the instance and never drawn from:
-    every simulation used the same value, with nothing to say so.
+    ``add_*`` method afterwards was never re-validated on a reseed and stayed
+    bound to the unseeded generator: a fixed seed did not reproduce it.
     """
     stochastic = StochasticRocket(rocket=calisto, radius=0.0127 / 2)
     getattr(stochastic, add_them)(x=(0.0, 0.001), y=(0.0, 0.001))
@@ -236,3 +236,47 @@ def test_two_seeds_move_an_eccentricity_that_was_added_late(calisto):
 
     assert drawn(7) == drawn(7)
     assert drawn(7) != drawn(8)
+
+
+def test_a_declared_eccentricity_is_not_drawn_a_second_time(calisto):
+    """``create_object`` applies the draw ``dict_generator`` already made.
+
+    A second draw spends another value out of the same stream, which moves
+    every component position ``create_object`` places after it.
+    """
+    stochastic = StochasticRocket(rocket=calisto, radius=0.0127 / 2)
+    stochastic.add_cp_eccentricity(x=(0.0, 0.01), y=(0.0, 0.01))
+    stochastic.add_thrust_eccentricity(x=(0.0, 0.01), y=(0.0, 0.01))
+
+    stochastic._set_stochastic(42)
+    declared = next(stochastic.dict_generator())
+    expected = {name: declared[name] for name in declared if "eccentricity" in name}
+    assert len(expected) == 4
+
+    stochastic._set_stochastic(42)
+    rocket = stochastic.create_object()
+
+    applied = {
+        "cp_eccentricity_x": rocket.cp_eccentricity_x,
+        "cp_eccentricity_y": rocket.cp_eccentricity_y,
+        "thrust_eccentricity_x": rocket.thrust_eccentricity_x,
+        "thrust_eccentricity_y": rocket.thrust_eccentricity_y,
+    }
+    assert applied == expected
+    assert {name: stochastic.last_rnd_dict[name] for name in expected} == expected
+
+
+def test_an_eccentricity_half_that_was_left_out_is_still_drawn(calisto):
+    """Only a half that was given is a declared input, so the other is not.
+
+    ``create_object`` has to keep drawing it, and keep reporting it, or the
+    inputs it writes stop describing the rocket it built.
+    """
+    stochastic = StochasticRocket(rocket=calisto, radius=0.0127 / 2)
+    stochastic.add_cp_eccentricity(x=(0.0, 0.01))
+
+    stochastic._set_stochastic(42)
+    rocket = stochastic.create_object()
+
+    assert "cp_eccentricity_y" in stochastic.last_rnd_dict
+    assert stochastic.last_rnd_dict["cp_eccentricity_y"] == rocket.cp_eccentricity_y


### PR DESCRIPTION
## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Lint (`ruff check` / `ruff format`) has passed locally
- [x] All tests (`pytest tests -m slow --runslow`) have passed locally, apart from the pre-existing failures listed below
- `CHANGELOG.md`: no action needed, an LLM workflow auto-updates it after merge

## Current behavior

The follow-up @Gui-FernandesBR asked for in https://github.com/RocketPy-Team/RocketPy/pull/1167#issuecomment-5302661852.

#1167 declared the eccentricities that `add_cp_eccentricity` and `add_thrust_eccentricity` install, so `dict_generator` now draws them. `create_object` then calls `_create_eccentricities`, which draws them a second time and overwrites the first value in `last_rnd_dict`.

The exported inputs still match the applied ones, because the second write wins. What the extra draw costs is stream position. `_create_eccentricities` runs before the motor, surface and rail button loops, so every component position `create_object` places after it moves too.

Nose cone position, `stochastic_calisto`, seed 42:

| | `develop` | this PR |
|---|---|---|
| no eccentricity | 1.133146956072 | 1.133146956072 |
| two declared | 1.135127241207 | 1.134777791935 |
| four declared | 1.133041117399 | 1.135127241207 |

Four declared on this branch lands on two declared on `develop`, bit for bit, and so do the motor and lower rail button positions. Both consume four extra draws ahead of the component loops, which is the whole of the effect.

## New behavior

`_create_eccentricities` reads a half that `dict_generator` has drawn already, and draws only a half the caller left out.

That second case is the reason this is not a plain dictionary lookup. `add_cp_eccentricity(x=...)` with no `y` is documented and supported, and `y` is then not a declared input, so it never reaches `dict_generator`. Reading the dictionary unconditionally raises `KeyError` on that call and drops `cp_eccentricity_y` from the exported inputs, which `develop` reports today. `test_an_eccentricity_half_that_was_left_out_is_still_drawn` holds that shut.

The docstring correction in `test_an_eccentricity_added_after_init_is_still_drawn` is the explanation from your #1167 review: the value did vary between simulations, what a fixed seed failed to do was reproduce it.

## Breaking change

- [x] Yes

Fixed-seed baselines that declare an eccentricity move: the eccentricity values themselves, and every component position placed after them. Runs with no eccentricity are untouched, and so is anything drawn from a submodel's own generator. #1167 is not in a release yet and `[Unreleased]` already carries two entries that move fixed-seed baselines (#953 and #1102), so this folds into the same re-baseline rather than asking for a second one later.

## Additional information

`test_a_declared_eccentricity_is_not_drawn_a_second_time` fails on unmodified `develop`, with all four values wrong. `test_an_eccentricity_half_that_was_left_out_is_still_drawn` passes there, and fails on the version that reads the dictionary unconditionally.

Local checks on `24861fdf`, Linux, Python 3.13:

- `ruff check .` and `ruff format --check .` clean, ruff 0.15.20
- `pylint rocketpy/ tests/ docs/` 10.00/10, exit 0
- `pytest tests/unit` 2080 passed, `pytest rocketpy --doctest-modules` 48 passed, `pytest tests/integration` 153 passed, `pytest tests/acceptance` 18 passed
- `pytest tests -m slow --runslow` 38 passed, 5 failed. The five are the `EnvironmentAnalysis` tests, and they fail the same way on an unmodified `24861fdf` here. `test_monte_carlo_simulate[True]` also hangs on an unmodified `24861fdf` on this machine, in a forked worker, so it is deselected from that count rather than reported as a pass.
