### PR TITLE
MNT: install contextily with the other optional requirements

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -7,5 +7,6 @@ imageio
 multiprocess>=0.70
 statsmodels
 prettytable
+contextily>=1.0.0; python_version < '3.14'
 pyvista>=0.45
 imageio-ffmpeg>=0.5

--- a/tests/unit/simulation/test_monte_carlo_plots_background.py
+++ b/tests/unit/simulation/test_monte_carlo_plots_background.py
@@ -1,4 +1,5 @@
 # pylint: disable=unused-argument,assignment-from-no-return
+import math
 import os
 import urllib.error
 from unittest.mock import MagicMock, patch
@@ -17,6 +18,33 @@ plt.rcParams.update({"figure.max_open_warning": 0})
 pytest.importorskip(
     "contextily", reason="This test requires contextily to be installed"
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_background_tiles(monkeypatch):
+    """Return deterministic map tiles without contacting a tile provider."""
+    contextily = import_optional_dependency("contextily")
+
+    def mock_bounds2img(west, south, east, north, **kwargs):
+        earth_radius = 6378137.0
+
+        def to_mercator(longitude, latitude):
+            x = earth_radius * math.radians(longitude)
+            y = earth_radius * math.log(
+                math.tan(math.pi / 4 + math.radians(latitude) / 2)
+            )
+            return x, y
+
+        min_x, min_y = to_mercator(west, south)
+        max_x, max_y = to_mercator(east, north)
+        return np.zeros((2, 2, 3), dtype=np.uint8), (
+            min_x,
+            max_x,
+            min_y,
+            max_y,
+        )
+
+    monkeypatch.setattr(contextily, "bounds2img", mock_bounds2img)
 
 
 class MockMonteCarlo(MonteCarlo):


### PR DESCRIPTION
## The gap

`contextily` is declared in the `monte-carlo` extra in `pyproject.toml`:

```toml
monte-carlo = [
    "imageio",
    "multiprocess>=0.70",
    "statsmodels",
    "prettytable",
    "contextily>=1.0.0; python_version < '3.14'",
]
```

but not in `requirements-optional.txt`, and that is what the documented setup installs:

```make
install:
	$(PYTHON) -m pip install --upgrade pip
	pip install -r requirements.txt
	pip install -r requirements-optional.txt
	pip install -r requirements-tests.txt
	pip install -e .
```

`tests/unit/simulation/test_monte_carlo_plots_background.py` opens with `pytest.importorskip("contextily")`, so the whole file is skipped.

## What it costs

Measured at `4263fa95d7fe6f63d9593f01e4ff7a088369e195`, running the five steps of `test_pytest.yaml` in order with `--cov-append`:

| | Without `contextily` | With it |
| --- | ---: | ---: |
| `plots/monte_carlo_plots.py` | 89 missed | 36 missed |
| Project, non-slow | 14,771 covered, 84.2757% | 14,824 covered, 84.5781% |

Codecov reports 84.57% for that commit, and 14,824 hits against 2,703 misses. The second row is the one that matches; the first is what a contributor following the Makefile sees.

`Tests` installs `.[all]`, which does resolve the extra on Python 3.10, so CI is unaffected either way. What this fixes is a local run quietly disagreeing with CI by 53 statements, with a skip reason buried in `-rs` output as the only clue.

## The change

One line, the same specifier as `pyproject.toml`, marker included:

```
contextily>=1.0.0; python_version < '3.14'
```

## Verification

Before, in an environment built from the requirements files:

```
$ pytest tests/unit/simulation/test_monte_carlo_plots_background.py -q
SKIPPED [1] tests/unit/simulation/test_monte_carlo_plots_background.py:17: This test requires contextily to be installed
1 skipped in 0.03s
```

After installing it:

```
$ pytest tests/unit/simulation/test_monte_carlo_plots_background.py -q
18 passed, 16 warnings in 37.14s
```

Those 18 do reach the network — they call `contextily.bounds2img` against real tile providers rather than stubbing it. That is existing behavior and not changed here, but it is worth knowing that this makes the default local suite contact Esri, OpenStreetMap and CartoDB where it previously did not. Happy to close this instead if the team would rather those tests were stubbed first, or would rather keep them opt-in.

Found while re-measuring the baseline for #709; it is why the figures in my first comment there were 53 statements low.