### PR TITLE
TST: cover the rocket and Monte Carlo plot branches

### DIFF
--- a/tests/unit/rocket/test_rocket_plots.py
+++ b/tests/unit/rocket/test_rocket_plots.py
@@ -1,0 +1,122 @@
+"""Unit tests for the rocket drawing helpers in ``rocketpy.plots.rocket_plots``."""
+
+from unittest.mock import patch
+
+import pytest
+
+from rocketpy import LinearGenericSurface
+from rocketpy.mathutils.vector_matrix import Vector
+from rocketpy.motors.ring_cluster_motor import RingClusterMotor
+
+REFERENCE_AREA = 0.005
+REFERENCE_LENGTH = 0.08
+
+
+@patch("matplotlib.pyplot.show")
+@pytest.mark.parametrize("plane", ["xz", "yz"])
+@pytest.mark.parametrize(
+    "fin_fixture",
+    ["calisto_trapezoidal_fin", "calisto_elliptical_fin", "calisto_free_form_fin"],
+)
+def test_draw_a_rocket_carrying_one_fin(  # pylint: disable=unused-argument
+    mock_show, request, calisto_robust, plane, fin_fixture
+):
+    """A single ``Fin`` takes ``_draw_fin``, not the ``_draw_fins`` set branch.
+
+    That method rotates one fin out of its own coordinate system into the body
+    frame, and it projects differently in each plane, so both are drawn here.
+    """
+    fin = request.getfixturevalue(fin_fixture)
+    calisto_robust.add_surfaces(fin, Vector([0, 0, -1.04956]))
+
+    assert calisto_robust.draw(plane=plane, filename=None) is None
+
+
+@patch("matplotlib.pyplot.show")
+@pytest.mark.parametrize("plane", ["xz", "yz"])
+def test_draw_a_rocket_carrying_a_generic_surface(  # pylint: disable=unused-argument
+    mock_show, calisto_robust, plane
+):
+    """A ``GenericSurface`` has no outline to trace, so it gets a scatter point.
+
+    ``_draw_generic_surface`` is the only branch that reads the surface position
+    by index rather than by attribute, and it picks a different index per plane.
+    """
+    surface = LinearGenericSurface(
+        reference_area=REFERENCE_AREA,
+        reference_length=REFERENCE_LENGTH,
+        coefficients={},
+        name="Canard",
+    )
+    calisto_robust.add_surfaces(surface, Vector([0, 0, -0.5]))
+
+    assert calisto_robust.draw(plane=plane, filename=None) is None
+
+
+@patch("matplotlib.pyplot.show")
+def test_draw_a_rocket_with_a_hybrid_motor(  # pylint: disable=unused-argument
+    mock_show, calisto_hybrid_modded, calisto_nose_cone
+):
+    """The hybrid branch of ``_generate_motor_patches`` draws grains and tanks."""
+    calisto_hybrid_modded.add_surfaces(calisto_nose_cone, 1.160)
+
+    assert calisto_hybrid_modded.draw(filename=None) is None
+
+
+@patch("matplotlib.pyplot.show")
+def test_draw_a_rocket_with_a_liquid_motor(  # pylint: disable=unused-argument
+    mock_show, calisto_liquid_modded, calisto_nose_cone
+):
+    """The liquid branch draws positioned tanks and no combustion chamber."""
+    calisto_liquid_modded.add_surfaces(calisto_nose_cone, 1.160)
+
+    assert calisto_liquid_modded.draw(filename=None) is None
+
+
+@patch("matplotlib.pyplot.show")
+def test_draw_a_rocket_with_a_motor_cluster(  # pylint: disable=unused-argument
+    mock_show, calisto_motorless, cesaroni_m1670, calisto_nose_cone
+):
+    """A cluster repeats the grain patches around the ring.
+
+    Only the first offset keeps its legend entry, so the loop that relabels the
+    rest runs solely when there is more than one motor.
+    """
+    calisto_motorless.add_motor(
+        RingClusterMotor(motor=cesaroni_m1670, number=3, radius=0.05),
+        position=-1.373,
+    )
+    calisto_motorless.add_surfaces(calisto_nose_cone, 1.160)
+
+    assert calisto_motorless.draw(filename=None) is None
+
+
+@patch("matplotlib.pyplot.show")
+@pytest.mark.parametrize(
+    "rocket_fixture,nose_position",
+    [("calisto", 1.160), ("calisto_nose_to_tail", -1.160)],
+)
+def test_draw_a_rocket_whose_nozzle_sits_behind_its_last_surface(  # pylint: disable=unused-argument
+    mock_show, request, rocket_fixture, nose_position, calisto_nose_cone
+):
+    """``_draw_nozzle_tube`` only draws when the nozzle is past the last surface.
+
+    A rocket carrying nothing but a nose cone leaves that gap open, and the
+    comparison flips with the coordinate system, so both orientations are drawn.
+    """
+    rocket = request.getfixturevalue(rocket_fixture)
+    rocket.add_surfaces(calisto_nose_cone, nose_position)
+
+    assert rocket.draw(filename=None) is None
+
+
+def test_draw_refuses_a_rocket_with_no_aerodynamic_surfaces(calisto_motorless):
+    """There is nothing to draw the body around without at least one surface."""
+    with pytest.raises(ValueError, match="at least one aerodynamic surface"):
+        calisto_motorless.draw(filename=None)
+
+
+def test_draw_refuses_a_plane_it_cannot_project_onto(calisto_robust):
+    """Only the two longitudinal planes are defined."""
+    with pytest.raises(ValueError, match="must be 'xz' or 'yz'"):
+        calisto_robust.draw(plane="xy", filename=None)

