### PR TITLE
BUG: accept the seed type a Monte Carlo worker is handed

### DIFF
--- a/rocketpy/stochastic/stochastic_model.py
+++ b/rocketpy/stochastic/stochastic_model.py
@@ -8,7 +8,7 @@ import numpy as np
 from rocketpy.mathutils.function import Function
 from rocketpy.stochastic.custom_sampler import CustomSampler
 
-from ..tools import get_distribution
+from ..tools import _seed_sequence_to_int, get_distribution
 
 
 def _names_as_spawn_key(input_names):
@@ -41,6 +41,18 @@ def _format_number(value):
     return f"array of shape {np.shape(value)}"
 
 
+def _seed_as_entropy(seed):
+    """A seed as something ``SeedSequence`` will take as entropy.
+
+    A parallel run is handed a ``SeedSequence``, which it will not take. Any
+    other seed goes through untouched, so the stream an int reaches stays where
+    it was.
+    """
+    if not isinstance(seed, np.random.SeedSequence):
+        return seed
+    return _seed_sequence_to_int(seed)
+
+
 def _sampler_seed(seed, input_names):
     """Derive a seed for one sampler, or for one group that shares a generator.
 
@@ -54,10 +66,10 @@ def _sampler_seed(seed, input_names):
     # Sorted here rather than trusting the caller, so a future call site cannot
     # give one group two different seeds by listing its members another way.
     root = np.random.SeedSequence(
-        entropy=seed, spawn_key=_names_as_spawn_key(tuple(sorted(input_names)))
+        entropy=_seed_as_entropy(seed),
+        spawn_key=_names_as_spawn_key(tuple(sorted(input_names))),
     )
-    words = root.generate_state(4, dtype=np.uint32)
-    return sum(int(word) << (32 * position) for position, word in enumerate(words))
+    return _seed_sequence_to_int(root)
 
 
 # TODO: Stop using assert in production code. Use exceptions instead.

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -1377,6 +1377,17 @@ def euler313_to_quaternions(phi, theta, psi):
     return e0, e1, e2, e3
 
 
+def _seed_sequence_to_int(seed_sequence):
+    """Returns a ``SeedSequence`` as the 128-bit ``int`` it can be rebuilt from.
+
+    Folded through ``generate_state`` rather than read off ``entropy``, since
+    the children of one root differ only by ``spawn_key``, and combined by
+    value so it does not depend on byte order.
+    """
+    words = seed_sequence.generate_state(4, dtype=np.uint32)
+    return sum(int(word) << (32 * position) for position, word in enumerate(words))
+
+
 def get_matplotlib_supported_file_endings():
     """Gets the file endings supported by matplotlib.
 

--- a/rocketpy/tools.py
+++ b/rocketpy/tools.py
@@ -1378,11 +1378,12 @@ def euler313_to_quaternions(phi, theta, psi):
 
 
 def _seed_sequence_to_int(seed_sequence):
-    """Returns a ``SeedSequence`` as the 128-bit ``int`` it can be rebuilt from.
+    """Returns the 128-bit ``int`` seed a ``SeedSequence`` derives.
 
