### PR TITLE
DOC: backfill the Unreleased changelog entries the automation missed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,11 +51,7 @@ Attention: The newest changes should be on top -->
 ### Changed
 
 - ENH: Compute the rocket static margin lazily [#1135](https://github.com/RocketPy-Team/RocketPy/pull/1135) [#780](https://github.com/RocketPy-Team/RocketPy/issues/780)
-- CI: Measure coverage on develop, not only on pull requests [#1162](https://github.com/RocketPy-Team/RocketPy/pull/1162)
-- MNT: Let pylint use every core it is given [#1163](https://github.com/RocketPy-Team/RocketPy/pull/1163)
 - DOC: Tighten the comments that came with the sampler seed groups [#1154](https://github.com/RocketPy-Team/RocketPy/pull/1154)
-- CI: Run the changelog job for pull requests from forks [#1112](https://github.com/RocketPy-Team/RocketPy/pull/1112)
-- CI: Keep per-matrix coverage artifacts and fail Codecov errors [#1123](https://github.com/RocketPy-Team/RocketPy/pull/1123) [#1088](https://github.com/RocketPy-Team/RocketPy/issues/1088)
 - CI: make the Gemini PR reviewer actually review [#1140](https://github.com/RocketPy-Team/RocketPy/pull/1140)
 - MNT: declare dependency floors the package can actually run on [#1108](https://github.com/RocketPy-Team/RocketPy/pull/1108)
 - CI: build the docs for pull requests into develop as well [#1104](https://github.com/RocketPy-Team/RocketPy/pull/1104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ Attention: The newest changes should be on top -->
 
 ### Added
 
+- ENH: Support fixed-time parachute deployment triggers [#1133](https://github.com/RocketPy-Team/RocketPy/pull/1133) [#437](https://github.com/RocketPy-Team/RocketPy/issues/437)
+- DOC: Add SIL parachute ejection integration example [#1131](https://github.com/RocketPy-Team/RocketPy/pull/1131) [#524](https://github.com/RocketPy-Team/RocketPy/issues/524)
+- ENH: List NOAA atmosphere datasets and fetch latest [#1136](https://github.com/RocketPy-Team/RocketPy/pull/1136) [#660](https://github.com/RocketPy-Team/RocketPy/issues/660)
+- ENH: Model unbonded solid-motor grain CM shift [#1138](https://github.com/RocketPy-Team/RocketPy/pull/1138) [#340](https://github.com/RocketPy-Team/RocketPy/issues/340)
+- ENH: Add `Flight` post-step callback across all phases [#1128](https://github.com/RocketPy-Team/RocketPy/pull/1128) [#758](https://github.com/RocketPy-Team/RocketPy/issues/758)
+- DOC: Document angle-of-attack drag inputs [#1142](https://github.com/RocketPy-Team/RocketPy/pull/1142)
+- ENH: Create ensembles from user-defined profiles [#1141](https://github.com/RocketPy-Team/RocketPy/pull/1141)
+- ENH: Add tube-fin aerodynamic surface [#1144](https://github.com/RocketPy-Team/RocketPy/pull/1144)
 - ENH: StochasticFreeFormFins for Monte Carlo simulations [#1117](https://github.com/RocketPy-Team/RocketPy/pull/1117)
 - ENH: `StochasticFreeFormFins`, so free-form fin sets can be used in Monte Carlo simulations. The outline is randomized as a block, since a shape is only meaningful as a complete set of points: every coordinate is perturbed by its own draw, the fin root is held on the body line, and a list of candidate outlines can have a different number of points in each. [#953](https://github.com/RocketPy-Team/RocketPy/issues/953)
 - ENH: Support for Open Meteo API in the `Environment` class, adding the `open_meteo` and `open_meteo_ensemble` atmospheric models. Pressure-level forecasts, past forecasts (from 2021 onwards) and ensembles are read straight from a keyless JSON API, with no external files and no netCDF/OPeNDAP dependency. [#520](https://github.com/RocketPy-Team/RocketPy/issues/520) [#1119](https://github.com/RocketPy-Team/RocketPy/pull/1119)
@@ -42,6 +50,12 @@ Attention: The newest changes should be on top -->
 
 ### Changed
 
+- ENH: Compute the rocket static margin lazily [#1135](https://github.com/RocketPy-Team/RocketPy/pull/1135) [#780](https://github.com/RocketPy-Team/RocketPy/issues/780)
+- CI: Measure coverage on develop, not only on pull requests [#1162](https://github.com/RocketPy-Team/RocketPy/pull/1162)
+- MNT: Let pylint use every core it is given [#1163](https://github.com/RocketPy-Team/RocketPy/pull/1163)
+- DOC: Tighten the comments that came with the sampler seed groups [#1154](https://github.com/RocketPy-Team/RocketPy/pull/1154)
+- CI: Run the changelog job for pull requests from forks [#1112](https://github.com/RocketPy-Team/RocketPy/pull/1112)
+- CI: Keep per-matrix coverage artifacts and fail Codecov errors [#1123](https://github.com/RocketPy-Team/RocketPy/pull/1123) [#1088](https://github.com/RocketPy-Team/RocketPy/issues/1088)
 - CI: make the Gemini PR reviewer actually review [#1140](https://github.com/RocketPy-Team/RocketPy/pull/1140)
 - MNT: declare dependency floors the package can actually run on [#1108](https://github.com/RocketPy-Team/RocketPy/pull/1108)
 - CI: build the docs for pull requests into develop as well [#1104](https://github.com/RocketPy-Team/RocketPy/pull/1104)
@@ -50,6 +64,24 @@ Attention: The newest changes should be on top -->
 
 ### Fixed
 
+- BUG: Sample `StochasticFlight` inputs once per simulation [#1126](https://github.com/RocketPy-Team/RocketPy/pull/1126) [#1090](https://github.com/RocketPy-Team/RocketPy/issues/1090)
+- BUG: Fix spurious `ValueError` from floating-point roundoff at exact tank depletion [#1166](https://github.com/RocketPy-Team/RocketPy/pull/1166)
+- BUG: Draw each declared eccentricity once per simulation [#1168](https://github.com/RocketPy-Team/RocketPy/pull/1168)
+- BUG: Accept numpy integer types as a `Parachute` trigger [#1116](https://github.com/RocketPy-Team/RocketPy/pull/1116)
+- BUG: Refuse to run a Monte Carlo over a results file it cannot write [#1161](https://github.com/RocketPy-Team/RocketPy/pull/1161)
+- BUG: Write MonteCarlo input and output rows atomically [#1125](https://github.com/RocketPy-Team/RocketPy/pull/1125) [#1110](https://github.com/RocketPy-Team/RocketPy/issues/1110)
+- BUG: Draw the eccentricities again, whichever way they were added [#1167](https://github.com/RocketPy-Team/RocketPy/pull/1167)
+- BUG: Serialize numpy `SeedSequence` for sensor seeds [#1124](https://github.com/RocketPy-Team/RocketPy/pull/1124) [#1087](https://github.com/RocketPy-Team/RocketPy/issues/1087)
+- BUG: Build the Monte Carlo flights with the configuration they were given [#1164](https://github.com/RocketPy-Team/RocketPy/pull/1164)
+- BUG: Apply the wind factors to the ensemble member that was selected [#1160](https://github.com/RocketPy-Team/RocketPy/pull/1160)
+- BUG: Avoid scalar statistics for structured Monte Carlo results [#1146](https://github.com/RocketPy-Team/RocketPy/pull/1146) [#1145](https://github.com/RocketPy-Team/RocketPy/issues/1145)
+- BUG: Evaluate parachute triggers once per time node [#1121](https://github.com/RocketPy-Team/RocketPy/pull/1121) [#1086](https://github.com/RocketPy-Team/RocketPy/issues/1086)
+- DOC: Fix the RST indentation in the `dict_generator` notes [`772480d`](https://github.com/RocketPy-Team/RocketPy/commit/772480d6bc69e5b5c2f517305e974c65ca781e57)
+- BUG: Stop `dict_generator` from sampling `initial_solution` [#1122](https://github.com/RocketPy-Team/RocketPy/pull/1122) [#1109](https://github.com/RocketPy-Team/RocketPy/issues/1109)
+- BUG: Report missing impact roots explicitly [#1148](https://github.com/RocketPy-Team/RocketPy/pull/1148) [#1147](https://github.com/RocketPy-Team/RocketPy/issues/1147)
+- DOC: Correct the `Flight` aerodynamic moment units [#1149](https://github.com/RocketPy-Team/RocketPy/pull/1149)
+- BUG: Seed the parachute pressure noise with a per-instance RNG [#1134](https://github.com/RocketPy-Team/RocketPy/pull/1134) [#1091](https://github.com/RocketPy-Team/RocketPy/issues/1091)
+- BUG: Restore the UTC fallback without timezonefinder [#1143](https://github.com/RocketPy-Team/RocketPy/pull/1143)
 - BUG: Pick between the candidate values of a list input with the stochastic model's own seeded generator. `random.choice` was used, which draws from the interpreter-wide stream that `_set_stochastic` does not reseed, so a fixed seed did not reproduce the values chosen from a list, and Monte Carlo workers forked from one process walked a single shared stream instead of sampling independently. Fixed-seed baselines that vary a list input change. [#953](https://github.com/RocketPy-Team/RocketPy/issues/953)
 - BUG: Report the atmospheric model time period and ensemble member count for lower-case model types. `set_atmospheric_model` documents `type` as case-insensitive, but `Environment.info()` and `all_info()` compared against capitalised literals, so `type="ensemble"` printed no time period and no member count, and skipped the ensemble comparison plot. [#520](https://github.com/RocketPy-Team/RocketPy/issues/520)
 - BUG: Give each `CustomSampler` input its own deterministic stream, and seed samplers sharing one generator once as a group. Existing fixed-seed `CustomSampler` baselines change, and samplers built on the legacy `RandomState` must move to `default_rng` because seeds now carry the full 128 bits. [#1102](https://github.com/RocketPy-Team/RocketPy/pull/1102)


### PR DESCRIPTION
Part of #1173.

## What this does

`CHANGELOG.md` was last touched by `5eae273b` on 12 August and the highest pull request it records is #1140. Thirty-nine commits have landed on `develop` since, so `[Unreleased]` no longer describes the branch. #1173 notes that those entries will not appear on their own and suggests writing them in one pass from the merge list; this is that pass.

Twenty-eight entries, `CHANGELOG.md` only:

| Section | Count |
| --- | ---: |
| Added | 6 ENH, 2 DOC |
| Changed | 1 ENH, 1 DOC |
| Fixed | 16 BUG, 2 DOC |

## How they were chosen

From `git log 5eae273b..develop`, following the rules in the file's own header comment: `Added` for new features, `Changed` for changes in existing functionality, `Fixed` for bug fixes, and tests and GitHub maintenance left out. Seven `TST:` commits and four CI or maintenance commits fall in the gap and are therefore not listed.

Each entry uses the pull request title and link, as the header comment asks, with the issue linked alongside where the commit names one. `772480d` is a direct commit to `develop` with no pull request, so that entry links the commit.

Newest on top within each section, as the `[Unreleased]` comment asks.

## Verification

Every link was resolved against the API rather than assembled by hand:

```
41 pull links, 19 issue links (16 distinct issues)
mismatched label vs url: none
```

Every `pull/N` link resolves to a pull request, every `issues/N` link resolves to an issue and not to a pull request, and each entry's text was checked against the pull request's own title. That check caught one wrong description — #1142 is "Document angle-of-attack drag inputs", not the multivariable inputs its squash-commit subject suggests — and twelve smaller drifts from the titles, all corrected.

## What this does not do

It does not fix the automation, and the next merge will fall out of the file again. Both causes #1173 identifies are outside what a pull request into `develop` can reach:

- a `pull_request_target` workflow is read from the default branch, and `master` still carries the older `changelog.yml` with the `pull_request` trigger, so neither trigger matches anything: `pull_request` events read the file from the pull request's branch, where only `pull_request_target` is declared, and `pull_request_target` events read it from `master`, where only `pull_request` is declared;
- `RELEASE_TOKEN` was already resolving to empty before that, which is why the four runs before #1112 all died on `actions/checkout`.

I confirmed the first against `upstream/master:.github/workflows/changelog.yml` and the run history; the second needs someone with access to the repository secrets.
