### PR TITLE
TST: run the EnvironmentAnalysis tests in the default suite

### DIFF
--- a/tests/fixtures/environment/environment_fixtures.py
+++ b/tests/fixtures/environment/environment_fixtures.py
@@ -99,7 +99,7 @@ def example_euroc_env(example_date_naive):
     return euroc_env
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def env_analysis():
     """Environment Analysis class with hardcoded parameters
 

--- a/tests/integration/environment/test_environment_analysis.py
+++ b/tests/integration/environment/test_environment_analysis.py
@@ -3,14 +3,12 @@ import os
 from unittest.mock import patch
 
 import matplotlib as plt
-import pytest
 
 from rocketpy import Environment
 
 plt.rcParams.update({"figure.max_open_warning": 0})
 
 
-@pytest.mark.slow
 @patch("matplotlib.pyplot.show")
 def test_all_info(mock_show, env_analysis):  # pylint: disable=unused-argument
     """Test the EnvironmentAnalysis.all_info() method, which already invokes
@@ -32,7 +30,6 @@ def test_all_info(mock_show, env_analysis):  # pylint: disable=unused-argument
     os.remove("wind_rose.gif")  # remove the files created by the method
 
 
-@pytest.mark.slow
 @patch("matplotlib.pyplot.show")
 def test_exports(mock_show, env_analysis):  # pylint: disable=unused-argument
     """Check the export methods of the EnvironmentAnalysis class. It
@@ -59,7 +56,6 @@ def test_exports(mock_show, env_analysis):  # pylint: disable=unused-argument
     os.remove("export_env_analysis.json")
 
 
-@pytest.mark.slow
 @patch("matplotlib.pyplot.show")
 def test_create_environment_object(mock_show, env_analysis):  # pylint: disable=unused-argument
     assert isinstance(env_analysis.create_environment_object(), Environment)

--- a/tests/unit/environment/test_environment_analysis.py
+++ b/tests/unit/environment/test_environment_analysis.py
@@ -48,7 +48,6 @@ def test_missing_timezonefinder_defaults_to_utc(
     assert analysis.end_date.tzinfo is not None
 
 
-@pytest.mark.slow
 @patch("matplotlib.pyplot.show")
 def test_distribution_plots(mock_show, env_analysis):  # pylint: disable=unused-argument
     """Tests the distribution plots method of the EnvironmentAnalysis class. It
@@ -79,7 +78,6 @@ def test_distribution_plots(mock_show, env_analysis):  # pylint: disable=unused-
     )
 
 
-@pytest.mark.slow
 @patch("matplotlib.pyplot.show")
 def test_average_plots(mock_show, env_analysis):  # pylint: disable=unused-argument
     """Tests the average plots method of the EnvironmentAnalysis class. It
@@ -105,7 +103,6 @@ def test_average_plots(mock_show, env_analysis):  # pylint: disable=unused-argum
     assert env_analysis.plots.average_wind_rose_specific_hour(12) is None
 
 
-@pytest.mark.slow
 @patch("matplotlib.pyplot.show")
 def test_profile_plots(mock_show, env_analysis):  # pylint: disable=unused-argument
     """Check the profile plots method of the EnvironmentAnalysis class. It
@@ -147,7 +144,6 @@ def test_profile_plots(mock_show, env_analysis):  # pylint: disable=unused-argum
     )
 
 
-@pytest.mark.slow
 def test_values(env_analysis):
     """Check the numeric properties of the EnvironmentAnalysis class. It computes
     a few values and compares them to the expected values. Not all the values are
@@ -171,7 +167,6 @@ def test_values(env_analysis):
     assert pytest.approx(env_analysis.std_pressure_at_30000ft, 1e-6) == 38.48947
 
 
-@pytest.mark.slow
 @patch("matplotlib.pyplot.show")
 def test_animation_plots(mock_show, env_analysis):  # pylint: disable=unused-argument
     """Check the animation plots method of the EnvironmentAnalysis class. It
@@ -202,7 +197,6 @@ def test_animation_plots(mock_show, env_analysis):  # pylint: disable=unused-arg
     os.remove("wind_rose.gif")  # remove the files created by the method
 
 