-    Folded through ``generate_state`` rather than read off ``entropy``, since
-    the children of one root differ only by ``spawn_key``, and combined by
-    value so it does not depend on byte order.
+    Derived, not serialized: the entropy and spawn key it came from cannot be
+    read back out. Folded through ``generate_state`` rather than off
+    ``entropy``, since the children of one root differ only by ``spawn_key``,
+    and combined by value so it does not depend on byte order.
     """
     words = seed_sequence.generate_state(4, dtype=np.uint32)
     return sum(int(word) << (32 * position) for position, word in enumerate(words))

--- a/tests/unit/simulation/test_monte_carlo_parallel_runs.py
+++ b/tests/unit/simulation/test_monte_carlo_parallel_runs.py
@@ -1,0 +1,32 @@
+import pytest
+
+from rocketpy.simulation.monte_carlo import MonteCarlo
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_a_monte_carlo_run_finishes(
+    stochastic_environment, stochastic_calisto, stochastic_flight, tmp_path, parallel
+):
+    # The parallel path hands each worker a SeedSequence rather than an int, and
+    # nothing else in the suite exercises that. A worker that dies on it is not
+    # reported, so this reads as a hang rather than as a failure.
+    #
+    # Built here rather than taken from the monte_carlo_calisto fixture, whose
+    # own filename is fixed, since `filename` is a plain attribute and the three
+    # working paths are settled when the object is constructed.
+    analysis = MonteCarlo(
+        filename=str(tmp_path / "study"),
+        environment=stochastic_environment,
+        rocket=stochastic_calisto,
+        flight=stochastic_flight,
+    )
+
+    analysis.simulate(
+        number_of_simulations=2,
+        append=False,
+        parallel=parallel,
+        n_workers=2 if parallel else None,
+    )
+
+    assert analysis.num_of_loaded_sims == 2
+    assert str(tmp_path) in str(analysis.output_file)

--- a/tests/unit/stochastic/test_seed_types.py
+++ b/tests/unit/stochastic/test_seed_types.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+
+from rocketpy.stochastic.stochastic_model import (
+    _names_as_spawn_key,
+    _sampler_seed,
+)
+from rocketpy.tools import _seed_sequence_to_int
+
+
+def _a_worker_seed(index=0, workers=2):
+    # What MonteCarlo.__run_in_parallel spawns and hands to each worker, which
+    # passes it straight to environment/rocket/flight._set_stochastic.
+    return np.random.SeedSequence().spawn(workers)[index]
+
+
+def test_the_seed_type_a_worker_is_handed_is_accepted(stochastic_calisto):
+    stochastic_calisto._set_stochastic(_a_worker_seed())
+
+    stochastic_calisto.create_object()
+
+
+def test_a_parachute_derives_its_noise_seed_from_a_worker_seed(
+    stochastic_main_parachute,
+):
+    stochastic_main_parachute._set_stochastic(_a_worker_seed())
+
+    assert stochastic_main_parachute.create_object().noise[2] is not None
+
+
+def test_two_workers_do_not_share_a_sampler_stream():
+    first, second = np.random.SeedSequence(7).spawn(2)
+    # They come off one root, so they carry the same entropy and differ only in
+    # spawn_key. Reading the entropy alone would put both on one stream.
+    assert first.entropy == second.entropy
+
+    assert _sampler_seed(first, ("__list_choice__",)) != _sampler_seed(
+        second, ("__list_choice__",)
+    )
+
+
+def test_a_caller_seed_sequence_is_not_consumed():
+    root = np.random.SeedSequence(42)
+
+    _sampler_seed(root, ("__list_choice__",))
+
+    assert root.n_children_spawned == 0
+    assert root.spawn(1)[0].spawn_key == (0,)
+
+
+def test_the_same_seed_sequence_twice_gives_the_same_sampler_seed():
+    root = np.random.SeedSequence(42)
+
+    first = _sampler_seed(root, ("pressure_noise", "main"))
+    second = _sampler_seed(root, ("pressure_noise", "main"))
+
+    assert first == second
+
+
+@pytest.mark.parametrize("seed", [42, 7, [1, 2, 3]])
+@pytest.mark.parametrize("names", [("__list_choice__",), ("pressure_noise", "main")])
+def test_a_seed_that_is_not_a_sequence_reaches_numpy_untouched(seed, names):
+    # The control. Every fixed-seed baseline in the suite was recorded through
+    # this path, so anything but a SeedSequence has to arrive as it always did.
+    # Compared with the expression rather than with a recorded number, which
+    # would go red on a NumPy release instead of on a change of ours.
+    unchanged = np.random.SeedSequence(
+        entropy=seed, spawn_key=_names_as_spawn_key(tuple(sorted(names)))
+    )
+
+    assert _sampler_seed(seed, names) == _seed_sequence_to_int(unchanged)
+
+
+def test_no_seed_still_means_no_seed():
+    # None is left out above on purpose: it asks NumPy for fresh entropy, so
+    # two calls must not agree, and comparing one against another would be
+    # asserting the opposite of what an unseeded run promises.
+    first = _sampler_seed(None, ("__list_choice__",))
+    second = _sampler_seed(None, ("__list_choice__",))
+
+    assert first != second


### PR DESCRIPTION
Parallel Monte Carlo does not run on `develop` right now. It hangs, and I think it has since 12 August.

## Pull request type

- [x] Code changes (bugfix, features)

## Checklist

- [x] Tests for the changes have been added (if needed)
- [x] Docs have been reviewed and added / updated
- [x] Lint (`ruff check` / `ruff format --check`, `pylint`) has passed locally
- [x] All tests have passed locally
- `CHANGELOG.md` — no action needed; an LLM workflow auto-updates it after merge. Worth knowing that it has not run since #1112, which I wrote up in #1173.

## Current behavior

A two-worker run over a real `Flight`, bisected:

```
d21abde6^   the commit before #1117     1 passed in 2.32s
develop     4263fa95                    did not finish; killed at 90s, 180s and 900s
develop     4263fa95, serial            1 passed in 3.86s
```

`__run_in_parallel` spawns a `SeedSequence` per worker and passes it down, so `_set_stochastic` receives one of those rather than an int:

```
monte_carlo.py:472   seeds = np.random.SeedSequence().spawn(n_workers)
monte_carlo.py:536   self.environment._set_stochastic(seed)
```

`_sampler_seed` then hands it to `SeedSequence(entropy=...)`, which takes an int or a sequence of ints, so the first worker dies before it draws anything:

```
TypeError: SeedSequence expects int or sequence of ints for entropy
```

Two things kept this quiet. `_sampler_seed` is mine, from #1102, and until recently it was only reached from the custom sampler reset loop, so a model without custom samplers never went near it. #1117 added the list-choice generator at `stochastic_model.py:157`, which every model goes through on every reseed. That turned a path almost nobody took into the one all of them take. Nothing wrong with the #1117 change; my function should have taken the type it can now be given.

The hang on top of the error is a separate problem in the worker's own handler, and I have that in a follow-up rather than in here.

Nothing in the test suite calls `_set_stochastic` with a `SeedSequence`, and no pull request job runs a real parallel Monte Carlo, which is why the matrix stayed green through all of it.

## New behavior

`_sampler_seed` normalizes what it is given before building anything from it.

The value is folded through `generate_state` rather than read off `.entropy`. The children of one root share their entropy and differ only by `spawn_key`, so reading the entropy would have quietly put every worker on the same sampler stream, which is worse than the crash it replaces:

```
np.random.SeedSequence(7).spawn(2)
  same .entropy on both      True
  spawn_key                  (0,)  (1,)
```

An int or `None` seed goes through untouched, so no fixed-seed baseline moves. `stochastic_calisto` under seed 42 still reads `mass=14.906007947 radius=0.063501935`, same as `develop`.

The fold itself lives in `rocketpy.tools`. The component streams in #1170 need the same one and the per-index seeding will too, and three copies would drift on width and word order.

`tests/unit/simulation/test_monte_carlo_parallel_runs.py` runs a real serial and parallel Monte Carlo. Both together take under six seconds and it is not marked slow, so a pull request gets the signal that was missing here. It builds its own `MonteCarlo` on `tmp_path` rather than retargeting the fixture's: `filename` is a plain attribute and the three log paths are settled in `__init__`, so assigning it would leave the test writing into the working directory.

## Breaking change

- [x] No

## Additional information

Verification, on a clean tree:

```
pytest tests/unit                     2168 passed
pytest rocketpy --doctest-modules       48 passed
pytest tests/integration               154 passed
pytest tests/acceptance                 18 passed
ruff check . / ruff format --check .   clean
pylint rocketpy/ tests/ docs/          10.00/10, exit 0
```

The four `tests/unit/test_sensitivity.py` failures on my machine are a missing `statsmodels` and fail the same way on an untouched `develop`.

Each mechanism is pinned by a mutation, and each leaves a control standing:

| undone | goes red | still passes |
|---|---|---|
| the seed is not normalized | five | the integer baseline test |
| the fold becomes `return seed.entropy` | exactly one, `test_two_workers_do_not_share_a_sampler_stream` | the other five |

The second row is the reason that test exists. Reading `.entropy` unbreaks everything else and silently collapses the workers onto one stream, so the suite would have gone green on a fix that is worse than the bug.

Merged with #1169, #1170 and my follow-up into a throwaway tree on `develop` and run there as well, since green on separate bases says nothing about the combination.