--- a/tests/unit/simulation/test_monte_carlo_plots.py
+++ b/tests/unit/simulation/test_monte_carlo_plots.py
@@ -1,0 +1,118 @@
+"""Unit tests for the ellipse plots in ``rocketpy.plots.monte_carlo_plots``.
+
+Background-map fetching is covered separately in
+``test_monte_carlo_plots_background.py``. Everything here runs with
+``background=None`` so no tile provider is contacted.
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from rocketpy.plots.monte_carlo_plots import _MonteCarloPlots
+from rocketpy.simulation import MonteCarlo
+
+APOGEE = {"apogee_x": [100, 200, 300], "apogee_y": [100, 200, 300]}
+IMPACT = {"x_impact": [1000, 2000, 3000], "y_impact": [1000, 2000, 3000]}
+
+
+class MockMonteCarlo(MonteCarlo):
+    """A MonteCarlo carrying only the results the ellipse plots read."""
+
+    def __init__(self, results, filename="test"):
+        # pylint: disable=super-init-not-called
+        self.filename = filename
+        self.results = results
+        self.plots = _MonteCarloPlots(self)
+
+
+@pytest.fixture(name="square_image")
+def square_image_fixture(tmp_path):
+    """A small on-disk image for the ``image`` background path."""
+    imageio = pytest.importorskip("imageio")
+    path = tmp_path / "launch_site.png"
+    imageio.imwrite(path, np.zeros((8, 8, 3), dtype=np.uint8))
+    return str(path)
+
+
+@patch("matplotlib.pyplot.show")
+def test_ellipses_without_apogee_data_plots_the_impact_points(mock_show, caplog):  # pylint: disable=unused-argument
+    """A results file may hold impacts and no apogees.
+
+    The apogee lookup is allowed to miss; the method warns and draws what is
+    left rather than failing.
+    """
+    monte_carlo = MockMonteCarlo(dict(IMPACT))
+
+    assert monte_carlo.plots.ellipses() is None
+    assert "No apogee data found" in caplog.text
+
+
+@patch("matplotlib.pyplot.show")
+def test_ellipses_without_impact_data_plots_the_apogee_points(mock_show, caplog):  # pylint: disable=unused-argument
+    """The mirror case: apogees recorded, impacts missing."""
+    monte_carlo = MockMonteCarlo(dict(APOGEE))
+
+    assert monte_carlo.plots.ellipses() is None
+    assert "No impact data found" in caplog.text
+
+
+def test_ellipses_refuses_results_with_neither_apogee_nor_impact():
+    """With both lookups missing there is nothing to draw an ellipse around."""
+    monte_carlo = MockMonteCarlo({"t_final": [10, 11, 12]})
+
+    with pytest.raises(ValueError, match="No apogee or impact data found"):
+        monte_carlo.plots.ellipses()
+
+
+def test_ellipses_reports_an_image_path_that_does_not_exist(tmp_path):
+    """The path is the user's input, so the failure names it rather than the read."""
+    monte_carlo = MockMonteCarlo({**APOGEE, **IMPACT})
+
+    with pytest.raises(FileNotFoundError, match="image file was not found"):
+        monte_carlo.plots.ellipses(image=str(tmp_path / "absent.png"))
+
+
+@patch("matplotlib.pyplot.show")
+def test_ellipses_draws_over_an_image_and_marks_the_actual_landing_point(  # pylint: disable=unused-argument
+    mock_show, square_image
+):
+    """``image`` and ``actual_landing_point`` are separate optional branches."""
+    monte_carlo = MockMonteCarlo({**APOGEE, **IMPACT})
+
+    assert (
+        monte_carlo.plots.ellipses(
+            image=square_image, actual_landing_point=(1500, 1500)
+        )
+        is None
+    )
+
+
+@patch("matplotlib.pyplot.show")
+def test_ellipses_comparison_without_apogee_data(mock_show, caplog):  # pylint: disable=unused-argument
+    """The comparison reads four series at once, so one miss drops all four."""
+    monte_carlo = MockMonteCarlo(dict(IMPACT))
+    other = MockMonteCarlo(dict(IMPACT), filename="other")
+
+    assert monte_carlo.plots.ellipses_comparison(other) is None
+    assert "No apogee data found" in caplog.text
+
+
+@patch("matplotlib.pyplot.show")
+def test_ellipses_comparison_without_impact_data(mock_show, caplog):  # pylint: disable=unused-argument
+    """The mirror case for the impact series."""
+    monte_carlo = MockMonteCarlo(dict(APOGEE))
+    other = MockMonteCarlo(dict(APOGEE), filename="other")
+
+    assert monte_carlo.plots.ellipses_comparison(other) is None
+    assert "No impact data found" in caplog.text
+
+
+@patch("matplotlib.pyplot.show")
+def test_ellipses_comparison_draws_over_an_image(mock_show, square_image):  # pylint: disable=unused-argument
+    """The comparison takes the same ``image`` branch as ``ellipses``."""
+    monte_carlo = MockMonteCarlo({**APOGEE, **IMPACT})
+    other = MockMonteCarlo({**APOGEE, **IMPACT}, filename="other")
+
+    assert monte_carlo.plots.ellipses_comparison(other, image=square_image) is None