-@pytest.mark.slow
 def test_pressure_level_wind_profile_uses_velocity_components(env_analysis):
     """Regression for PR #1041: the redundant per-level ``wind_heading`` and
     ``wind_direction`` functions were removed from the pressure-level data.


### PR DESCRIPTION
# TST: run the EnvironmentAnalysis tests in the default suite

Closes part of #709.

## What this changes

`EnvironmentAnalysis` has ten tests. Nine of them carry `@pytest.mark.slow`, so `test_pytest.yaml` never runs them and the subsystem measures 7.0% (`plots/environment_analysis_plots.py`), 39.7% (`environment/environment_analysis.py`) and 19.4% (`prints/environment_analysis_prints.py`) in the run that gates every pull request.

They are not slow because of the work they do. The `env_analysis` fixture reads two committed files under `data/weather/`, touches no network, and is declared at function scope, so nine tests each rebuild it and twenty years of hourly reanalysis data is parsed nine times.

This pull request sets the fixture to `scope="session"` and removes the nine slow marks. No production code changes.

## Effect on the default suite

| | Before | After |
| --- | ---: | ---: |
| Statements | 17,527 | 17,527 |
| Covered | 14,824 | 15,769 |
| Missed | 2,703 | 1,758 |
| Coverage | 84.5781% | 89.9583% |

Measured by running the five steps of `test_pytest.yaml` in order — unit, doctests, integration with the three animation deselects, the VTK animation tests, acceptance — each `--cov-append`, at `4263fa95d7fe6f63d9593f01e4ff7a088369e195`, before and after this branch.

Per module:

| Module | Before | After |
| --- | ---: | ---: |
| `plots/environment_analysis_plots.py` | 7.0% | 98.4% |
| `environment/environment_analysis.py` | 39.7% | 94.2% |
| `prints/environment_analysis_prints.py` | 19.4% | 100.0% |

That is +945 statements and +5.39 points, which leaves the suite 6 statements short of the 90% target in #709. Codecov reports the same pair for this branch, 84.57% to 89.96%.

## Effect on runtime

Per stage, same five commands:

| Stage | Before | After |
| --- | ---: | ---: |
| Unit | 2,167 passed, 13 skipped, 126.70s | 2,173 passed, 7 skipped, 154.04s |
| Doctests | 48 passed, 4.41s | 48 passed, 4.29s |
| Integration | 154 passed, 40 skipped, 83.61s | 157 passed, 37 skipped, 130.02s |
| VTK animation | 3 passed, 5.93s | 3 passed, 4.51s |
| Acceptance | 18 passed, 12.51s | 18 passed, 12.56s |

About 74 seconds added in total. The fixture is built once per pytest invocation, so the unit and integration steps pay for it separately.

That cost is what is left after the scope change. The nine tests on their own, both timings with a warm page cache so the comparison is fair:

```
$ pytest tests/unit/environment/test_environment_analysis.py \
         tests/integration/environment/test_environment_analysis.py --runslow -q
10 passed in 106.70s     # function-scoped fixture
10 passed in  30.11s     # session-scoped fixture
```

The repeated setups were roughly 212 of the 247 seconds this file took on a cold cache.

Holding the analysis for the session costs about 84 MB of resident memory, measured as the RSS delta across constructing the fixture object.

## Why the session scope is safe here

Every one of the ten tests reads from the fixture and none rebinds its attributes. `test_exports` is the only one that loads state into an `EnvironmentAnalysis`, and it already does that on a `copy.deepcopy` rather than on the fixture. `create_environment_object` returns a new `Environment`.

## What is not in scope

Twenty slow marks remain, twelve of them in `tests/integration/environment/test_environment.py`, the rest across the Monte Carlo, flight, encoding and Open-Meteo tests. Those are slow for reasons a fixture scope does not address, and the scheduled `test-pytest-slow.yaml` job still runs them with `-m slow --runslow`.

No CHANGELOG entry: the file asks for tests to be left out.



---

*Corrected after opening: the first version of this table was measured in an environment without `contextily`, which skips `test_monte_carlo_plots_background.py` and understated both columns by 53 statements. The change itself, +945, was reported correctly and matches Codecov. #1179 fixes the packaging gap that caused it.*
