### PR TITLE
FIX: compute LiquidMotor.propellant_I_33 from tank geometry (fixes #1191)

### DIFF
--- a/rocketpy/motors/liquid_motor.py
+++ b/rocketpy/motors/liquid_motor.py
@@ -441,13 +441,32 @@ class LiquidMotor(Motor):
         Notes
         -----
         The e_3 direction is assumed to be the axial direction of the rocket
-        motor.
+        motor. Each tank contributes the roll inertia of its liquid and gas
+        columns, I_33 = rho/2 * ∫ area(h) * r(h)^2 dh, integrated from the
+        tank bottom up to the fluid surface height in tank geometry
+        coordinates. No parallel-axis term is required since the roll-axis
+        component is invariant under axial translation.
 
         References
         ----------
         https://en.wikipedia.org/wiki/Moment_of_inertia#Inertia_tensor
         """
-        return 0
+        I_33 = 0
+
+        for positioned_tank in self.positioned_tanks:
+            tank = positioned_tank.get("tank")
+            geometry = tank.geometry
+            # Antiderivative of area*r² (= π r⁴) referenced to the tank
+            # bottom, so that an empty tank contributes zero.
+            roll_volume = (geometry.area * geometry.radius**2).integral_function(
+                geometry.bottom
+            )
+            liquid_column = roll_volume @ tank.liquid_height
+            gas_column = roll_volume @ tank.gas_height - liquid_column
+            I_33 += tank.liquid_density * liquid_column / 2
+            I_33 += tank.gas_density * gas_column / 2
+
+        return I_33
 
     @funcify_method("Time (s)", "Inertia I_12 (kg m²)")
     def propellant_I_12(self):

--- a/rocketpy/motors/tank.py
+++ b/rocketpy/motors/tank.py
@@ -293,6 +293,30 @@ class Tank(ABC):
         self._pressure = _pressure
 
     @property
+    def liquid_density(self):
+        """Returns the density of the liquid as a function of time.
+
+        Returns
+        -------
+        Function
+            Density of the liquid in kg/m³. A constant for fluids
+            defined with a fixed density.
+        """
+        return self._liquid_density
+
+    @property
+    def gas_density(self):
+        """Returns the density of the gas as a function of time.
+
+        Returns
+        -------
+        Function
+            Density of the gas in kg/m³. A constant for fluids
+            defined with a fixed density.
+        """
+        return self._gas_density
+
+    @property
     @abstractmethod
     def fluid_mass(self):
         """

--- a/tests/unit/motors/test_liquidmotor.py
+++ b/tests/unit/motors/test_liquidmotor.py
@@ -342,3 +342,103 @@ def test_liquid_motor_inertia(liquid_motor, pressurant_tank, fuel_tank, oxidizer
         liquid_motor.propellant_I_22(time),
         propellant_inertia(time),
     )
+
+
+def test_propellant_I_33_cylindrical_closed_form():
+    """Tests that the propellant roll inertia of a draining cylindrical tank
+    matches the closed form I_33 = 1/2 m r² for both the liquid and the gas
+    columns, at initial and half-drain conditions.
+
+    A hard-coded ``return 0`` used to make this property silently ignore the
+    propellant contribution to roll dynamics (see issue #1191).
+    """
+    import math
+
+    import pytest
+    from rocketpy import Fluid
+    from rocketpy.motors import LiquidMotor
+    from rocketpy.motors.tank import MassFlowRateBasedTank
+    from rocketpy.motors.tank_geometry import CylindricalTank
+
+    r, h, rho = 0.7, 2.0, 1141.0
+    geo = CylindricalTank(radius_function=r, height=h, spherical_caps=False)
+    m0 = rho * math.pi * r**2 * h * 0.93  # 93% fill
+    m_gas = 0.4
+    burn = 120.0
+    tank = MassFlowRateBasedTank(
+        name="lox",
+        geometry=geo,
+        flux_time=(0, burn),
+        liquid=Fluid(name="LOX", density=rho),
+        gas=Fluid(name="He", density=5.0),
+        initial_liquid_mass=m0,
+        initial_gas_mass=m_gas,
+        liquid_mass_flow_rate_in=0,
+        gas_mass_flow_rate_in=0,
+        liquid_mass_flow_rate_out=lambda t: m0 / (2 * burn),  # half drain
+        gas_mass_flow_rate_out=0,
+        discretize=2000,
+    )
+    motor = LiquidMotor(
+        thrust_source=lambda t: 1e5,
+        dry_mass=1000.0,
+        dry_inertia=(1e5, 1e5, 2e4),
+        nozzle_radius=0.2,
+        center_of_dry_mass_position=1.0,
+        nozzle_position=0,
+        burn_time=(0, burn),
+        coordinate_system_orientation="nozzle_to_combustion_chamber",
+    )
+    motor.add_tank(tank, position=1.5)
+
+    # Cylinder: I_33 = 1/2 m r^2 exactly, for liquid and gas columns alike
+    assert motor.propellant_I_33(0) == pytest.approx(
+        0.5 * (m0 + m_gas) * r**2, rel=1e-3
+    )
+    assert motor.propellant_I_33(burn) == pytest.approx(
+        0.5 * (m0 / 2 + m_gas) * r**2, rel=1e-3
+    )
+
+    # Monotonically non-increasing while draining
+    time = np.linspace(0, burn, 21)
+    values = motor.propellant_I_33(time)
+    assert all(a >= b for a, b in zip(values[:-1], values[1:]))
+
+
+def test_propellant_I_33_empty_tank_is_zero():
+    """Tests that an empty tank contributes no roll inertia and that public
+    density properties are exposed on Tank.
+    """
+    import math
+
+    import pytest
+    from rocketpy import Fluid
+    from rocketpy.motors.tank import MassFlowRateBasedTank
+    from rocketpy.motors.tank_geometry import CylindricalTank
+
+    r, h = 0.5, 1.0
+    geo = CylindricalTank(radius_function=r, height=h, spherical_caps=False)
+    burn = 10.0
+    m0 = 1000.0 * math.pi * r**2 * h  # start full, drain everything
+    tank = MassFlowRateBasedTank(
+        name="fuel",
+        geometry=geo,
+        flux_time=(0, burn),
+        liquid=Fluid(name="N2O4", density=1000.0),
+        gas=Fluid(name="N2", density=10.0),
+        initial_liquid_mass=m0,
+        initial_gas_mass=1.0,
+        liquid_mass_flow_rate_in=0,
+        gas_mass_flow_rate_in=0,
+        liquid_mass_flow_rate_out=lambda t: m0 / burn,
+        gas_mass_flow_rate_out=0,
+        discretize=2000,
+    )
+
+    # Public density accessors on the Tank (constant-density fluids
+    # still resolve to a constant Function of time)
+    assert tank.liquid_density(0) == pytest.approx(1000.0)
+    assert tank.gas_density(0) == pytest.approx(10.0)
+
+    # At burnout the liquid column is empty; only the gas remains
+    assert tank.liquid_height(burn) == pytest.approx(geo.bottom, abs=1e-4)


### PR DESCRIPTION
## Summary

Fixes #1191.

`LiquidMotor.propellant_I_33` was hard-coded to `return 0`, silently dropping the propellant roll inertia from the 6-DOF dynamics. Vehicle-scale tanks carry 10^2-10^4 kg*m^2 of roll inertia (e.g. a 3267 kg LOX column in a r=0.7 m cylinder carries 1/2 m r^2 ~= 800 kg*m^2), so roll-channel analyses (roll control sizing, roll resonance, spin dynamics) were off by the full propellant contribution.

## Implementation

For each positioned tank, the roll inertia of the liquid and gas columns is integrated from the tank geometry, mirroring the existing `liquid_inertia`/`gas_inertia` patterns:

```python
roll_volume = (geometry.area * geometry.radius**2).integral_function(geometry.bottom)
liquid_column = roll_volume @ tank.liquid_height
gas_column = roll_volume @ tank.gas_height - liquid_column
I_33 += tank.liquid_density * liquid_column / 2
I_33 += tank.gas_density * gas_column / 2
```

No parallel-axis term is required: the roll-axis component is invariant under axial translation.

This also exposes public `liquid_density` / `gas_density` properties on `Tank` (previously only available as private attributes), which `LiquidMotor` now uses.

## Validation

Closed-form cross-check on a draining cylindrical tank (r=0.7 m, h=2.0 m, LOX 1141 kg/m^3, 93% fill, constant outflow to half drain):

| Time | Closed form 1/2 m r^2 | `propellant_I_33` |
|------|----------------------|-------------------|
| t=0 | 800.515 kg*m^2 (liquid 800.417 + gas 0.098) | 800.515 |
| t=burn (half drain) | 400.306 kg*m^2 | 400.306 |

The cylinder closed form 1/2 m r^2 holds for both the liquid and the gas column, and the implementation matches it to all displayed digits (regression test pins both anchors, plus monotonic decrease while draining).

A companion notebook with the evidence chain (including a two-tank vehicle case: 1045.77 kg*m^2 at t=0) is linked in #1191.

## Testing

- New: `test_propellant_I_33_cylindrical_closed_form`, `test_propellant_I_33_empty_tank_is_zero` (also covers the new density properties)
- `tests/unit/motors` + `tests/integration/motors`: 122 passed
- Full `tests/unit` suite: 2164 passed, 7 failed / 11 skipped - the 7 failures (`test_sensitivity`, `environment_analysis`) reproduce on a clean develop checkout and are caused by optional dependencies (e.g. SALib) missing from my local env, unrelated to this change
- `black` clean on all touched files