### PR DESCRIPTION
# TST: cover the rocket and Monte Carlo plot branches

Works toward #709.

## Why these two modules

At `4263fa95d7fe6f63d9593f01e4ff7a088369e195`, `plots/rocket_plots.py` measures 73.9% and `plots/monte_carlo_plots.py` 85.1% in the run that gates every pull request. Neither is untested; the fixtures simply never reach several branches.

`Rocket.draw` dispatches per component type, and the test rockets only ever carry a nose cone, a tail and a fin *set* on a solid motor. So the branches for an individual `Fin`, for a `GenericSurface`, for hybrid and liquid motors, for a ring cluster, and for a nozzle that sits behind the last aerodynamic surface were never entered.

The ellipse plots read their series out of `results` with `try`/`except KeyError`, so the warning paths only run when a results file is missing a series — which no fixture produces.

## What this adds

Two test-only files. No production code changes.

`tests/unit/rocket/test_rocket_plots.py`, 15 cases:

| Case | Branch it reaches |
| --- | --- |
| a rocket carrying one `Fin`, three fin classes × two planes | `_draw_fin`, which rotates a single fin out of its own frame rather than a set |
| a rocket carrying a `GenericSurface`, two planes | `_draw_generic_surface`, the only branch that reads position by index |
| a hybrid motor | the `HybridMotor` arm of `_generate_motor_patches` |
| a liquid motor | the `LiquidMotor` arm |
| a ring cluster | the loop that strips the legend from every grain but the first |
| a nozzle behind the last surface, both coordinate systems | both arms of `_draw_nozzle_tube` |
| no aerodynamic surfaces, and an undefined plane | the two refusals in `__validate_aerodynamic_surfaces` |

`tests/unit/simulation/test_monte_carlo_plots.py`, 8 cases: results missing their apogee series, missing their impact series, missing both, an `image` path that does not exist, and an `image` drawn together with `actual_landing_point` — for both `ellipses` and `ellipses_comparison`.

Background-map fetching stays where it already lives, in `test_monte_carlo_plots_background.py`. Everything added here passes `background=None` and contacts no tile provider.

## Effect

| | Before | After |
| --- | ---: | ---: |
| `plots/rocket_plots.py` | 73.8832% (76 missed) | 99.3127% (2 missed) |
| `plots/monte_carlo_plots.py` | 85.0622% (36 missed) | 96.6805% (8 missed) |
| Project, non-slow | 84.5781% | 85.1600% |

That is +102 statements. The unit step goes from 2,185 to 2,208 passing, and no step slows measurably: 133.83s to 134.14s for unit, 89.90s to 89.40s for integration.

Measured by running the five steps of `test_pytest.yaml` in order — unit, doctests, integration with the three animation deselects, the VTK animation tests, acceptance — each `--cov-append`, before and after this branch on the same machine with the same script. The baseline agrees with Codecov's figure for the same commit to the statement: 14,824 covered, 2,703 missed, against Codecov's 84.57%.

This branch sits on `develop`, not on #1176. The two touch disjoint modules — that one moves the `EnvironmentAnalysis` files, this one moves the two plot files — so the +945 and the +102 add rather than overlap, which would put the pair above the 90% this issue asks for. That is arithmetic on disjoint sets rather than a measured combined run; Codecov will report each against `develop` on its own.

## One thing worth fixing separately

That baseline only agrees once `contextily` is installed, and `make install` does not install it. It is declared in the `monte-carlo` extra in `pyproject.toml` but not in `requirements-optional.txt`, which is what the Makefile reads. `test_monte_carlo_plots_background.py` opens with `pytest.importorskip("contextily")`, so a contributor following the documented setup silently skips 18 tests and measures 53 statements less than CI reports, with nothing pointing at why. The workflow installs `.[all]`, so CI is unaffected. Raised separately rather than folded in here.

```
$ ruff check rocketpy/ tests/ && ruff format --check rocketpy/ tests/
All checks passed!

$ pylint tests/unit/rocket/test_rocket_plots.py tests/unit/simulation/test_monte_carlo_plots.py
Your code has been rated at 10.00/10
```

No CHANGELOG entry: the file asks for tests to be left out.

Measured on Python 3.12.3, Linux.
